### PR TITLE
fix(webhook): 补全 Issue 关闭和 PR 拒绝的状态同步

### DIFF
--- a/bin/__tests__/session-state-machine.test.ts
+++ b/bin/__tests__/session-state-machine.test.ts
@@ -54,4 +54,54 @@ describe("session-state-machine.ts", () => {
     expect(isActiveSessionStatus("waiting_human")).toBe(false);
     expect(isActiveSessionStatus("completed")).toBe(false);
   });
+
+  it("Issue 关闭后进入 completed/done/archive_result", () => {
+    const result = applySessionStateEvent(
+      { lifecycle: "waiting_external", phase: "stabilization", step: "await_merge", context: { issueNumber: 1 } },
+      { type: "ISSUE_CLOSED" },
+    );
+
+    expect(result.nextLifecycle).toBe("completed");
+    expect(result.patch.phase).toBe("done");
+    expect(result.patch.step).toBe("archive_result");
+    expect(result.patch.message).toBe("Issue 已关闭");
+    expect(result.patch.endTime).toBe("2026-04-20T12:00:00.000Z");
+  });
+
+  it("ISSUE_CLOSED 支持自定义消息", () => {
+    const result = applySessionStateEvent(
+      { lifecycle: "waiting_external", phase: "stabilization", step: "await_merge", context: { issueNumber: 1 } },
+      { type: "ISSUE_CLOSED", message: "Issue 已关闭（兜底同步）" },
+    );
+
+    expect(result.nextLifecycle).toBe("completed");
+    expect(result.patch.message).toBe("Issue 已关闭（兜底同步）");
+  });
+
+  it("PR 被拒绝后进入 failed 状态", () => {
+    const result = applySessionStateEvent(
+      { lifecycle: "waiting_external", phase: "stabilization", step: "await_merge", context: { issueNumber: 1 } },
+      { type: "PR_REJECTED", message: "PR #10 被关闭但未合并" },
+    );
+
+    expect(result.nextLifecycle).toBe("failed");
+    expect(result.patch.phase).toBe("stabilization");
+    expect(result.patch.step).toBe("await_merge");
+    expect(result.patch.message).toBe("PR #10 被关闭但未合并");
+    expect(result.patch.endTime).toBe("2026-04-20T12:00:00.000Z");
+    expect(result.patch.error).toEqual({
+      message: "PR #10 被关闭但未合并",
+      retryable: false,
+    });
+  });
+
+  it("PR_REJECTED 使用默认消息", () => {
+    const result = applySessionStateEvent(
+      { lifecycle: "waiting_external", phase: "stabilization", step: "await_merge", context: { issueNumber: 1 } },
+      { type: "PR_REJECTED" },
+    );
+
+    expect(result.nextLifecycle).toBe("failed");
+    expect(result.patch.message).toBe("PR 被关闭但未合并");
+  });
 });

--- a/bin/session-state-machine.ts
+++ b/bin/session-state-machine.ts
@@ -77,6 +77,8 @@ export const EVENT = {
   CI_FIX_STARTED: "CI_FIX_STARTED",
   CI_FIX_COMPLETED: "CI_FIX_COMPLETED",
   PR_MERGED: "PR_MERGED",
+  ISSUE_CLOSED: "ISSUE_CLOSED",
+  PR_REJECTED: "PR_REJECTED",
   APPROVED: "APPROVED",
   MANUAL_STATUS_UPDATE: "MANUAL_STATUS_UPDATE",
 } as const;
@@ -152,6 +154,8 @@ export type SessionStateEvent =
   | { type: typeof EVENT["CI_FIX_STARTED"]; failedCount: number }
   | { type: typeof EVENT["CI_FIX_COMPLETED"] }
   | { type: typeof EVENT["PR_MERGED"]; message?: string }
+  | { type: typeof EVENT["ISSUE_CLOSED"]; message?: string }
+  | { type: typeof EVENT["PR_REJECTED"]; message?: string }
   | { type: typeof EVENT["APPROVED"] }
   | { type: typeof EVENT["MANUAL_STATUS_UPDATE"]; lifecycle: SessionLifecycle; message?: string; step?: SessionStep };
 
@@ -507,6 +511,31 @@ export function applySessionStateEvent(
         pid: undefined,
         endTime: now,
         error: null,
+      });
+
+    case EVENT.ISSUE_CLOSED:
+      return nextStatePatch(current, {
+        lifecycle: LIFECYCLE.COMPLETED,
+        phase: PHASE.DONE,
+        step: STEP.ARCHIVE_RESULT,
+        message: event.message ?? "Issue 已关闭",
+        pid: undefined,
+        endTime: now,
+        error: null,
+      });
+
+    case EVENT.PR_REJECTED:
+      return nextStatePatch(current, {
+        lifecycle: LIFECYCLE.FAILED,
+        phase: current?.phase ?? PHASE.STABILIZATION,
+        step: current?.step ?? STEP.AWAIT_MERGE,
+        message: event.message ?? "PR 被关闭但未合并",
+        pid: undefined,
+        endTime: now,
+        error: {
+          message: event.message ?? "PR 被关闭但未合并",
+          retryable: false,
+        },
       });
 
     case EVENT.APPROVED:

