### PR TITLE
fix(pr-create): 自动追加 fixes: #issueNumber 建立 PR 与 Issue 关联

### DIFF
--- a/bin/pr-create.ts
+++ b/bin/pr-create.ts
@@ -85,13 +85,18 @@ async function main() {
     ? { ...process.env, GH_TOKEN: tokenRes.data }
     : { ...process.env };
 
+  // 自动追加 fixes: #issueNumber 确保 PR 与 Issue 关联
+  const linkedBody = body.endsWith(`fixes: #${issueNumber}`)
+    ? body
+    : `${body}\n\nfixes: #${issueNumber}`;
+
   try {
     const result = await $`gh pr create \
       --repo ${repo.owner}/${repo.name} \
       --head ${branchName} \
       --base ${defaultBranch} \
       --title ${title} \
-      --body ${body}`.cwd(worktreePath).env(ghEnv).text();
+      --body ${linkedBody}`.cwd(worktreePath).env(ghEnv).text();
 
     const prUrl = result.trim();
     logger.success(`PR 创建成功: ${prUrl}`);
@@ -132,7 +137,7 @@ async function main() {
       ``,
       `## PR 描述`,
       ``,
-      body,
+      linkedBody,
     ].join("\n");
     const outputFile = saveStepOutput(paths, 5, "pr-create", outputContent);
     completeTodoStep(paths, 5, `PR: ${prUrl}`, outputFile);


### PR DESCRIPTION
fixes: #54

## 修改内容
- `bin/pr-create.ts`：在创建 PR 时自动追加 `fixes: #${issueNumber}` 到 body，确保 PR 与 Issue 建立关联

## 执行步骤
1. 分析 Issue #54 的根因：PR 描述中缺少 `fixes: #54` 关联信息
2. 修改 `pr-create.ts`，在调用 `gh pr create` 前自动追加 `fixes: #issueNumber`（仅当 body 未包含时）
3. 验证语法正确性，安装依赖后测试通过
4. 提交并推送代码

## 影响范围
- 仅影响 PR 创建行为，修复后所有通过 `along pr-create` 创建的 PR 都会自动关联对应 Issue
- 无破坏性变更