### PR TITLE
feat(github): PR 合并后自动移除 Issue 的 WIP 标签

### DIFF
--- a/bin/cleanup-utils.ts
+++ b/bin/cleanup-utils.ts
@@ -4,6 +4,7 @@ import {
   check_process_running,
   iso_timestamp,
 } from "./common";
+import { get_gh_client } from "./github-client";
 
 const logger = consola.withTag("cleanup-utils");
 import { config } from "./config";
@@ -152,6 +153,19 @@ export async function cleanupIssue(issueNumber: string, options: CleanupOptions 
   const statusFile = path.join(config.SESSION_DIR, `${issueNumber}-status.json`);
   const worktreePath = path.join(config.WORKTREE_DIR, `${issueNumber}`);
   const reason = options.reason || (options.force ? "force" : "normal");
+
+  // PR 合并时兜底移除 WIP 标签
+  if (reason === "pr-merged") {
+    try {
+      const clientRes = await get_gh_client();
+      if (clientRes.success) {
+        await clientRes.data.removeIssueLabel(issueNumber, "WIP");
+        info("WIP 标签已移除", options.silent);
+      }
+    } catch {
+      // 标签可能已被移除，忽略错误
+    }
+  }
 
   // 读取分支名（必须在归档前读取）
   const branchName = readBranchName(statusFile);

--- a/bin/github-client.ts
+++ b/bin/github-client.ts
@@ -62,6 +62,13 @@ export class GitHubClient {
     });
   }
 
+  async removeIssueLabel(number: string | number, label: string): Promise<void> {
+    await this.octokit.issues.removeLabel({
+      ...this.repoParams,
+      issue_number: Number(number),
+      name: label,
+    });
+  }
 
   async getRepositoryDetails(): Promise<RestEndpointMethodTypes["repos"]["get"]["response"]["data"]> {
     const { data } = await this.octokit.repos.get({

--- a/bin/pr-watch.ts
+++ b/bin/pr-watch.ts
@@ -464,6 +464,16 @@ async function pollLoop(
           logger.info(chalk.yellow(`[${timeStr}] PR 已关闭`));
         }
 
+        // PR 合并时移除 WIP 标签
+        if (pr.merged) {
+          try {
+            await client.removeIssueLabel(Number(issueNumber), "WIP");
+            logger.success("WIP 标签已移除");
+          } catch (e: any) {
+            logger.warn(`移除 WIP 标签失败: ${e.message}`);
+          }
+        }
+
         // 更新 session 状态为 completed
         const sessionManager = new SessionManager(Number(issueNumber), config);
         sessionManager.writeStatus({


### PR DESCRIPTION
fixes: #14

## 修改内容
- `bin/github-client.ts`：新增 `removeIssueLabel` 方法，封装 Octokit 的 `issues.removeLabel` API，支持按名称移除单个标签
- `bin/pr-watch.ts`：在 PR 合并检测逻辑中（`if (pr.merged)` 分支），于更新 session 状态之前调用 `removeIssueLabel` 移除 WIP 标签，失败时仅打印警告不阻断流程
- `bin/cleanup-utils.ts`：在 `cleanupIssue` 函数中新增兜底逻辑，当 cleanup reason 为 `pr-merged` 时也尝试移除 WIP 标签，覆盖 pr-watch 未运行的场景

## 执行步骤
1. 分析现有代码流程，确认 WIP 标签仅在 `branch-create` 中添加，全流程无移除逻辑
2. 在 `GitHubClient` 类中新增 `removeIssueLabel` 方法
3. 在 `pr-watch.ts` 的 PR 合并检测分支中调用移除 WIP 标签
4. 在 `cleanup-utils.ts` 的 `cleanupIssue` 中添加兜底移除逻辑
5. 验证代码修改正确性

## 影响范围
- 仅影响 PR 合并后的清理流程，不影响正常开发工作流
- 新增的 `removeIssueLabel` 方法可供其他模块复用
- 无破坏性变更，标签不存在时静默忽略错误