--- a/bin/webhook-server.ts
+++ b/bin/webhook-server.ts
@@ -30,13 +30,14 @@ import { check_process_running, calculate_runtime } from "./common";
 import { setupLogInterceptor, getLogEntries } from "./log-buffer";
 import { ensureWebhookSecret, ensureProjectBootstrap } from "./bootstrap";
 import { cleanupIssue, cleanupIssueAssets } from "./cleanup-utils";
-import { syncLifecycleLabel } from "./github-client";
+import { syncLifecycleLabel, get_gh_client } from "./github-client";
 import {
   isActiveSessionStatus,
   EVENT,
   LIFECYCLE,
   COMMAND,
   PHASE,
+  STEP,
 } from "./session-state-machine";
 import { SessionManager } from "./session-manager";
 import { SessionPathManager } from "./session-paths";
@@ -102,6 +103,10 @@ function runAgent(label: string, fn: () => Promise<any>) {
 const DEDUP_MAX_SIZE = 1000;
 const processedDeliveries = new Set<string>();
 const issueCommentLocks = new Map<string, Promise<any>>();
+
+// ── Dashboard 兜底同步节流（防止频繁调用 GitHub API） ──
+const FALLBACK_SYNC_INTERVAL_MS = 60_000;
+let lastFallbackSyncTime = 0;
 
 function isDuplicateDelivery(deliveryId: string): boolean {
   if (!deliveryId || deliveryId === "-") return false;
@@ -267,6 +272,36 @@ async function handleEvent(
         return {
           status: 202,
           message: `已触发 Issue #${issueNumber} 资产清理`,
+        };
+      }
+
+      if (action === "closed") {
+        logger.info(`Issue #${issueNumber} 已关闭，检查关联 session...`);
+        fireAndForget(async () => {
+          const session = new SessionManager(owner, repo, issueNumber);
+          const statusRes = session.readStatus();
+          if (!statusRes.success || !statusRes.data) return;
+
+          const { lifecycle } = statusRes.data;
+          if (lifecycle === LIFECYCLE.COMPLETED || lifecycle === LIFECYCLE.FAILED) return;
+
+          await session.transition({ type: EVENT.ISSUE_CLOSED });
+          await syncLifecycleLabel(owner, repo, issueNumber, LIFECYCLE.COMPLETED);
+
+          logger.info(`Issue #${issueNumber} 关闭，开始清理本地资源...`);
+          const cleanRes = await cleanupIssue(
+            String(issueNumber),
+            { reason: "issue-closed", silent: false },
+            owner,
+            repo,
+          );
+          if (!cleanRes.success) {
+            logger.warn(`清理 Issue #${issueNumber} 失败: ${cleanRes.error}`);
+          }
+        });
+        return {
+          status: 202,
+          message: `已触发 Issue #${issueNumber} 关闭处理`,
         };
       }
 
@@ -515,6 +550,34 @@ async function handleEvent(
         return { status: 200, message: "PR 已合并但未关联 issue" };
       }
 
+      if (action === "closed" && !payload.pull_request?.merged) {
+        const body = payload.pull_request?.body || "";
+        const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
+        if (issueMatch) {
+          const linkedIssue = Number(issueMatch[1]);
+          logger.info(`PR #${prNumber} 被关闭但未合并，处理 Issue #${linkedIssue}...`);
+          fireAndForget(async () => {
+            const session = new SessionManager(owner, repo, linkedIssue);
+            const statusRes = session.readStatus();
+            if (!statusRes.success || !statusRes.data) return;
+
+            const { lifecycle } = statusRes.data;
+            if (lifecycle === LIFECYCLE.COMPLETED || lifecycle === LIFECYCLE.FAILED) return;
+
+            await session.transition({
+              type: EVENT.PR_REJECTED,
+              message: `PR #${prNumber} 被关闭但未合并`,
+            });
+            await syncLifecycleLabel(owner, repo, linkedIssue, LIFECYCLE.FAILED);
+          });
+          return {
+            status: 202,
+            message: `PR #${prNumber} 被拒绝，已触发 Issue #${linkedIssue} 状态更新`,
+          };
+        }
+        return { status: 200, message: "PR 被关闭但未关联 issue" };
+      }
+
       return { status: 200, message: `忽略 pull_request.${action} 事件` };
     }
 
@@ -719,6 +782,80 @@ async function main() {
             });
           }
         }
