### PR TITLE
fix: 修复 lifecycle 标签同步逻辑，避免 404 错误

### DIFF
--- a/bin/github-client.ts
+++ b/bin/github-client.ts
@@ -492,10 +492,32 @@ export async function syncLifecycleLabel(
   if (!clientRes.success) return;
   const client = clientRes.data;
 
-  const removePromises = LIFECYCLE_LABELS
-    .filter(l => l !== newLifecycle)
-    .map(l => client.removeIssueLabel(issueNumber, l));
-  await Promise.all(removePromises);
-  await client.addIssueLabels(issueNumber, [newLifecycle]);
+  // 获取 Issue 当前数据，获取所有标签
+  const issueRes = await client.getIssue(issueNumber);
+  if (!issueRes.success) return;
+
+  // 提取当前 lifecycle 标签（Issue labels 可能是对象或字符串）
+  const currentLifecycleLabels: string[] = issueRes.data.labels
+    .map(l => typeof l === "string" ? l : l.name)
+    .filter((name): name is string => LIFECYCLE_LABELS.includes(name as SessionLifecycle));
+
+  // 计算期望的标签集合
+  const expectedLabels = [newLifecycle];
+
+  // 计算需要添加的标签（只在当前不存在时添加）
+  const labelsToAdd = expectedLabels.filter(l => !currentLifecycleLabels.includes(l));
+
+  // 计算需要删除的标签（只删当前存在的）
+  const labelsToRemove = currentLifecycleLabels.filter(l => l !== newLifecycle);
+
+  // 先添加新标签，确保新状态存在
+  if (labelsToAdd.length > 0) {
+    await client.addIssueLabels(issueNumber, labelsToAdd);
+  }
+
+  // 再删除旧标签
+  for (const label of labelsToRemove) {
+    await client.removeIssueLabel(issueNumber, label);
+  }
 }
 


### PR DESCRIPTION
## Summary

修复 `syncLifecycleLabel` 函数的标签同步逻辑，避免当 GitHub Issue 标签与系统状态不一致时产生 404 错误。

## 问题

原实现盲目删除所有旧 lifecycle 标签再添加新标签，没有检查 GitHub 实际标签状态：
1. 尝试删除所有非当前状态的 lifecycle 标签
2. 再添加新标签

当外部手动删除标签或网络问题导致标签未成功添加时，系统仍尝试删除不存在的标签，导致 404 错误。

## 修复

```typescript
// 1. 先获取 GitHub Issue 当前所有标签
const issueRes = await client.getIssue(issueNumber);

// 2. 计算需要添加的标签（当前不存在的）
const labelsToAdd = expectedLabels.filter(l => !currentLifecycleLabels.includes(l));

// 3. 计算需要删除的标签（当前存在但不应存在的）
const labelsToRemove = currentLifecycleLabels.filter(l => l !== newLifecycle);

// 4. 先添加新标签确保新状态存在，再删除旧标签
if (labelsToAdd.length > 0) {
  await client.addIssueLabels(issueNumber, labelsToAdd);
}
for (const label of labelsToRemove) {
  await client.removeIssueLabel(issueNumber, label);
}
```

## Test plan

- [x] 运行 `bunx vitest run bin/__tests__/session-manager.test.ts` 通过

fixes #50