### PR TITLE
fix(webhook): 重启接口增加 Issue 状态校验

### DIFF
--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -23,6 +23,7 @@ import {
 } from "./webhook-handlers";
 import { triageIssue, handleTriagedIssue } from "./issue-triage";
 import { launchIssueAgent, setDashboardMode } from "./issue-agent";
+import { Issue } from "./issue";
 import { config } from "./config";
 import { findAllSessions, readSession } from "./db";
 import { check_process_running, calculate_runtime } from "./common";
@@ -744,6 +745,35 @@ async function main() {
             );
           }
           logger.info(`手动重启 Issue #${issueNumber} (${owner}/${repo})...`);
+
+          const issue = new Issue(issueNumber, config);
+          const loadRes = await issue.load();
+          if (!loadRes.success) {
+            return new Response(
+              JSON.stringify({ error: `无法获取 Issue 状态: ${loadRes.error}` }),
+              {
+                status: 500,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              },
+            );
+          }
+          const healthRes = issue.checkHealth({ skipWipCheck: true });
+          if (!healthRes.success) {
+            return new Response(
+              JSON.stringify({ error: healthRes.error }),
+              {
+                status: 409,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              },
+            );
+          }
+
           enqueueAgent(`Issue #${issueNumber} 手动重启`, async () => {
             const sessionRes = readSession(owner, repo, issueNumber);
             const phase =

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -238,7 +238,8 @@ function App() {
         body: JSON.stringify({ owner: session.owner, repo: session.repo, issueNumber: session.issueNumber }),
       });
       if (!res.ok) {
-        const data = await res.json();
+        const data = await res.json().catch(() => ({ error: '重启请求失败' }));
+        alert(data.error || '重启请求失败');
         console.error('Restart failed:', data.error);
       }
     } catch (e) {


### PR DESCRIPTION
## 问题

/api/restart 端点缺少 Issue 状态校验，允许对已关闭的 Issue 执行重启操作，导致无效的 agent 启动。

## 修复

- 在 /api/restart 端点复用 Issue.load() + checkHealth({ skipWipCheck: true }) 校验 Issue 状态
- 已关闭 Issue 返回 HTTP 409 Conflict，GitHub API 失败返回 HTTP 500
- 前端 restartSession 增加 alert() 展示服务端返回的错误信息，附带 .catch() 兜底

## 改动文件

- bin/webhook-server.ts — 增加 Issue 状态校验逻辑
- web/src/App.tsx — 前端错误提示展示

fixes: #65