### PR TITLE
feat: 增加多仓库 session 支持的核心基础设施

### DIFF
--- a/bin/common.ts
+++ b/bin/common.ts
@@ -66,3 +66,51 @@ export async function check_process_running(pid: number | string): Promise<boole
 export function iso_timestamp(): string {
   return new Date().toISOString();
 }
+
+// Session ID 相关工具函数
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+}
+
+export interface SessionIdentifier extends RepoInfo {
+  issueNumber: number;
+}
+
+// 生成唯一的 session ID
+export function getSessionId(owner: string, repo: string, issueNumber: number): string {
+  return `${owner}-${repo}-${issueNumber}`;
+}
+
+// 从 session ID 解析出仓库信息和 issue 编号
+export function parseSessionId(sessionId: string): Result<SessionIdentifier> {
+  const parts = sessionId.split("-");
+  if (parts.length < 3) {
+    return failure(`Invalid session ID format: ${sessionId}`);
+  }
+  
+  // 尝试找到 issueNumber 的位置（它是最后一个数字部分）
+  let issueNumberIndex = -1;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (/^\d+$/.test(parts[i])) {
+      issueNumberIndex = i;
+      break;
+    }
+  }
+  
+  if (issueNumberIndex === -1) {
+    return failure(`Could not find issue number in session ID: ${sessionId}`);
+  }
+  
+  const issueNumber = Number(parts[issueNumberIndex]);
+  const owner = parts.slice(0, issueNumberIndex - 1).join("-");
+  const repo = parts.slice(issueNumberIndex - 1, issueNumberIndex).join("-");
+  
+  return success({ owner, repo, issueNumber });
+}
+
+// 判断字符串是否是新格式的 session ID（包含 owner-repo-）
+export function isNewFormatSessionId(id: string): boolean {
+  return /^[^-]+-[^-]+-\d+$/.test(id);
+}
+

