### PR TITLE
fix(cleanup): 保留 session 记录，cleanup 仅清理本地资源

### DIFF
--- a/bin/cleanup-utils.ts
+++ b/bin/cleanup-utils.ts
@@ -13,7 +13,7 @@ import { config } from "./config";
 import fs from "fs";
 import { SessionPathManager } from "./session-paths";
 import { SessionManager } from "./session-manager";
-import { deleteSession, readSession } from "./db";
+import { readSession } from "./db";
 import { isActiveSessionStatus } from "./session-state-machine";
 
 export interface CleanupOptions {
@@ -151,12 +151,6 @@ export async function cleanupIssue(
   // 删除本地分支
   await cleanupBranch(branchName, options.silent, session, repoPath);
 
-  const deleteRes = deleteSession(owner, repo, Number(issueNumber));
-  if (!deleteRes.success) {
-    return failure(deleteRes.error);
-  }
-  info(`会话记录已删除: ${owner}/${repo}#${issueNumber}`, options.silent);
-
   session.logEvent("cleanup-completed", { issueNumber, reason, branchName });
   return success(undefined);
 }
@@ -217,12 +211,6 @@ export async function cleanupIssueAssets(
       return failure(`删除本地数据目录失败: ${e.message}`);
     }
   }
-
-  const deleteRes = deleteSession(owner, repo, issueNumberNum);
-  if (!deleteRes.success) {
-    return failure(deleteRes.error);
-  }
-  info(`会话记录已删除: ${owner}/${repo}#${issueNumber}`, options.silent);
 
   return success(undefined);
 }


### PR DESCRIPTION
## Summary

- cleanup 流程不再删除 SQLite 中的 session 记录，仅清理本地资源（worktree、分支、文件目录）
- 移除 `cleanupIssue()` 和 `cleanupIssueAssets()` 中的 `deleteSession()` 调用
- Dashboard 在 Issue 关闭后仍可展示已完成的 session 历史

## Changes

- `bin/cleanup-utils.ts`: 移除 `cleanupIssue()` 中 L151-155 的 `deleteSession()` 调用及错误处理
- `bin/cleanup-utils.ts`: 移除 `cleanupIssueAssets()` 中 L217 附近的 `deleteSession()` 调用及错误处理
- `deleteSession()` 函数定义保留在 `db.ts` 中，作为基础 CRUD 操作备用

## Test Plan

- [x] `vitest run` 全部 127 个测试通过
- [ ] 验证 `along cleanup <N>` 执行后 Dashboard 仍显示 session 记录
- [ ] 验证 webhook issue-closed 事件后 Dashboard 条目状态为 completed 且可见

fixes: #69