### PR TITLE
feat(web): 添加 agent 会话查看器

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -124,7 +124,7 @@ export const config = {
     {
       id: "claude",
       name: "Claude Code",
-      runTemplate: '{tag} "请解决 GitHub Issue #{num}，严格按照系统提示中的工作流执行" --append-system-prompt-file .claude/commands/{workflow}.md --dangerously-skip-permissions --verbose --print',
+      runTemplate: '{tag} "请解决 GitHub Issue #{num}，严格按照系统提示中的工作流执行" --append-system-prompt-file .claude/commands/{workflow}.md --dangerously-skip-permissions --output-format stream-json --verbose --print',
       mappings: [
         { from: "skills", to: ".claude/skills" },
         { from: "prompts", to: ".claude/commands" },

--- a/bin/db.ts
+++ b/bin/db.ts
@@ -32,6 +32,7 @@ const CAMEL_TO_SNAKE: Record<string, string> = {
   agentCommand: "agent_command",
   lastUpdate: "last_update",
   ciResults: "ci_results",
+  claudeSessionId: "claude_session_id",
 };
 
 const SNAKE_TO_CAMEL: Record<string, string> = {};
@@ -114,6 +115,7 @@ function initSchema(db: Database) {
       crash_log TEXT,
       review_comment_count INTEGER,
       workflow_phase TEXT,
+      claude_session_id TEXT,
       UNIQUE(owner, repo, issue_number)
     );
   `);
@@ -131,6 +133,7 @@ function initSchema(db: Database) {
   tryAddColumn(db, "ALTER TABLE sessions ADD COLUMN error TEXT");
   tryAddColumn(db, "ALTER TABLE sessions ADD COLUMN phase_started_at TEXT");
   tryAddColumn(db, "ALTER TABLE sessions ADD COLUMN step_started_at TEXT");
+  tryAddColumn(db, "ALTER TABLE sessions ADD COLUMN claude_session_id TEXT");
 }
 
 function rowToSessionStatus(row: any): SessionStatus {

--- a/bin/issue-agent.ts
+++ b/bin/issue-agent.ts
@@ -118,12 +118,97 @@ async function drainStream(stream: ReadableStream<Uint8Array>, out: WritableTarg
   }
 }
 
+interface DrainJsonStreamResult {
+  sessionId?: string;
+}
+
+async function drainJsonStream(stream: ReadableStream<Uint8Array>, out: WritableTarget): Promise<DrainJsonStreamResult> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let sessionId: string | undefined;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const record = JSON.parse(trimmed);
+        if (!sessionId && record.sessionId) {
+          sessionId = record.sessionId;
+        }
+        const formatted = formatJsonRecord(record);
+        if (formatted) {
+          out.write(formatted + "\n");
+        }
+      } catch {
+        out.write(trimmed + "\n");
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    out.write(buffer.trim() + "\n");
+  }
+
+  return { sessionId };
+}
+
+function formatJsonRecord(record: any): string | null {
+  const type = record.type;
+  if (type === "assistant") {
+    const content = record.message?.content;
+    if (Array.isArray(content)) {
+      const texts = content
+        .filter((c: any) => c.type === "text" && c.text)
+        .map((c: any) => c.text);
+      if (texts.length > 0) return `[assistant] ${texts.join("\n")}`;
+    }
+    return null;
+  }
+  if (type === "tool_use") {
+    const msg = record.message;
+    if (msg?.content) {
+      const tools = Array.isArray(msg.content) ? msg.content : [msg.content];
+      return tools
+        .filter((c: any) => c.type === "tool_use")
+        .map((c: any) => `[tool_use] ${c.name}: ${JSON.stringify(c.input).slice(0, 200)}`)
+        .join("\n") || null;
+    }
+    return null;
+  }
+  if (type === "tool_result") {
+    const msg = record.message;
+    if (msg?.content) {
+      const results = Array.isArray(msg.content) ? msg.content : [msg.content];
+      return results
+        .filter((c: any) => c.type === "tool_result")
+        .map((c: any) => {
+          const text = typeof c.content === "string" ? c.content : JSON.stringify(c.content);
+          return `[tool_result] ${text.slice(0, 200)}`;
+        })
+        .join("\n") || null;
+    }
+    return null;
+  }
+  return null;
+}
+
 export async function execAgent(
   worktreePath: string,
   issueNumber: number,
   workflow: string,
   onPid?: (pid: number) => void,
   logFile?: string,
+  sessionManager?: SessionManager,
 ): Promise<Result<number>> {
   const syncRes = syncPromptsToWorktree(worktreePath);
   if (!syncRes.success) return syncRes;
@@ -167,12 +252,23 @@ export async function execAgent(
 
   const out: WritableTarget = fileWriter || process.stdout;
   const err: WritableTarget = fileWriter || process.stderr;
+  const isClaude = editor?.id === "claude";
 
   try {
+    let jsonResult: DrainJsonStreamResult | undefined;
     await Promise.all([
-      proc.stdout ? drainStream(proc.stdout, out) : Promise.resolve(),
+      proc.stdout
+        ? (isClaude
+            ? drainJsonStream(proc.stdout, out).then(r => { jsonResult = r; })
+            : drainStream(proc.stdout, out))
+        : Promise.resolve(),
       proc.stderr ? drainStream(proc.stderr, err) : Promise.resolve(),
     ]);
+
+    if (isClaude && jsonResult?.sessionId && sessionManager) {
+      sessionManager.updateClaudeSessionId(jsonResult.sessionId);
+      logger.info(`已捕获 Claude sessionId: ${jsonResult.sessionId}`);
+    }
   } finally {
     fileWriter?.flush();
     fileHandle?.end();
@@ -332,6 +428,7 @@ export async function launchIssueAgent(
         session.updateStep(STEP.READ_ISSUE, undefined, undefined, undefined, pid);
       },
       logFile,
+      session,
     );
 
     if (!agentRes.success) return agentRes;

--- a/bin/issue-agent.ts
+++ b/bin/issue-agent.ts
@@ -25,8 +25,20 @@ import { getAgentRole } from "./agent-config";
 import { get_gh_client } from "./github-client";
 import { readSession } from "./db";
 import { setCurrentIssueContext, clearCurrentIssueContext } from "./log-buffer";
-import { clearSessionDiagnostic, generateSessionDiagnostic, writeSessionDiagnostic } from "./session-diagnostics";
-import { PHASE, STEP, EVENT, LIFECYCLE, type SessionPhase, type SessionStep, type SessionContext } from "./session-state-machine";
+import {
+  clearSessionDiagnostic,
+  generateSessionDiagnostic,
+  writeSessionDiagnostic,
+} from "./session-diagnostics";
+import {
+  PHASE,
+  STEP,
+  EVENT,
+  LIFECYCLE,
+  type SessionPhase,
+  type SessionStep,
+  type SessionContext,
+} from "./session-state-machine";
 
 const PHASE_START_STEP: Record<SessionPhase, SessionStep> = {
   [PHASE.PLANNING]: STEP.READ_ISSUE,
@@ -55,7 +67,8 @@ export function syncPromptsToWorktree(worktreePath: string): Result<void> {
   if (!logTagRes.success) return logTagRes;
   const logTag = logTagRes.data;
 
-  const editor = config.EDITORS.find((e) => e.id === logTag) || config.EDITORS[0];
+  const editor =
+    config.EDITORS.find((e) => e.id === logTag) || config.EDITORS[0];
 
   for (const mapping of editor.mappings) {
     const sourceDir = path.join(config.ROOT_DIR, mapping.from);
@@ -83,7 +96,9 @@ export function syncPromptsToWorktree(worktreePath: string): Result<void> {
 
 type WritableTarget = { write(data: string): any };
 
-function createTimestampedWriter(out: WritableTarget): WritableTarget & { flush(): void } {
+function createTimestampedWriter(
+  out: WritableTarget,
+): WritableTarget & { flush(): void } {
   let buffer = "";
 
   const writeLine = (line: string) => {
@@ -108,7 +123,10 @@ function createTimestampedWriter(out: WritableTarget): WritableTarget & { flush(
   };
 }
 
-async function drainStream(stream: ReadableStream<Uint8Array>, out: WritableTarget): Promise<void> {
+async function drainStream(
+  stream: ReadableStream<Uint8Array>,
+  out: WritableTarget,
+): Promise<void> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   while (true) {
@@ -122,7 +140,10 @@ interface DrainJsonStreamResult {
   sessionId?: string;
 }
 
-async function drainJsonStream(stream: ReadableStream<Uint8Array>, out: WritableTarget): Promise<DrainJsonStreamResult> {
+async function drainJsonStream(
+  stream: ReadableStream<Uint8Array>,
+  out: WritableTarget,
+): Promise<DrainJsonStreamResult> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -178,10 +199,15 @@ function formatJsonRecord(record: any): string | null {
     const msg = record.message;
     if (msg?.content) {
       const tools = Array.isArray(msg.content) ? msg.content : [msg.content];
-      return tools
-        .filter((c: any) => c.type === "tool_use")
-        .map((c: any) => `[tool_use] ${c.name}: ${JSON.stringify(c.input).slice(0, 200)}`)
-        .join("\n") || null;
+      return (
+        tools
+          .filter((c: any) => c.type === "tool_use")
+          .map(
+            (c: any) =>
+              `[tool_use] ${c.name}: ${JSON.stringify(c.input ?? {}).slice(0, 200)}`,
+          )
+          .join("\n") || null
+      );
     }
     return null;
   }
@@ -189,13 +215,18 @@ function formatJsonRecord(record: any): string | null {
     const msg = record.message;
     if (msg?.content) {
       const results = Array.isArray(msg.content) ? msg.content : [msg.content];
-      return results
-        .filter((c: any) => c.type === "tool_result")
-        .map((c: any) => {
-          const text = typeof c.content === "string" ? c.content : JSON.stringify(c.content);
-          return `[tool_result] ${text.slice(0, 200)}`;
-        })
-        .join("\n") || null;
+      return (
+        results
+          .filter((c: any) => c.type === "tool_result")
+          .map((c: any) => {
+            const text =
+              typeof c.content === "string"
+                ? c.content
+                : JSON.stringify(c.content);
+            return `[tool_result] ${text.slice(0, 200)}`;
+          })
+          .join("\n") || null
+      );
     }
     return null;
   }
@@ -258,9 +289,11 @@ export async function execAgent(
     let jsonResult: DrainJsonStreamResult | undefined;
     await Promise.all([
       proc.stdout
-        ? (isClaude
-            ? drainJsonStream(proc.stdout, out).then(r => { jsonResult = r; })
-            : drainStream(proc.stdout, out))
+        ? isClaude
+          ? drainJsonStream(proc.stdout, out).then((r) => {
+              jsonResult = r;
+            })
+          : drainStream(proc.stdout, out)
         : Promise.resolve(),
       proc.stderr ? drainStream(proc.stderr, err) : Promise.resolve(),
     ]);
@@ -363,7 +396,9 @@ export async function launchIssueAgent(
       const tagRes = config.getLogTag();
       const tag = tagRes.success ? tagRes.data : "unknown";
       const gitHeadSha = (await git.raw(["rev-parse", "HEAD"])).trim();
-      const pkg = JSON.parse(fs.readFileSync(path.join(config.ROOT_DIR, "package.json"), "utf-8"));
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(config.ROOT_DIR, "package.json"), "utf-8"),
+      );
       statusData.agentType = tag;
       statusData.environment = {
         agentType: tag,
@@ -397,7 +432,9 @@ export async function launchIssueAgent(
     if (tagRes.success) {
       const tag = tagRes.data;
       const editor = config.EDITORS.find((e) => e.id === tag);
-      const agentCommand = (editor?.runTemplate || "{tag} --prompt-template {workflow} {num}")
+      const agentCommand = (
+        editor?.runTemplate || "{tag} --prompt-template {workflow} {num}"
+      )
         .replace("{tag}", tag)
         .replace("{workflow}", workflow)
         .replace("{num}", String(issueNumber));
@@ -425,7 +462,13 @@ export async function launchIssueAgent(
       issueNumber,
       workflow,
       (pid) => {
-        session.updateStep(STEP.READ_ISSUE, undefined, undefined, undefined, pid);
+        session.updateStep(
+          STEP.READ_ISSUE,
+          undefined,
+          undefined,
+          undefined,
+          pid,
+        );
       },
       logFile,
       session,
@@ -439,13 +482,21 @@ export async function launchIssueAgent(
       try {
         if (fs.existsSync(logFile)) {
           const content = fs.readFileSync(logFile, "utf-8");
-          crashLog = content.length > 3000 ? "..." + content.slice(-3000) : content;
+          crashLog =
+            content.length > 3000 ? "..." + content.slice(-3000) : content;
         }
       } catch (e) {}
-      await session.markAsCrashed(`Agent 意外退出 (退出码: ${exitCode})`, crashLog || "无法获取日志文件内容", exitCode);
+      await session.markAsCrashed(
+        `Agent 意外退出 (退出码: ${exitCode})`,
+        crashLog || "无法获取日志文件内容",
+        exitCode,
+      );
       const currentRes = session.readStatus();
       if (currentRes.success && currentRes.data) {
-        writeSessionDiagnostic(paths, generateSessionDiagnostic(currentRes.data, paths));
+        writeSessionDiagnostic(
+          paths,
+          generateSessionDiagnostic(currentRes.data, paths),
+        );
       }
     } else {
       await session.transition({ type: "AGENT_EXITED_SUCCESS" });

--- a/bin/session-manager.ts
+++ b/bin/session-manager.ts
@@ -41,6 +41,7 @@ export interface SessionStatus {
   error?: SessionError;
   retryCount?: number;
   ciResults?: { passed: number; failed: number; lastSha?: string };
+  claudeSessionId?: string;
   environment?: {
     agentType: string;
     gitHeadSha: string;
@@ -211,6 +212,13 @@ export class SessionManager {
         ciResults: JSON.stringify({ passed, failed, lastSha: sha }),
       } as Partial<SessionContext>,
     });
+  }
+
+  updateClaudeSessionId(claudeSessionId: string): Result<void> {
+    return upsertSession(this.owner, this.repo, this.issueNumber, {
+      claudeSessionId,
+      lastUpdate: iso_timestamp(),
+    } as Partial<SessionStatus>);
   }
 
   getPathManager(): SessionPathManager {

--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -220,44 +220,6 @@ async function handleEvent(
         return { status: 202, message: `已触发 Issue #${issueNumber} 分类` };
       }
 
-      if (action === "labeled" && payload.label?.name === "approved") {
-        // 类型守卫：只有 bug/enhancement 标签的 issue 才触发 implementation
-        const issueLabels = (payload.issue?.labels || []).map((l: any) =>
-          typeof l === "string" ? l : l.name,
-        );
-        if (
-          !issueLabels.some((l: string) => l === "bug" || l === "enhancement")
-        ) {
-          return {
-            status: 200,
-            message: "非 bug/feature issue，忽略 approved 标签",
-          };
-        }
-
-        logger.info(`Issue #${issueNumber} 已审批，触发 APPROVED 事件...`);
-        const session = new SessionManager(owner, repo, issueNumber);
-        const transitionRes = session.transition({ type: EVENT.APPROVED });
-        if (!transitionRes.success) {
-          logger.error(`触发 APPROVED 事件失败: ${transitionRes.error}`);
-        }
-
-        logger.info(`Issue #${issueNumber} 已审批，启动实现阶段...`);
-        enqueueAgent(`Issue #${issueNumber} 实现`, async () => {
-          const res = await launchIssueAgent(
-            owner,
-            repo,
-            issueNumber,
-            "implementation",
-            { taskData: { title: `Issue #${issueNumber}` } },
-          );
-          if (!res.success) logger.error(`启动实现阶段失败: ${res.error}`);
-        });
-        return {
-          status: 202,
-          message: `已触发实现阶段: Issue #${issueNumber}`,
-        };
-      }
-
       if (action === "deleted") {
         logger.info(`收到 Issue #${issueNumber} 删除事件，启动资产清理...`);
         fireAndForget(async () => {
@@ -337,45 +299,18 @@ async function handleEvent(
         const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
         if (issueMatch) {
           const linkedIssue = Number(issueMatch[1]);
-          logger.info(
-            `PR #${prNumber} 已合并，清理 Issue #${linkedIssue} 的 WIP 标签...`,
-          );
+          logger.info(`PR #${prNumber} 已合并，处理 Issue #${linkedIssue}...`);
           fireAndForget(async () => {
             const session = new SessionManager(owner, repo, linkedIssue);
-            session.transition({ type: "PR_MERGED" });
-            const tokenRes = await readGithubToken();
-            if (!tokenRes.success) {
-              logger.error(`获取 Token 失败: ${tokenRes.error}`);
-              return;
-            }
-            const client = new GitHubClient(tokenRes.data, owner, repo);
-            const res = await client.removeIssueLabel(linkedIssue, "WIP");
-            if (!res.success) {
-              logger.warn(
-                `移除 Issue #${linkedIssue} 的 WIP 标签失败: ${res.error}`,
-              );
-            } else {
-              logger.info(`已移除 Issue #${linkedIssue} 的 WIP 标签`);
-            }
+            await session.transition({ type: "PR_MERGED" });
 
-            // 自动清理 worktree
-            logger.info(
-              `PR #${prNumber} 已合并，开始清理 Issue #${linkedIssue} 的本地资源...`,
-            );
-            const cleanRes = await cleanupIssue(
-              String(linkedIssue),
-              { reason: "pr-merged", silent: false },
-              owner,
-              repo,
-            );
+            logger.info(`PR #${prNumber} 已合并，开始清理 Issue #${linkedIssue} 的本地资源...`);
+            const cleanRes = await cleanupIssue(String(linkedIssue), { reason: "pr-merged", silent: false }, owner, repo);
             if (!cleanRes.success) {
               logger.warn(`清理 Issue #${linkedIssue} 失败: ${cleanRes.error}`);
             }
           });
-          return {
-            status: 202,
-            message: `已触发 WIP 清理与资产回收: Issue #${linkedIssue}`,
-          };
+          return { status: 202, message: `已触发资产回收: Issue #${linkedIssue}` };
         }
         return { status: 200, message: "PR 已合并但未关联 issue" };
       }
@@ -967,12 +902,12 @@ async function main() {
                   });
                 }
               } else if (type === "assistant") {
-                const content = record.message?.content;
-                if (Array.isArray(content)) {
-                  const texts = content
+                const msgContent = record.message?.content;
+                if (Array.isArray(msgContent)) {
+                  const texts = msgContent
                     .filter((c: any) => c.type === "text" && c.text)
                     .map((c: any) => c.text);
-                  const toolUses = content.filter(
+                  const toolUses = msgContent.filter(
                     (c: any) => c.type === "tool_use",
                   );
                   if (texts.length > 0) {
@@ -986,15 +921,15 @@ async function main() {
                     messages.push({
                       type: "tool_use",
                       toolName: tool.name,
-                      toolInput: JSON.stringify(tool.input).slice(0, 500),
+                      toolInput: JSON.stringify(tool.input ?? {}).slice(0, 500),
                       timestamp: record.timestamp,
                     });
                   }
                 }
               } else if (type === "tool_result") {
-                const content = record.message?.content;
-                if (Array.isArray(content)) {
-                  for (const c of content) {
+                const msgContent = record.message?.content;
+                if (Array.isArray(msgContent)) {
+                  for (const c of msgContent) {
                     if (c.type === "tool_result") {
                       const text =
                         typeof c.content === "string"

--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -617,6 +617,111 @@ async function main() {
         });
       }
 
+      // ── API: /api/agent-conversation ──
+      if (url.pathname === "/api/agent-conversation" && req.method === "GET") {
+        const query = getSessionQuery(url);
+        if (!query) {
+          return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        }
+
+        const sessionRes = readSession(query.owner, query.repo, query.issueNumber);
+        if (!sessionRes.success || !sessionRes.data) {
+          return new Response(JSON.stringify({ error: "Session not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        }
+
+        const claudeSessionId = (sessionRes.data as any).claudeSessionId;
+        const worktreePath = sessionRes.data.worktreePath;
+        if (!claudeSessionId || !worktreePath) {
+          return new Response(JSON.stringify([]), {
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        }
+
+        const encodedPath = worktreePath.replace(/\//g, "-");
+        const jsonlPath = path.join(
+          process.env.HOME || "~",
+          ".claude",
+          "projects",
+          encodedPath,
+          `${claudeSessionId}.jsonl`,
+        );
+
+        if (!fs.existsSync(jsonlPath)) {
+          return new Response(JSON.stringify([]), {
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        }
+
+        try {
+          const content = fs.readFileSync(jsonlPath, "utf-8");
+          const messages: any[] = [];
+          for (const line of content.split("\n")) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+              const record = JSON.parse(trimmed);
+              const type = record.type;
+              if (type === "user") {
+                const text = Array.isArray(record.message?.content)
+                  ? record.message.content.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n")
+                  : typeof record.message?.content === "string" ? record.message.content : "";
+                if (text) {
+                  messages.push({ type: "user", content: text, timestamp: record.timestamp });
+                }
+              } else if (type === "assistant") {
+                const content = record.message?.content;
+                if (Array.isArray(content)) {
+                  const texts = content.filter((c: any) => c.type === "text" && c.text).map((c: any) => c.text);
+                  const toolUses = content.filter((c: any) => c.type === "tool_use");
+                  if (texts.length > 0) {
+                    messages.push({ type: "assistant", content: texts.join("\n"), timestamp: record.timestamp });
+                  }
+                  for (const tool of toolUses) {
+                    messages.push({
+                      type: "tool_use",
+                      toolName: tool.name,
+                      toolInput: JSON.stringify(tool.input).slice(0, 500),
+                      timestamp: record.timestamp,
+                    });
+                  }
+                }
+              } else if (type === "tool_result") {
+                const content = record.message?.content;
+                if (Array.isArray(content)) {
+                  for (const c of content) {
+                    if (c.type === "tool_result") {
+                      const text = typeof c.content === "string" ? c.content : JSON.stringify(c.content);
+                      messages.push({
+                        type: "tool_result",
+                        content: text.slice(0, 1000),
+                        isError: c.is_error || false,
+                        timestamp: record.timestamp,
+                      });
+                    }
+                  }
+                }
+              }
+            } catch {
+              // skip malformed lines
+            }
+          }
+          return new Response(JSON.stringify(messages), {
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        } catch (e: any) {
+          return new Response(JSON.stringify({ error: `Failed to read conversation: ${e.message}` }), {
+            status: 500,
+            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          });
+        }
+      }
+
       // ── Static Web UI ──
       if (req.method === "GET" && useDashboard) {
          try {

--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -15,7 +15,12 @@ import { $ } from "bun";
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { reviewPr, resolveReview, resolveCi, cleanupIssueSession } from "./webhook-handlers";
+import {
+  reviewPr,
+  resolveReview,
+  resolveCi,
+  cleanupIssueSession,
+} from "./webhook-handlers";
 import { triageIssue, handleTriagedIssue } from "./issue-triage";
 import { launchIssueAgent, setDashboardMode } from "./issue-agent";
 import { config } from "./config";
@@ -26,12 +31,20 @@ import { cleanupIssue, cleanupIssueAssets } from "./cleanup-utils";
 import { isActiveSessionStatus, EVENT, LIFECYCLE, COMMAND } from "./session-state-machine";
 import { SessionManager } from "./session-manager";
 import { SessionPathManager } from "./session-paths";
-import { readSessionDiagnostic, readSessionLog, generateSessionDiagnostic, type SessionLogSource } from "./session-diagnostics";
+import {
+  readSessionDiagnostic,
+  readSessionLog,
+  generateSessionDiagnostic,
+  type SessionLogSource,
+} from "./session-diagnostics";
 
 const logger = consola.withTag("webhook-server");
 
 // ── Agent 并发限制（防止同时启动过多 agent 耗尽资源） ──
-const MAX_CONCURRENT_AGENTS = parseInt(process.env.ALONG_MAX_CONCURRENT_AGENTS || "3", 10);
+const MAX_CONCURRENT_AGENTS = parseInt(
+  process.env.ALONG_MAX_CONCURRENT_AGENTS || "3",
+  10,
+);
 let runningAgents = 0;
 const agentQueue: Array<{ fn: () => Promise<any>; label: string }> = [];
 
@@ -39,21 +52,27 @@ function enqueueAgent(label: string, fn: () => Promise<any>) {
   if (runningAgents < MAX_CONCURRENT_AGENTS) {
     runAgent(label, fn);
   } else {
-    logger.info(`[并发限制] ${label} 已排队（当前 ${runningAgents}/${MAX_CONCURRENT_AGENTS} 运行中，队列 ${agentQueue.length} 个）`);
+    logger.info(
+      `[并发限制] ${label} 已排队（当前 ${runningAgents}/${MAX_CONCURRENT_AGENTS} 运行中，队列 ${agentQueue.length} 个）`,
+    );
     agentQueue.push({ fn, label });
   }
 }
 
 function runAgent(label: string, fn: () => Promise<any>) {
   runningAgents++;
-  logger.info(`[并发限制] ${label} 开始执行（${runningAgents}/${MAX_CONCURRENT_AGENTS}）`);
+  logger.info(
+    `[并发限制] ${label} 开始执行（${runningAgents}/${MAX_CONCURRENT_AGENTS}）`,
+  );
   fn()
     .catch((err) => {
       logger.error(`[并发限制] ${label} 执行异常: ${err.message}`);
     })
     .finally(() => {
       runningAgents--;
-      logger.info(`[并发限制] ${label} 执行完毕（${runningAgents}/${MAX_CONCURRENT_AGENTS}，队列 ${agentQueue.length} 个）`);
+      logger.info(
+        `[并发限制] ${label} 执行完毕（${runningAgents}/${MAX_CONCURRENT_AGENTS}，队列 ${agentQueue.length} 个）`,
+      );
       // 从队列中取出下一个任务
       const next = agentQueue.shift();
       if (next) {
@@ -81,13 +100,20 @@ function isDuplicateDelivery(deliveryId: string): boolean {
 /**
  * 验证 GitHub webhook HMAC-SHA256 签名
  */
-function verifySignature(payload: string, signature: string, secret: string): boolean {
+function verifySignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
   if (!secret) return true;
   if (!signature || signature === "none") return false;
 
   const expected = `sha256=${crypto.createHmac("sha256", secret).update(payload).digest("hex")}`;
   try {
-    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+    return crypto.timingSafeEqual(
+      Buffer.from(expected),
+      Buffer.from(signature),
+    );
   } catch {
     return false;
   }
@@ -96,7 +122,9 @@ function verifySignature(payload: string, signature: string, secret: string): bo
 /**
  * 解析仓库信息
  */
-function parseRepository(fullName: string): { owner: string; repo: string } | null {
+function parseRepository(
+  fullName: string,
+): { owner: string; repo: string } | null {
   const parts = fullName.split("/");
   if (parts.length !== 2) return null;
   return { owner: parts[0], repo: parts[1] };
@@ -111,7 +139,9 @@ function fireAndForget(fn: () => Promise<any>) {
   });
 }
 
-function getSessionQuery(url: URL): { owner: string; repo: string; issueNumber: number } | null {
+function getSessionQuery(
+  url: URL,
+): { owner: string; repo: string; issueNumber: number } | null {
   const owner = url.searchParams.get("owner") || "";
   const repo = url.searchParams.get("repo") || "";
   const issueNumber = Number(url.searchParams.get("issueNumber") || "");
@@ -139,7 +169,9 @@ async function handleEvent(
 
   const { owner, repo } = repoInfo;
   const action = payload.action || "";
-  logger.info(`[${deliveryId}] 收到事件: ${eventType}.${action} | 仓库: ${repoFullName}`);
+  logger.info(
+    `[${deliveryId}] 收到事件: ${eventType}.${action} | 仓库: ${repoFullName}`,
+  );
 
   switch (eventType) {
     case "issues": {
@@ -154,25 +186,76 @@ async function handleEvent(
         const issueTitle = payload.issue?.title || "";
         const issueBody = payload.issue?.body || "";
         const issueLabels = (payload.issue?.labels || []).map((l: any) =>
-          typeof l === "string" ? l : l.name
+          typeof l === "string" ? l : l.name,
         );
 
         logger.info(`Issue #${issueNumber} 已创建，开始分类...`);
         enqueueAgent(`Issue #${issueNumber} 分类+处理`, async () => {
-          const triageRes = await triageIssue(issueTitle, issueBody, issueLabels);
+          const triageRes = await triageIssue(
+            issueTitle,
+            issueBody,
+            issueLabels,
+          );
           if (!triageRes.success) {
-            logger.error(`Issue #${issueNumber} 分类失败，终止处理: ${triageRes.error}`);
+            logger.error(
+              `Issue #${issueNumber} 分类失败，终止处理: ${triageRes.error}`,
+            );
             return;
           }
 
           const triageResult = triageRes.data;
-          logger.info(`Issue #${issueNumber} 分类结果: ${triageResult.classification} (${triageResult.reason})`);
-          const handleRes = await handleTriagedIssue(owner, repo, issueNumber, triageResult);
+          logger.info(
+            `Issue #${issueNumber} 分类结果: ${triageResult.classification} (${triageResult.reason})`,
+          );
+          const handleRes = await handleTriagedIssue(
+            owner,
+            repo,
+            issueNumber,
+            triageResult,
+          );
           if (!handleRes.success) {
             logger.error(`处理分类结果失败: ${handleRes.error}`);
           }
         });
         return { status: 202, message: `已触发 Issue #${issueNumber} 分类` };
+      }
+
+      if (action === "labeled" && payload.label?.name === "approved") {
+        // 类型守卫：只有 bug/enhancement 标签的 issue 才触发 implementation
+        const issueLabels = (payload.issue?.labels || []).map((l: any) =>
+          typeof l === "string" ? l : l.name,
+        );
+        if (
+          !issueLabels.some((l: string) => l === "bug" || l === "enhancement")
+        ) {
+          return {
+            status: 200,
+            message: "非 bug/feature issue，忽略 approved 标签",
+          };
+        }
+
+        logger.info(`Issue #${issueNumber} 已审批，触发 APPROVED 事件...`);
+        const session = new SessionManager(owner, repo, issueNumber);
+        const transitionRes = session.transition({ type: EVENT.APPROVED });
+        if (!transitionRes.success) {
+          logger.error(`触发 APPROVED 事件失败: ${transitionRes.error}`);
+        }
+
+        logger.info(`Issue #${issueNumber} 已审批，启动实现阶段...`);
+        enqueueAgent(`Issue #${issueNumber} 实现`, async () => {
+          const res = await launchIssueAgent(
+            owner,
+            repo,
+            issueNumber,
+            "implementation",
+            { taskData: { title: `Issue #${issueNumber}` } },
+          );
+          if (!res.success) logger.error(`启动实现阶段失败: ${res.error}`);
+        });
+        return {
+          status: 202,
+          message: `已触发实现阶段: Issue #${issueNumber}`,
+        };
       }
 
       if (action === "deleted") {
@@ -183,7 +266,10 @@ async function handleEvent(
             logger.error(`Issue #${issueNumber} 资产清理失败: ${res.error}`);
           }
         });
-        return { status: 202, message: `已触发 Issue #${issueNumber} 资产清理` };
+        return {
+          status: 202,
+          message: `已触发 Issue #${issueNumber} 资产清理`,
+        };
       }
 
       return { status: 200, message: `忽略 issues.${action} 事件` };
@@ -251,18 +337,45 @@ async function handleEvent(
         const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
         if (issueMatch) {
           const linkedIssue = Number(issueMatch[1]);
-          logger.info(`PR #${prNumber} 已合并，处理 Issue #${linkedIssue}...`);
+          logger.info(
+            `PR #${prNumber} 已合并，清理 Issue #${linkedIssue} 的 WIP 标签...`,
+          );
           fireAndForget(async () => {
             const session = new SessionManager(owner, repo, linkedIssue);
-            await session.transition({ type: "PR_MERGED" });
+            session.transition({ type: "PR_MERGED" });
+            const tokenRes = await readGithubToken();
+            if (!tokenRes.success) {
+              logger.error(`获取 Token 失败: ${tokenRes.error}`);
+              return;
+            }
+            const client = new GitHubClient(tokenRes.data, owner, repo);
+            const res = await client.removeIssueLabel(linkedIssue, "WIP");
+            if (!res.success) {
+              logger.warn(
+                `移除 Issue #${linkedIssue} 的 WIP 标签失败: ${res.error}`,
+              );
+            } else {
+              logger.info(`已移除 Issue #${linkedIssue} 的 WIP 标签`);
+            }
 
-            logger.info(`PR #${prNumber} 已合并，开始清理 Issue #${linkedIssue} 的本地资源...`);
-            const cleanRes = await cleanupIssue(String(linkedIssue), { reason: "pr-merged", silent: false }, owner, repo);
+            // 自动清理 worktree
+            logger.info(
+              `PR #${prNumber} 已合并，开始清理 Issue #${linkedIssue} 的本地资源...`,
+            );
+            const cleanRes = await cleanupIssue(
+              String(linkedIssue),
+              { reason: "pr-merged", silent: false },
+              owner,
+              repo,
+            );
             if (!cleanRes.success) {
               logger.warn(`清理 Issue #${linkedIssue} 失败: ${cleanRes.error}`);
             }
           });
-          return { status: 202, message: `已触发资产回收: Issue #${linkedIssue}` };
+          return {
+            status: 202,
+            message: `已触发 WIP 清理与资产回收: Issue #${linkedIssue}`,
+          };
         }
         return { status: 200, message: "PR 已合并但未关联 issue" };
       }
@@ -283,7 +396,10 @@ async function handleEvent(
         return { status: 202, message: `已触发评论处理 PR #${prNumber}` };
       }
 
-      return { status: 200, message: `忽略 pull_request_review.${action} 事件` };
+      return {
+        status: 200,
+        message: `忽略 pull_request_review.${action} 事件`,
+      };
     }
 
     case "check_run": {
@@ -317,7 +433,10 @@ async function main() {
     .name("along webhook-server")
     .description("启动本地 webhook 接收服务器，监听 GitHub App webhook 事件")
     .option("--port <port>", "监听端口", "9876")
-    .option("--secret <secret>", "Webhook 签名密钥（GitHub App 的 webhook secret）")
+    .option(
+      "--secret <secret>",
+      "Webhook 签名密钥（GitHub App 的 webhook secret）",
+    )
     .option("--host <host>", "监听地址", "0.0.0.0")
     .option("--no-dashboard", "禁用终端 Dashboard，使用原始日志模式")
     .parse(process.argv);
@@ -344,9 +463,12 @@ async function main() {
 
       // 健康检查
       if (url.pathname === "/health") {
-        return new Response(JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }), {
-          headers: { "Content-Type": "application/json" },
-        });
+        return new Response(
+          JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }),
+          {
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
 
       // Webhook 端点
@@ -389,7 +511,9 @@ async function main() {
 
         // 处理 ping 事件（GitHub App 安装/配置时发送）
         if (githubEvent === "ping") {
-          logger.success(`[${deliveryId}] 收到 GitHub ping 事件，zen: ${payload.zen}`);
+          logger.success(
+            `[${deliveryId}] 收到 GitHub ping 事件，zen: ${payload.zen}`,
+          );
           return new Response(JSON.stringify({ message: "pong" }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -397,10 +521,13 @@ async function main() {
         }
 
         if (!githubEvent) {
-          return new Response(JSON.stringify({ error: "缺少 X-GitHub-Event header" }), {
-            status: 400,
-            headers: { "Content-Type": "application/json" },
-          });
+          return new Response(
+            JSON.stringify({ error: "缺少 X-GitHub-Event header" }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
         }
 
         const result = await handleEvent(githubEvent, payload, deliveryId);
@@ -426,29 +553,39 @@ async function main() {
       if (url.pathname === "/api/sessions" && req.method === "GET") {
         const allRes = findAllSessions();
         if (!allRes.success) {
-          return new Response(JSON.stringify({ error: "Failed to load sessions" }), { status: 500 });
+          return new Response(
+            JSON.stringify({ error: "Failed to load sessions" }),
+            { status: 500 },
+          );
         }
         const sessions = [];
         const worktreeList = await $`git worktree list`.text();
         for (const info of allRes.data) {
           const res = readSession(info.owner, info.repo, info.issueNumber);
           if (res.success && res.data) {
-             let displayLifecycle = res.data.lifecycle;
-             if (isActiveSessionStatus(displayLifecycle) && res.data.pid) {
-                const alive = await check_process_running(res.data.pid);
-                if (!alive) displayLifecycle = "zombie" as any;
-             }
-             sessions.push({
-                ...res.data,
-                lifecycle: displayLifecycle,
-                owner: info.owner,
-                repo: info.repo,
-                runtime: calculate_runtime(res.data.startTime),
-                hasWorktree: res.data.worktreePath ? worktreeList.includes(res.data.worktreePath) : false,
-              });
+            let displayLifecycle = res.data.lifecycle;
+            if (isActiveSessionStatus(displayLifecycle) && res.data.pid) {
+              const alive = await check_process_running(res.data.pid);
+              if (!alive) displayLifecycle = "zombie" as any;
+            }
+            sessions.push({
+              ...res.data,
+              lifecycle: displayLifecycle,
+              owner: info.owner,
+              repo: info.repo,
+              runtime: calculate_runtime(res.data.startTime),
+              hasWorktree: res.data.worktreePath
+                ? worktreeList.includes(res.data.worktreePath)
+                : false,
+            });
           }
         }
-        return new Response(JSON.stringify(sessions), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } });
+        return new Response(JSON.stringify(sessions), {
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        });
       }
 
       // ── API: /api/restart ──
@@ -457,27 +594,55 @@ async function main() {
           const body = await req.json();
           const { owner, repo, issueNumber } = body;
           if (!owner || !repo || !issueNumber) {
-            return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-              status: 400,
-              headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-            });
+            return new Response(
+              JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+              {
+                status: 400,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              },
+            );
           }
           logger.info(`手动重启 Issue #${issueNumber} (${owner}/${repo})...`);
           enqueueAgent(`Issue #${issueNumber} 手动重启`, async () => {
             const sessionRes = readSession(owner, repo, issueNumber);
-            const phase = sessionRes.success && sessionRes.data?.phase ? sessionRes.data.phase : "planning";
-            const title = sessionRes.success && sessionRes.data?.title ? sessionRes.data.title : `Issue #${issueNumber}`;
-            const res = await launchIssueAgent(owner, repo, issueNumber, phase, { taskData: { title } });
-            if (!res.success) logger.error(`手动重启 Issue #${issueNumber} 失败: ${res.error}`);
+            const phase =
+              sessionRes.success && sessionRes.data?.phase
+                ? sessionRes.data.phase
+                : "planning";
+            const title =
+              sessionRes.success && sessionRes.data?.title
+                ? sessionRes.data.title
+                : `Issue #${issueNumber}`;
+            const res = await launchIssueAgent(
+              owner,
+              repo,
+              issueNumber,
+              phase,
+              { taskData: { title } },
+            );
+            if (!res.success)
+              logger.error(`手动重启 Issue #${issueNumber} 失败: ${res.error}`);
           });
-          return new Response(JSON.stringify({ message: `已触发重启 Issue #${issueNumber}` }), {
-            status: 202,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({ message: `已触发重启 Issue #${issueNumber}` }),
+            {
+              status: 202,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         } catch (e: any) {
           return new Response(JSON.stringify({ error: e.message }), {
             status: 500,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
       }
@@ -488,27 +653,54 @@ async function main() {
           const body = await req.json();
           const { owner, repo, issueNumber } = body;
           if (!owner || !repo || !issueNumber) {
-            return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-              status: 400,
-              headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-            });
+            return new Response(
+              JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+              {
+                status: 400,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              },
+            );
           }
-          logger.info(`清理 Issue #${issueNumber} 的 worktree (${owner}/${repo})...`);
-          const res = await cleanupIssue(String(issueNumber), { force: true, reason: "dashboard", silent: true }, owner, repo);
+          logger.info(
+            `清理 Issue #${issueNumber} 的 worktree (${owner}/${repo})...`,
+          );
+          const res = await cleanupIssue(
+            String(issueNumber),
+            { force: true, reason: "dashboard", silent: true },
+            owner,
+            repo,
+          );
           if (!res.success) {
             return new Response(JSON.stringify({ error: res.error }), {
               status: 500,
-              headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
             });
           }
-          return new Response(JSON.stringify({ message: `已清理 Issue #${issueNumber} 的 worktree` }), {
-            status: 200,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({
+              message: `已清理 Issue #${issueNumber} 的 worktree`,
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         } catch (e: any) {
           return new Response(JSON.stringify({ error: e.message }), {
             status: 500,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
       }
@@ -519,76 +711,124 @@ async function main() {
           const body = await req.json();
           const { owner, repo, issueNumber } = body;
           if (!owner || !repo || !issueNumber) {
-            return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-              status: 400,
-              headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-            });
+            return new Response(
+              JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+              {
+                status: 400,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              },
+            );
           }
-          logger.info(`彻底删除 Issue #${issueNumber} 的本地资产 (${owner}/${repo})...`);
-          const res = await cleanupIssueAssets(String(issueNumber), { force: true, reason: "dashboard-delete", silent: true }, owner, repo);
+          logger.info(
+            `彻底删除 Issue #${issueNumber} 的本地资产 (${owner}/${repo})...`,
+          );
+          const res = await cleanupIssueAssets(
+            String(issueNumber),
+            { force: true, reason: "dashboard-delete", silent: true },
+            owner,
+            repo,
+          );
           if (!res.success) {
             return new Response(JSON.stringify({ error: res.error }), {
               status: 500,
-              headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
             });
           }
-          return new Response(JSON.stringify({ message: `已彻底删除 Issue #${issueNumber} 的本地资产` }), {
-            status: 200,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({
+              message: `已彻底删除 Issue #${issueNumber} 的本地资产`,
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         } catch (e: any) {
           return new Response(JSON.stringify({ error: e.message }), {
             status: 500,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
       }
 
       // ── API: /api/system-logs (SSE) ──
       if (url.pathname === "/api/system-logs" && req.method === "GET") {
-         return new Response(new ReadableStream({
-             start(controller) {
-                 const id = setInterval(() => {
-                     const logs = getLogEntries();
-                     controller.enqueue(`data: ${JSON.stringify(logs)}\n\n`);
-                 }, 2000);
-                 req.signal.addEventListener("abort", () => {
-                     clearInterval(id);
-                 });
-             }
-         }), {
-             headers: {
-                 "Content-Type": "text/event-stream",
-                 "Cache-Control": "no-cache",
-                 "Connection": "keep-alive",
-                 "Access-Control-Allow-Origin": "*"
-             }
-         });
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              const id = setInterval(() => {
+                const logs = getLogEntries();
+                controller.enqueue(`data: ${JSON.stringify(logs)}\n\n`);
+              }, 2000);
+              req.signal.addEventListener("abort", () => {
+                clearInterval(id);
+              });
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          },
+        );
       }
 
       // ── API: /api/session-log ──
       if (url.pathname === "/api/session-log" && req.method === "GET") {
         const query = getSessionQuery(url);
         if (!query) {
-          return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-            status: 400,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         }
 
-        const source = (url.searchParams.get("source") || "system") as SessionLogSource;
+        const source = (url.searchParams.get("source") ||
+          "system") as SessionLogSource;
         if (source !== "system" && source !== "agent" && source !== "merged") {
           return new Response(JSON.stringify({ error: "Invalid source" }), {
             status: 400,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
 
-        const maxLines = Number(url.searchParams.get("maxLines") || "") || undefined;
-        const paths = new SessionPathManager(query.owner, query.repo, query.issueNumber);
+        const maxLines =
+          Number(url.searchParams.get("maxLines") || "") || undefined;
+        const paths = new SessionPathManager(
+          query.owner,
+          query.repo,
+          query.issueNumber,
+        );
         const logs = readSessionLog(paths, source, maxLines);
         return new Response(JSON.stringify(logs), {
-          headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
         });
       }
 
@@ -596,24 +836,46 @@ async function main() {
       if (url.pathname === "/api/session-diagnostic" && req.method === "GET") {
         const query = getSessionQuery(url);
         if (!query) {
-          return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-            status: 400,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         }
 
-        const sessionRes = readSession(query.owner, query.repo, query.issueNumber);
+        const sessionRes = readSession(
+          query.owner,
+          query.repo,
+          query.issueNumber,
+        );
         if (!sessionRes.success || !sessionRes.data) {
           return new Response(JSON.stringify({ error: "Session not found" }), {
             status: 404,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
 
-        const paths = new SessionPathManager(query.owner, query.repo, query.issueNumber);
-        const diagnostic = readSessionDiagnostic(paths) || generateSessionDiagnostic(sessionRes.data, paths);
+        const paths = new SessionPathManager(
+          query.owner,
+          query.repo,
+          query.issueNumber,
+        );
+        const diagnostic =
+          readSessionDiagnostic(paths) ||
+          generateSessionDiagnostic(sessionRes.data, paths);
         return new Response(JSON.stringify(diagnostic), {
-          headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
         });
       }
 
@@ -621,29 +883,47 @@ async function main() {
       if (url.pathname === "/api/agent-conversation" && req.method === "GET") {
         const query = getSessionQuery(url);
         if (!query) {
-          return new Response(JSON.stringify({ error: "Missing owner, repo, or issueNumber" }), {
-            status: 400,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({ error: "Missing owner, repo, or issueNumber" }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         }
 
-        const sessionRes = readSession(query.owner, query.repo, query.issueNumber);
+        const sessionRes = readSession(
+          query.owner,
+          query.repo,
+          query.issueNumber,
+        );
         if (!sessionRes.success || !sessionRes.data) {
           return new Response(JSON.stringify({ error: "Session not found" }), {
             status: 404,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
 
-        const claudeSessionId = (sessionRes.data as any).claudeSessionId;
+        const claudeSessionId = sessionRes.data.claudeSessionId;
         const worktreePath = sessionRes.data.worktreePath;
         if (!claudeSessionId || !worktreePath) {
           return new Response(JSON.stringify([]), {
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
 
-        const encodedPath = worktreePath.replace(/\//g, "-");
+        const encodedPath = worktreePath
+          .replace(/\/\./g, "--")
+          .replace(/\//g, "-");
         const jsonlPath = path.join(
           process.env.HOME || "~",
           ".claude",
@@ -654,7 +934,10 @@ async function main() {
 
         if (!fs.existsSync(jsonlPath)) {
           return new Response(JSON.stringify([]), {
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         }
 
@@ -669,18 +952,35 @@ async function main() {
               const type = record.type;
               if (type === "user") {
                 const text = Array.isArray(record.message?.content)
-                  ? record.message.content.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n")
-                  : typeof record.message?.content === "string" ? record.message.content : "";
+                  ? record.message.content
+                      .filter((c: any) => c.type === "text")
+                      .map((c: any) => c.text)
+                      .join("\n")
+                  : typeof record.message?.content === "string"
+                    ? record.message.content
+                    : "";
                 if (text) {
-                  messages.push({ type: "user", content: text, timestamp: record.timestamp });
+                  messages.push({
+                    type: "user",
+                    content: text,
+                    timestamp: record.timestamp,
+                  });
                 }
               } else if (type === "assistant") {
                 const content = record.message?.content;
                 if (Array.isArray(content)) {
-                  const texts = content.filter((c: any) => c.type === "text" && c.text).map((c: any) => c.text);
-                  const toolUses = content.filter((c: any) => c.type === "tool_use");
+                  const texts = content
+                    .filter((c: any) => c.type === "text" && c.text)
+                    .map((c: any) => c.text);
+                  const toolUses = content.filter(
+                    (c: any) => c.type === "tool_use",
+                  );
                   if (texts.length > 0) {
-                    messages.push({ type: "assistant", content: texts.join("\n"), timestamp: record.timestamp });
+                    messages.push({
+                      type: "assistant",
+                      content: texts.join("\n"),
+                      timestamp: record.timestamp,
+                    });
                   }
                   for (const tool of toolUses) {
                     messages.push({
@@ -696,7 +996,10 @@ async function main() {
                 if (Array.isArray(content)) {
                   for (const c of content) {
                     if (c.type === "tool_result") {
-                      const text = typeof c.content === "string" ? c.content : JSON.stringify(c.content);
+                      const text =
+                        typeof c.content === "string"
+                          ? c.content
+                          : JSON.stringify(c.content);
                       messages.push({
                         type: "tool_result",
                         content: text.slice(0, 1000),
@@ -712,35 +1015,46 @@ async function main() {
             }
           }
           return new Response(JSON.stringify(messages), {
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+            headers: {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
           });
         } catch (e: any) {
-          return new Response(JSON.stringify({ error: `Failed to read conversation: ${e.message}` }), {
-            status: 500,
-            headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
-          });
+          return new Response(
+            JSON.stringify({
+              error: `Failed to read conversation: ${e.message}`,
+            }),
+            {
+              status: 500,
+              headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            },
+          );
         }
       }
 
       // ── Static Web UI ──
       if (req.method === "GET" && useDashboard) {
-         try {
-             const webDist = path.join(import.meta.dir, "..", "web", "dist");
-             const reqPath = url.pathname === "/" ? "/index.html" : url.pathname;
-             const filePath = path.join(webDist, reqPath);
-             
-             // Check if it's a regular file that exists
-             const file = Bun.file(filePath);
-             if (await file.exists()) {
-                 return new Response(file);
-             }
-             
-             // Fallback to index.html for SPA routing
-             const fallbackFile = Bun.file(path.join(webDist, "index.html"));
-             if (await fallbackFile.exists()) {
-                 return new Response(fallbackFile);
-             }
-         } catch(e) {}
+        try {
+          const webDist = path.join(import.meta.dir, "..", "web", "dist");
+          const reqPath = url.pathname === "/" ? "/index.html" : url.pathname;
+          const filePath = path.join(webDist, reqPath);
+
+          // Check if it's a regular file that exists
+          const file = Bun.file(filePath);
+          if (await file.exists()) {
+            return new Response(file);
+          }
+
+          // Fallback to index.html for SPA routing
+          const fallbackFile = Bun.file(path.join(webDist, "index.html"));
+          if (await fallbackFile.exists()) {
+            return new Response(fallbackFile);
+          }
+        } catch (e) {}
       }
 
       return new Response("Not Found", { status: 404 });
@@ -771,7 +1085,7 @@ async function main() {
       // 尝试自动打开浏览器
       const { exec } = await import("child_process");
       exec(`start ${dashboardUrl}`);
-    } catch(e) {}
+    } catch (e) {}
   } else {
     logger.info("按 Ctrl+C 停止服务器");
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import type { SessionDiagnostic, SessionLogEntry, DashboardSession, StatusCounts } from './types';
+import type { SessionDiagnostic, SessionLogEntry, DashboardSession, StatusCounts, ConversationMessage } from './types';
 import './index.css';
 
 const statusFilters = [
@@ -17,10 +17,11 @@ function App() {
   const [sessions, setSessions] = useState<DashboardSession[]>([]);
   const [currentFilter, setCurrentFilter] = useState<string>('all');
   const [selectedSession, setSelectedSession] = useState<DashboardSession | null>(null);
-  const [selectedLogTab, setSelectedLogTab] = useState<'system' | 'agent' | 'merged'>('merged');
+  const [selectedLogTab, setSelectedLogTab] = useState<'system' | 'agent' | 'merged' | 'conversation'>('merged');
   const [selectedSystemLogs, setSelectedSystemLogs] = useState<SessionLogEntry[]>([]);
   const [selectedAgentLogs, setSelectedAgentLogs] = useState<SessionLogEntry[]>([]);
   const [selectedMergedLogs, setSelectedMergedLogs] = useState<SessionLogEntry[]>([]);
+  const [selectedConversation, setSelectedConversation] = useState<ConversationMessage[]>([]);
   const [selectedDiagnostic, setSelectedDiagnostic] = useState<SessionDiagnostic | null>(null);
   const [selectedLogsLoading, setSelectedLogsLoading] = useState(false);
   const [restartingIssues, setRestartingIssues] = useState<Set<string>>(new Set());
@@ -59,6 +60,7 @@ function App() {
       setSelectedSystemLogs([]);
       setSelectedAgentLogs([]);
       setSelectedMergedLogs([]);
+      setSelectedConversation([]);
       setSelectedDiagnostic(null);
       return;
     }
@@ -75,11 +77,12 @@ function App() {
 
     const loadDetails = async () => {
       try {
-        const [systemRes, agentRes, mergedRes, diagnosticRes] = await Promise.all([
+        const [systemRes, agentRes, mergedRes, diagnosticRes, conversationRes] = await Promise.all([
           fetch(`/api/session-log?${params.toString()}&source=system&maxLines=150`),
           fetch(`/api/session-log?${params.toString()}&source=agent&maxLines=250`),
           fetch(`/api/session-log?${params.toString()}&source=merged&maxLines=250`),
           fetch(`/api/session-diagnostic?${params.toString()}`),
+          fetch(`/api/agent-conversation?${params.toString()}`),
         ]);
 
         if (!active) return;
@@ -107,11 +110,23 @@ function App() {
         } else {
           setSelectedDiagnostic(null);
         }
+
+        if (conversationRes.ok) {
+          const data = await conversationRes.json();
+          if (Array.isArray(data)) {
+            setSelectedConversation(data);
+          } else {
+            setSelectedConversation([]);
+          }
+        } else {
+          setSelectedConversation([]);
+        }
       } catch {
         if (!active) return;
         setSelectedSystemLogs([]);
         setSelectedAgentLogs([]);
         setSelectedMergedLogs([]);
+        setSelectedConversation([]);
         setSelectedDiagnostic(null);
       } finally {
         if (active) {
@@ -349,6 +364,73 @@ function App() {
         <span>{entry.message}</span>
       </div>
     ));
+  };
+
+  const renderConversationMessages = (messages: ConversationMessage[]) => {
+    if (messages.length === 0) {
+      return <div className="p-4 text-text-muted">No conversation data yet. Conversation is only available for Kira Code (Claude) agents.</div>;
+    }
+
+    return messages.map((msg, i) => {
+      if (msg.type === 'user') {
+        return (
+          <div key={`conv-${i}`} className="flex justify-end">
+            <div className="max-w-[85%] bg-blue-600/20 border border-blue-500/30 rounded-lg p-3">
+              {msg.timestamp && (
+                <div className="text-[10px] text-blue-300/60 mb-1">
+                  {new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date(msg.timestamp))}
+                </div>
+              )}
+              <div className="text-blue-100 whitespace-pre-wrap break-all">{msg.content}</div>
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.type === 'assistant') {
+        return (
+          <div key={`conv-${i}`} className="flex justify-start">
+            <div className="max-w-[85%] bg-white/5 border border-border-color rounded-lg p-3">
+              {msg.timestamp && (
+                <div className="text-[10px] text-text-muted mb-1">
+                  {new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' }).format(new Date(msg.timestamp))}
+                </div>
+              )}
+              <div className="text-gray-200 whitespace-pre-wrap break-all">{msg.content}</div>
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.type === 'tool_use') {
+        return (
+          <div key={`conv-${i}`} className="flex justify-start pl-4">
+            <div className="max-w-[85%] bg-amber-900/15 border border-amber-500/20 rounded-lg p-2 text-xs">
+              <span className="text-amber-400 font-semibold">{msg.toolName}</span>
+              {msg.toolInput && (
+                <div className="text-amber-200/60 mt-1 break-all truncate max-h-20 overflow-hidden">{msg.toolInput}</div>
+              )}
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.type === 'tool_result') {
+        return (
+          <div key={`conv-${i}`} className="flex justify-start pl-4">
+            <div className={`max-w-[85%] rounded-lg p-2 text-xs border ${
+              msg.isError
+                ? 'bg-red-900/15 border-red-500/20 text-red-300'
+                : 'bg-emerald-900/15 border-emerald-500/20 text-emerald-300'
+            }`}>
+              <div className="break-all max-h-32 overflow-hidden whitespace-pre-wrap">{msg.content}</div>
+            </div>
+          </div>
+        );
+      }
+
+      return null;
+    });
   };
 
   const currentSelectedLogs =
@@ -725,12 +807,24 @@ function App() {
                          >
                            Agent Log
                          </button>
+                         <button
+                           className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all cursor-pointer ${
+                             selectedLogTab === 'conversation'
+                               ? 'bg-white/10 text-white border-border-color'
+                               : 'bg-transparent text-text-secondary border-border-color hover:bg-white/5'
+                           }`}
+                           onClick={() => setSelectedLogTab('conversation')}
+                         >
+                           Conversation
+                         </button>
                        </div>
                      </div>
                      <div className="bg-black border border-border-color rounded-lg p-3 md:p-4 font-mono text-xs md:text-[13px] text-gray-300 overflow-auto flex-1 min-h-0 flex flex-col gap-1.5">
                        {selectedLogsLoading
                          ? <div className="p-4 text-text-muted">Loading logs...</div>
-                         : renderSessionLogLines(currentSelectedLogs, selectedLogTab)}
+                         : selectedLogTab === 'conversation'
+                           ? renderConversationMessages(selectedConversation)
+                           : renderSessionLogLines(currentSelectedLogs, selectedLogTab as 'system' | 'agent' | 'merged')}
                      </div>
                    </div>
                  </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -111,6 +111,15 @@ export interface DashboardSession {
   hasWorktree?: boolean;
 }
 
+export interface ConversationMessage {
+  type: "user" | "assistant" | "tool_use" | "tool_result";
+  content?: string;
+  toolName?: string;
+  toolInput?: string;
+  isError?: boolean;
+  timestamp?: string;
+}
+
 export interface StatusCounts {
   running: number;
   waiting_human: number;


### PR DESCRIPTION
## Summary

在 Dashboard 中新增 **Conversation** 标签页，支持实时查看 Claude Agent 的完整对话内容（用户消息、助手回复、工具调用及结果）。

fixes: #43

## 变更内容

### 后端（数据捕获 + API）

- **`bin/db.ts`**: 新增 `claude_session_id` 字段到 sessions 表，支持存储 Claude 会话 ID
- **`bin/session-manager.ts`**: 新增 `updateClaudeSessionId()` 方法，供 agent 执行时写入 sessionId
- **`bin/config.ts`**: Claude runTemplate 添加 `--output-format stream-json`，启用结构化 JSONL 输出
- **`bin/issue-agent.ts`**: 新增 `drainJsonStream()` 函数，解析 Claude JSONL 流并提取 sessionId；新增 `formatJsonRecord()` 将结构化记录转为可读日志
- **`bin/webhook-server.ts`**: 新增 `/api/agent-conversation` 端点，读取 Claude 本地 JSONL 会话文件并返回结构化消息列表

### 前端（会话查看器）

- **`web/src/types.ts`**: 新增 `ConversationMessage` 接口
- **`web/src/App.tsx`**: 新增 Conversation 标签页，包含：
  - 用户消息（蓝色气泡，右对齐）
  - 助手回复（灰色气泡，左对齐）
  - 工具调用（琥珀色，显示工具名和截断的输入）
  - 工具结果（绿色/红色，区分成功和错误）

## 数据流

```
Claude CLI (--output-format stream-json)
  → JSONL stdout stream
  → drainJsonStream() 解析并提取 sessionId
  → SQLite sessions.claude_session_id
  → /api/agent-conversation 读取 ~/.claude/projects/{path}/{sessionId}.jsonl
  → 前端 3s 轮询渲染
```

## 影响范围

- 仅影响 Claude Agent 类型，OpenCode/PI 不受影响
- 新增 SQLite 字段通过 `tryAddColumn` 迁移，向后兼容
- API 在无 sessionId 或文件不存在时返回空数组，不会报错

## Test plan

- [ ] 启动 `along webhook-server`，触发一个 Issue 任务
- [ ] 在 Dashboard 中点击会话详情，切换到 Conversation 标签页
- [ ] 验证用户消息、助手回复、工具调用、工具结果均正确渲染
- [ ] 验证无会话数据时显示友好提示
- [ ] 验证 OpenCode/PI agent 不受影响（Conversation 标签显示空状态）