### PR TITLE
[Bug] 手动重启 Issue 时校验 approval 状态

### DIFF
--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -451,8 +451,32 @@ async function main() {
             });
           }
           logger.info(`手动重启 Issue #${issueNumber} (${owner}/${repo})...`);
+
+          // 校验 approval 状态：检查是否存在 APPROVE review
+          const sessionRes = readSession(owner, repo, issueNumber);
+          if (sessionRes.success && sessionRes.data?.context?.prNumber) {
+            const prNumber = sessionRes.data.context.prNumber;
+            const tokenRes = await readGithubToken();
+            if (tokenRes.success) {
+              const client = new GitHubClient(tokenRes.data, owner, repo);
+              const reviewsRes = await client.listReviews(prNumber);
+              if (reviewsRes.success) {
+                const hasApproval = reviewsRes.data.some((r: any) => r.state === "APPROVED");
+                if (!hasApproval) {
+                  logger.warn(`Issue #${issueNumber} 重启被拒绝：PR #${prNumber} 尚无 APPROVE review`);
+                  return new Response(JSON.stringify({
+                    error: `Issue #${issueNumber} 重启被拒绝：PR #${prNumber} 尚无 APPROVE review。请先获得审批再重启。`,
+                  }), {
+                    status: 403,
+                    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+                  });
+                }
+                logger.info(`Issue #${issueNumber} 重启校验通过：PR #${prNumber} 已获得 APPROVE`);
+              }
+            }
+          }
+
           enqueueAgent(`Issue #${issueNumber} 手动重启`, async () => {
-            const sessionRes = readSession(owner, repo, issueNumber);
             const phase = sessionRes.success && sessionRes.data?.phase ? sessionRes.data.phase : "planning";
             const title = sessionRes.success && sessionRes.data?.title ? sessionRes.data.title : `Issue #${issueNumber}`;
             const res = await launchIssueAgent(owner, repo, issueNumber, phase, { taskData: { title } });


### PR DESCRIPTION
## Summary
- 在 `/api/restart` 端点中增加 approval 状态校验
- 重启前通过 `listReviews` API 检查 PR 是否已获得 APPROVE review
- 如无 APPROVE review，阻止重启并返回 403 错误，避免未经审批的 Issue 绕过工作流

## Test plan
- [ ] 手动重启一个已 APPROVE 的 Issue，应成功启动
- [ ] 手动重启一个未 APPROVE 的 Issue，应返回 403 错误
- [ ] 手动重启一个没有关联 PR 的 Issue（旧版数据），应兼容处理并正常启动

fixes: #45