+
+        // 兜底同步：对 await_merge 状态的 session 检查 GitHub 实际状态
+        const now = Date.now();
+        if (now - lastFallbackSyncTime >= FALLBACK_SYNC_INTERVAL_MS) {
+          lastFallbackSyncTime = now;
+          const staleAwaitMerge = sessions.filter(
+            (s) =>
+              s.lifecycle === LIFECYCLE.WAITING_EXTERNAL &&
+              s.step === STEP.AWAIT_MERGE,
+          );
+          if (staleAwaitMerge.length > 0) {
+            fireAndForget(async () => {
+              for (const s of staleAwaitMerge) {
+                try {
+                  const clientRes = await get_gh_client(s.owner, s.repo);
+                  if (!clientRes.success) continue;
+                  const client = clientRes.data;
+
+                  const prNumber = s.context?.prNumber;
+                  if (prNumber) {
+                    const prRes = await client.getPullRequest(prNumber);
+                    if (!prRes.success) continue;
+                    const pr = prRes.data;
+
+                    const session = new SessionManager(s.owner, s.repo, s.issueNumber);
+                    if (pr.merged) {
+                      logger.info(`[兜底同步] PR #${prNumber} 已合并，同步 Issue #${s.issueNumber} 状态`);
+                      await session.transition({ type: EVENT.PR_MERGED });
+                      await syncLifecycleLabel(s.owner, s.repo, s.issueNumber, LIFECYCLE.COMPLETED);
+                      const cleanRes = await cleanupIssue(
+                        String(s.issueNumber),
+                        { reason: "fallback-sync", silent: true },
+                        s.owner,
+                        s.repo,
+                      );
+                      if (!cleanRes.success) {
+                        logger.warn(`[兜底同步] 清理 Issue #${s.issueNumber} 失败: ${cleanRes.error}`);
+                      }
+                    } else if (pr.state === "closed") {
+                      logger.info(`[兜底同步] PR #${prNumber} 已关闭未合并，同步 Issue #${s.issueNumber} 状态`);
+                      await session.transition({
+                        type: EVENT.PR_REJECTED,
+                        message: `PR #${prNumber} 被关闭但未合并（兜底同步）`,
+                      });
+                      await syncLifecycleLabel(s.owner, s.repo, s.issueNumber, LIFECYCLE.FAILED);
+                    }
+                    continue;
+                  }
+
+                  const issueRes = await client.getIssue(s.issueNumber);
+                  if (!issueRes.success) continue;
+                  if (issueRes.data.state === "closed") {
+                    logger.info(`[兜底同步] Issue #${s.issueNumber} 已关闭，同步状态`);
+                    const session = new SessionManager(s.owner, s.repo, s.issueNumber);
+                    await session.transition({ type: EVENT.ISSUE_CLOSED, message: "Issue 已关闭（兜底同步）" });
+                    await syncLifecycleLabel(s.owner, s.repo, s.issueNumber, LIFECYCLE.COMPLETED);
+                    const cleanRes = await cleanupIssue(
+                      String(s.issueNumber),
+                      { reason: "fallback-sync", silent: true },
+                      s.owner,
+                      s.repo,
+                    );
+                    if (!cleanRes.success) {
+                      logger.warn(`[兜底同步] 清理 Issue #${s.issueNumber} 失败: ${cleanRes.error}`);
+                    }
+                  }
+                } catch (err: any) {
+                  logger.warn(`[兜底同步] Issue #${s.issueNumber} 同步异常: ${err.message}`);
+                }
+              }
+            });
+          }
+        }
+
         return new Response(JSON.stringify(sessions), {
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- 状态机新增 `ISSUE_CLOSED` 和 `PR_REJECTED` 事件类型，分别处理 Issue 关闭和 PR 被拒绝的状态转换
- Webhook 补全 `issues.closed` 事件处理：查找关联 session 并触发状态转换 + 资源清理
- Webhook 补全 `pull_request.closed(merged=false)` 处理：通过 PR body 关联 Issue 并触发 `PR_REJECTED` 状态转换
- Dashboard `/api/sessions` 端点增加兜底同步机制：每 60 秒检查 `await_merge` 状态的 session，通过 GitHub API 验证 PR/Issue 实际状态并自动补偿

## Test plan

- [x] 状态机单元测试：验证 `ISSUE_CLOSED` 转换到 completed/done/archive_result
- [x] 状态机单元测试：验证 `PR_REJECTED` 转换到 failed 并携带 error 信息
- [x] 状态机单元测试：验证自定义消息和默认消息
- [ ] 手动测试：创建 PR 并合并 → 确认 session 转为 completed
- [ ] 手动测试：关闭 Issue → 确认 session 转为 completed
- [ ] 手动测试：关闭 PR 不合并 → 确认 session 转为 failed
- [ ] 手动测试：停止 webhook server，合并 PR，重启后访问 dashboard → 确认兜底同步生效

fixes: #67