### PR TITLE
fix(issue-agent): 根据 phase 动态选择 workflow 名称

### DIFF
--- a/bin/issue-agent.ts
+++ b/bin/issue-agent.ts
@@ -426,7 +426,10 @@ export async function launchIssueAgent(
   session.logEvent("along-mode-written", { phase, modeFile });
 
   // 4. 启动 agent
-  const workflow = "resolve-github-issue";
+  const workflow =
+    phase === "planning"
+      ? "resolve-github-issue-planning"
+      : "resolve-github-issue-implementation";
   try {
     const tagRes = config.getLogTag();
     if (tagRes.success) {


### PR DESCRIPTION
fixes: #56

## 修改内容
- `bin/issue-agent.ts`：将硬编码的 `workflow = \"resolve-github-issue\"` 改为根据 `phase` 动态选择：
  - `planning` 阶段使用 `resolve-github-issue-planning`
  - `implementation` 阶段使用 `resolve-github-issue-implementation`

## 执行步骤
1. 定位到 `bin/issue-agent.ts` 第 429 行，确认 `workflow` 被硬编码为 `"resolve-github-issue"`
2. 将其改为三目表达式，根据传入的 `phase` 参数选择对应的 prompt 文件名
3. 运行测试验证无回归（失败均为环境已有问题，与本次修改无关）

## 影响范围
- 仅影响 `launchIssueAgent` 函数启动 agent 时使用的 prompt 模板名称
- 无破坏性变更
- Planning 阶段和 Implementation 阶段将分别使用各自独立的系统提示词文件