--- a/bin/session-manager.ts
+++ b/bin/session-manager.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { config } from "./config";
-import { iso_timestamp } from "./common";
+import { iso_timestamp, getSessionId, isNewFormatSessionId } from "./common";
 
 export interface SessionStatus {
   issueNumber: number;
@@ -22,15 +22,53 @@ export interface SessionStatus {
 
 export class SessionManager {
   private issueNumber: number;
+  private owner?: string;
+  private repo?: string;
   private config: any;
   private statusFile: string;
   private logFile: string;
+  private sessionId: string;
 
-  constructor(issueNumber: number, config: any) {
+  constructor(issueNumber: number, config: any, owner?: string, repo?: string) {
     this.issueNumber = issueNumber;
+    this.owner = owner;
+    this.repo = repo;
     this.config = config;
-    this.statusFile = path.join(config.SESSION_DIR, `${issueNumber}-status.json`);
-    this.logFile = path.join(config.LOG_DIR, `${issueNumber}.log`);
+    
+    // 确定使用的 session ID
+    if (owner && repo) {
+      this.sessionId = getSessionId(owner, repo, issueNumber);
+    } else {
+      this.sessionId = String(issueNumber);
+    }
+    
+    // 尝试查找状态文件（优先新格式，降级到旧格式）
+    this.statusFile = this.findStatusFile(config, this.sessionId, issueNumber);
+    this.logFile = this.findLogFile(config, this.sessionId, issueNumber);
+  }
+
+  /**
+   * 查找状态文件：优先新格式，降级到旧格式
+   */
+  private findStatusFile(config: any, sessionId: string, issueNumber: number): string {
+    const newFormat = path.join(config.SESSION_DIR, `${sessionId}-status.json`);
+    if (fs.existsSync(newFormat) || (this.owner && this.repo)) {
+      return newFormat;
+    }
+    // 降级到旧格式
+    return path.join(config.SESSION_DIR, `${issueNumber}-status.json`);
+  }
+
+  /**
+   * 查找日志文件：优先新格式，降级到旧格式
+   */
+  private findLogFile(config: any, sessionId: string, issueNumber: number): string {
+    const newFormat = path.join(config.LOG_DIR, `${sessionId}.log`);
+    if (fs.existsSync(newFormat) || (this.owner && this.repo)) {
+      return newFormat;
+    }
+    // 降级到旧格式
+    return path.join(config.LOG_DIR, `${issueNumber}.log`);
   }
 
   /**

--- a/bin/session-paths.ts
+++ b/bin/session-paths.ts
@@ -1,0 +1,195 @@
+import path from "path";
+import fs from "fs";
+import { config } from "./config";
+import { getSessionId, isNewFormatSessionId, parseSessionId, Result, success, failure } from "./common";
+
+export interface SessionPathOptions {
+  owner?: string;
+  repo?: string;
+  issueNumber: number;
+}
+
+/**
+ * 统一管理所有 session 相关的路径生成
+ */
+export class SessionPathManager {
+  private options: SessionPathOptions;
+  private sessionId: string;
+  private useNewFormat: boolean;
+
+  constructor(options: SessionPathOptions) {
+    this.options = options;
+    this.useNewFormat = !!(options.owner && options.repo);
+    this.sessionId = this.useNewFormat 
+      ? getSessionId(options.owner!, options.repo!, options.issueNumber)
+      : String(options.issueNumber);
+  }
+
+  /**
+   * 从 issueNumber 或 sessionId 创建实例（自动检测格式）
+   */
+  static fromIdentifier(identifier: string | number, config: any): SessionPathManager {
+    const idStr = String(identifier);
+    
+    if (isNewFormatSessionId(idStr)) {
+      const parseResult = parseSessionId(idStr);
+      if (parseResult.success) {
+        return new SessionPathManager(parseResult.data);
+      }
+    }
+    
+    // 回退到旧格式
+    return new SessionPathManager({ issueNumber: Number(identifier) });
+  }
+
+  /**
+   * 获取状态文件路径
+   */
+  getStatusFile(): string {
+    return path.join(config.SESSION_DIR, `${this.sessionId}-status.json`);
+  }
+
+  /**
+   * 获取 todo 文件路径
+   */
+  getTodoFile(): string {
+    return path.join(config.SESSION_DIR, `${this.sessionId}-todo.md`);
+  }
+
+  /**
+   * 获取 issue 缓存文件路径
+   */
+  getIssueFile(): string {
+    return path.join(config.SESSION_DIR, `${this.sessionId}-issue.json`);
+  }
+
+  /**
+   * 获取步骤产出文件路径
+   */
+  getStepOutputFile(stepNumber: number, scriptName: string): string {
+    return path.join(config.SESSION_DIR, `${this.sessionId}-step${stepNumber}-${scriptName}.md`);
+  }
+
+  /**
+   * 获取 PR 评论文件路径
+   */
+  getPrCommentsFile(): string {
+    return path.join(config.SESSION_DIR, `${this.sessionId}-pr-comments.json`);
+  }
+
+  /**
+   * 获取主日志文件路径
+   */
+  getLogFile(): string {
+    return path.join(config.LOG_DIR, `${this.sessionId}.log`);
+  }
+
+  /**
+   * 获取 tmux 日志文件路径
+   */
+  getTmuxLogFile(): string {
+    return path.join(config.LOG_DIR, `${this.sessionId}-tmux.log`);
+  }
+
+  /**
+   * 获取 PR review tmux 日志文件路径
+   */
+  getPrReviewTmuxLogFile(): string {
+    return path.join(config.LOG_DIR, `${this.sessionId}-pr-review-tmux.log`);
+  }
+
+  /**
+   * 获取工作区目录路径
+   */
+  getWorktreeDir(): string {
+    return path.join(config.WORKTREE_DIR, this.sessionId);
+  }
+
+  /**
+   * 查找现有文件（支持向后兼容：先尝试新格式，再尝试旧格式）
+   */
+  findExistingFile(getNewPath: () => string, getOldPath: () => string): string | null {
+    const newPath = getNewPath();
+    if (fs.existsSync(newPath)) {
+      return newPath;
+    }
+    
+    const oldPath = getOldPath();
+    if (fs.existsSync(oldPath)) {
+      return oldPath;
+    }
+    
+    return null;
+  }
+
+  /**
+   * 获取 sessionId
+   */
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
+  /**
+   * 检查是否使用新格式
+   */
+  isNewFormat(): boolean {
+    return this.useNewFormat;
+  }
+
+  /**
+   * 获取选项
+   */
+  getOptions(): SessionPathOptions {
+    return { ...this.options };
+  }
+}
+
+/**
+ * 便捷函数：创建 SessionPathManager 实例
+ */
+export function getSessionPaths(issueNumber: number, owner?: string, repo?: string): SessionPathManager {
+  return new SessionPathManager({ issueNumber, owner, repo });
+}
+
+/**
+ * 便捷函数：从状态文件中读取 repo 信息并创建 SessionPathManager
+ */
+export function getSessionPathsFromStatus(issueNumber: number, config: any): Result<SessionPathManager> {
+  // 先尝试旧格式
+  let statusFile = path.join(config.SESSION_DIR, `${issueNumber}-status.json`);
+  if (!fs.existsSync(statusFile)) {
+    return failure(`状态文件不存在: ${statusFile}`);
+  }
+  
+  try {
+    const status = JSON.parse(fs.readFileSync(statusFile, "utf-8"));
+    if (status.repo && status.repo.owner && status.repo.name) {
+      return success(new SessionPathManager({
+        owner: status.repo.owner,
+        repo: status.repo.name,
+        issueNumber
+      }));
+    }
+    // 没有 repo 信息，使用旧格式
+    return success(new SessionPathManager({ issueNumber }));
+  } catch (e) {
+    return failure(`解析状态文件失败: ${statusFile}`);
+  }
+}
+
+/**
+ * 扫描 sessions 目录，找到所有状态文件
+ */
+export function findAllStatusFiles(config: any): Array<{ path: string; sessionId: string; isNewFormat: boolean }> {
+  if (!fs.existsSync(config.SESSION_DIR)) return [];
+  
+  const files = fs.readdirSync(config.SESSION_DIR).filter(f => f.endsWith("-status.json"));
+  return files.map(file => {
+    const sessionId = file.replace("-status.json", "");
+    return {
+      path: path.join(config.SESSION_DIR, file),
+      sessionId,
+      isNewFormat: isNewFormatSessionId(sessionId)
+    };
+  });
+}

--- a/bin/task.ts
+++ b/bin/task.ts
@@ -1,23 +1,35 @@
 import path from "path";
 import fs from "fs";
-import { failure, success } from "./common";
+import { failure, success, getSessionId } from "./common";
 
 /**
  * Task 类，用于管理任务相关的 Session 文件数据和工作区
  */
 export class Task {
   public taskNumber: number;
+  public owner?: string;
+  public repo?: string;
   public config: any;
   public status: any = null;
   public todo: any = null;
   public worktree: string | null = null;
+  public sessionId: string;
 
-  constructor(taskNumber: number, config: any) {
+  constructor(taskNumber: number, config: any, owner?: string, repo?: string) {
     if (taskNumber === undefined || taskNumber === null) {
       throw new Error("实例化 Task 时必须传入 taskNumber");
     }
     this.taskNumber = taskNumber;
+    this.owner = owner;
+    this.repo = repo;
     this.config = config;
+    
+    // 确定使用的 session ID
+    if (owner && repo) {
+      this.sessionId = getSessionId(owner, repo, taskNumber);
+    } else {
+      this.sessionId = String(taskNumber);
+    }
 
     // 在构造时自动加载并解析数据
     this.status = this.readStatus();
@@ -26,13 +38,22 @@ export class Task {
   }
 
   /**
+   * 查找文件：优先新格式，降级到旧格式
+   */
+  private findFile(dir: string, suffix: string): string {
+    const newFormat = path.join(dir, `${this.sessionId}${suffix}`);
+    if (fs.existsSync(newFormat) || (this.owner && this.repo)) {
+      return newFormat;
+    }
+    // 降级到旧格式
+    return path.join(dir, `${this.taskNumber}${suffix}`);
+  }
+
+  /**
    * 读取状态文件并解析为 JSON 对象
    */
   readStatus() {
-    const file = path.join(
-      this.config.SESSION_DIR,
-      `${this.taskNumber}-status.json`,
-    );
+    const file = this.findFile(this.config.SESSION_DIR, "-status.json");
     if (!fs.existsSync(file)) return null;
     try {
       return JSON.parse(fs.readFileSync(file, "utf-8"));
@@ -45,10 +66,7 @@ export class Task {
    * 读取待办事项文件并解析为 JSON 对象
    */
   readToDo() {
-    const file = path.join(
-      this.config.SESSION_DIR,
-      `${this.taskNumber}-todo.md`,
-    );
+    const file = this.findFile(this.config.SESSION_DIR, "-todo.md");
     if (!fs.existsSync(file)) return null;
     try {
       const content = fs.readFileSync(file, "utf-8");
@@ -92,8 +110,14 @@ export class Task {
    * 读取工作区路径
    */
   readWorktree() {
-    const dir = path.join(this.config.WORKTREE_DIR, `${this.taskNumber}`);
-    return fs.existsSync(dir) ? dir : null;
+    // 优先新格式，降级到旧格式
+    const newFormatDir = path.join(this.config.WORKTREE_DIR, this.sessionId);
+    if (fs.existsSync(newFormatDir) || (this.owner && this.repo)) {
+      return fs.existsSync(newFormatDir) ? newFormatDir : null;
+    }
+    // 降级到旧格式
+    const oldFormatDir = path.join(this.config.WORKTREE_DIR, `${this.taskNumber}`);
+    return fs.existsSync(oldFormatDir) ? oldFormatDir : null;
   }
 
   notExists() {

--- a/bin/todo-helper.ts
+++ b/bin/todo-helper.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { config } from "./config";
 import { consola } from "consola";
-import { iso_timestamp } from "./common";
+import { iso_timestamp, getSessionId } from "./common";
 
 const logger = consola.withTag("todo-helper");
 
@@ -16,13 +16,43 @@ const STEP_LABELS: Record<number, string> = {
 
 /**
  * 保存步骤产出到独立文件
- * 文件命名: {issueNumber}-step{N}-{scriptName}.md
+ * 文件命名: {sessionId}-step{N}-{scriptName}.md 或 {issueNumber}-step{N}-{scriptName}.md
  * @returns 产出文件的文件名（不含目录）
  */
-export function saveStepOutput(issueNumber: string, stepNumber: number, scriptName: string, content: string): string {
-  const fileName = `${issueNumber}-step${stepNumber}-${scriptName}.md`;
+export function saveStepOutput(
+  issueNumberOrOwner: string, 
+  stepNumber: number, 
+  scriptNameOrRepo: string, 
+  contentOrIssueNumber: string | number,
+  maybeScriptName?: string,
+  maybeContent?: string
+): string {
+  let sessionId: string;
+  let actualStepNumber: number;
+  let actualScriptName: string;
+  let actualContent: string;
+  
+  // 判断调用方式：新格式 (owner, repo, issueNumber, stepNumber, scriptName, content) 还是旧格式 (issueNumber, stepNumber, scriptName, content)
+  if (typeof contentOrIssueNumber === 'number' && maybeScriptName && maybeContent) {
+    // 新格式
+    const owner = issueNumberOrOwner;
+    const repo = scriptNameOrRepo;
+    const issueNumber = contentOrIssueNumber;
+    sessionId = getSessionId(owner, repo, issueNumber);
+    actualStepNumber = stepNumber;
+    actualScriptName = maybeScriptName;
+    actualContent = maybeContent;
+  } else {
+    // 旧格式（向后兼容）
+    sessionId = issueNumberOrOwner;
+    actualStepNumber = stepNumber;
+    actualScriptName = scriptNameOrRepo;
+    actualContent = contentOrIssueNumber as string;
+  }
+  
+  const fileName = `${sessionId}-step${actualStepNumber}-${actualScriptName}.md`;
   const filePath = path.join(config.SESSION_DIR, fileName);
-  fs.writeFileSync(filePath, content, "utf-8");
+  fs.writeFileSync(filePath, actualContent, "utf-8");
   return fileName;
 }
 
@@ -33,11 +63,40 @@ export function saveStepOutput(issueNumber: string, stepNumber: number, scriptNa
  * ```
  * - [x] 第N步：xxx
  *   > ✅ 2026-04-01T12:00:00Z | summary
- *   > 📄 详情: {issueNumber}-step{N}-{scriptName}.md
+ *   > 📄 详情: {sessionId}-step{N}-{scriptName}.md
  * ```
  */
-export function completeTodoStep(issueNumber: string, stepNumber: number, summary: string, outputFileName?: string): void {
-  const todoFile = path.join(config.SESSION_DIR, `${issueNumber}-todo.md`);
+export function completeTodoStep(
+  issueNumberOrOwner: string, 
+  stepNumber: number, 
+  summaryOrRepo: string, 
+  outputFileNameOrIssueNumber?: string | number,
+  maybeOutputFileName?: string
+): void {
+  let sessionId: string;
+  let actualStepNumber: number;
+  let actualSummary: string;
+  let actualOutputFileName: string | undefined;
+  
+  // 判断调用方式：新格式 (owner, repo, issueNumber, stepNumber, summary, outputFileName?) 还是旧格式 (issueNumber, stepNumber, summary, outputFileName?)
+  if (typeof outputFileNameOrIssueNumber === 'number') {
+    // 新格式
+    const owner = issueNumberOrOwner;
+    const repo = summaryOrRepo;
+    const issueNumber = outputFileNameOrIssueNumber;
+    sessionId = getSessionId(owner, repo, issueNumber);
+    actualStepNumber = stepNumber;
+    actualSummary = maybeOutputFileName !== undefined ? arguments[4] as string : '';
+    actualOutputFileName = arguments.length > 5 ? arguments[5] as string : undefined;
+  } else {
+    // 旧格式（向后兼容）
+    sessionId = issueNumberOrOwner;
+    actualStepNumber = stepNumber;
+    actualSummary = summaryOrRepo;
+    actualOutputFileName = outputFileNameOrIssueNumber as string | undefined;
+  }
+  
+  const todoFile = path.join(config.SESSION_DIR, `${sessionId}-todo.md`);
   if (!fs.existsSync(todoFile)) {
     logger.warn(`todo 文件不存在: ${todoFile}`);
     return;


### PR DESCRIPTION
## 修复内容

本 PR 实现了多仓库并行工作时 session 文件冲突问题的核心基础设施。

### 修改概述

为了解决不同仓库相同 issueNumber 导致 session 文件互相覆盖的问题，我们引入了 **owner-repo-issueNumber** 复合 ID 作为唯一标识。

### 具体修改

1. **bin/common.ts** - 新增 session ID 工具函数：
   -  - 生成唯一 session ID
   -  - 反向解析 session ID
   -  - 判断是否为新格式 ID
   - 新增相关类型定义（RepoInfo、SessionIdentifier）

2. **bin/session-manager.ts** - 支持新路径格式：
   - 构造函数支持可选的 owner/repo 参数
   - 自动检测并使用新格式路径
   - 保持向后兼容，旧格式文件仍可正常读取

3. **bin/task.ts** - 支持复合 ID：
   - 构造函数支持可选的 owner/repo 参数
   - 统一的文件查找逻辑（优先新格式，降级旧格式）
   - 更新工作区路径查找逻辑

4. **bin/todo-helper.ts** - 更新路径逻辑：
   - 函数重载支持新旧两种调用方式
   - 保持向后兼容性

5. **bin/session-paths.ts** - 新增统一路径管理模块：
   - SessionPathManager 类统一管理所有 session 相关路径
   - 提供便捷函数简化路径生成
   - 支持扫描和发现所有状态文件

### 向后兼容性

- 所有修改保持完全向后兼容
- 旧格式的 session 文件仍可正常读取和使用
- 新的调用方式可选，不影响现有代码

### 后续工作

剩余 CLI 子命令的迁移将在后续 PR 中逐步完成，包括：
- bin/run.ts
- bin/branch-create.ts
- bin/commit-push.ts
- bin/pr-create.ts / bin/pr-watch.ts
- bin/cleanup.ts / bin/cleanup-utils.ts
- bin/issue-list.ts / bin/status.ts
- 等等

fixes: #3