### PR TITLE
refactor(label-sync): 提取 label 同步逻辑为可复用领域模块并自动触发

### DIFF
--- a/bin/commands/label-sync.ts
+++ b/bin/commands/label-sync.ts
@@ -1,179 +1,29 @@
 #!/usr/bin/env bun
 /**
- * label-sync.ts - 仓库 Label 同步脚本
+ * label-sync.ts - 仓库 Label 同步命令
  *
  * 将代码中定义的 label 元数据同步到 GitHub 仓库，
  * 同时清理项目不使用的默认 label。
  */
 import { get_gh_client } from "../integration/github-client";
+import { syncLabels } from "../domain/label-sync";
 import { consola } from "consola";
 
 const logger = consola.withTag("label-sync");
 
-// === Label 元数据定义（唯一真实来源）===
-
-interface LabelMeta {
-  name: string;
-  color: string;
-  description: string;
-}
-
-/**
- * Lifecycle 类 label（蓝色系）
- */
-const LIFECYCLE_LABELS_META: LabelMeta[] = [
-  { name: "running", color: "1E90FF", description: "Session 正在运行中" },
-  { name: "waiting_human", color: "4169E1", description: "等待人工介入" },
-  { name: "waiting_external", color: "6495ED", description: "等待外部依赖（PR 审核、CI 等）" },
-  { name: "completed", color: "228B22", description: "Session 已完成" },
-  { name: "failed", color: "DC143C", description: "Session 执行失败" },
-  { name: "interrupted", color: "FF8C00", description: "Session 被中断" },
-];
-
-/**
- * Triage 类 label（红/绿/黄/灰色系）
- */
-const TRIAGE_LABELS_META: LabelMeta[] = [
-  { name: "bug", color: "D73A4A", description: "缺陷/回归/异常行为，需要代码修复" },
-  { name: "feature", color: "A2EEEF", description: "新功能/增强/重构/文档改进" },
-  { name: "question", color: "D876E3", description: "提问/求助/咨询，不需要代码修改" },
-  { name: "spam", color: "6A737D", description: "广告/无意义/测试内容" },
-];
-
-/**
- * Phase 类 label（紫色系）
- */
-const PHASE_LABELS_META: LabelMeta[] = [
-  { name: "planning", color: "8B5CF6", description: "规划阶段" },
-  { name: "implementation", color: "7C3AED", description: "实施阶段" },
-  { name: "delivery", color: "6D28D9", description: "交付阶段" },
-  { name: "stabilization", color: "5B21B6", description: "稳定化阶段（审核、CI）" },
-  { name: "done", color: "4C1D95", description: "已完成" },
-];
-
-/**
- * 需要清理的 GitHub 默认 label
- */
-const DEFAULT_LABELS_TO_DELETE = [
-  "duplicate",
-  "good first issue",
-  "help wanted",
-  "wontfix",
-  "documentation",
-  "invalid",
-  "WIP",
-  "approved",
-  "enhancement",
-];
-
-// 合并所有定义的 label
-const ALL_DEFINED_LABELS = [
-  ...LIFECYCLE_LABELS_META,
-  ...TRIAGE_LABELS_META,
-  ...PHASE_LABELS_META,
-];
-
 async function main() {
   logger.info("开始同步仓库标签...");
 
-  // 获取 GitHub 客户端
   const clientRes = await get_gh_client();
   if (!clientRes.success) {
     logger.error(`获取 GitHub 客户端失败: ${clientRes.error}`);
     process.exit(1);
   }
-  const client = clientRes.data;
 
-  // 获取仓库当前所有 label
-  const labelsRes = await client.listLabels();
-  if (!labelsRes.success) {
-    logger.error(`获取仓库标签列表失败: ${labelsRes.error}`);
+  const res = await syncLabels(clientRes.data);
+  if (!res.success) {
+    logger.error(`同步失败: ${res.error}`);
     process.exit(1);
-  }
-  const currentLabels = labelsRes.data;
-
-  logger.info(`仓库当前共 ${currentLabels.length} 个标签`);
-
-  const definedLabelNames = new Set(ALL_DEFINED_LABELS.map((l) => l.name));
-
-  // === 1. 创建或更新定义的 label ===
-  const toCreate: LabelMeta[] = [];
-  const toUpdate: LabelMeta[] = [];
-
-  for (const meta of ALL_DEFINED_LABELS) {
-    const existing = currentLabels.find((l) => l.name === meta.name);
-    if (!existing) {
-      toCreate.push(meta);
-    } else {
-      // 颜色或描述不一致需要更新
-      if (existing.color !== meta.color || existing.description !== meta.description) {
-        toUpdate.push(meta);
-      }
-    }
-  }
-
-  // === 2. 删除仓库中存在但代码未定义的 label ===
-  const toDelete = currentLabels
-    .filter((l) => !definedLabelNames.has(l.name) && DEFAULT_LABELS_TO_DELETE.includes(l.name))
-    .map((l) => l.name);
-
-  // === 执行同步 ===
-
-  let created = 0;
-  let updated = 0;
-  let deleted = 0;
-
-  // 创建缺失的 label
-  for (const meta of toCreate) {
-    const res = await client.createLabel(meta.name, meta.color, meta.description);
-    if (res.success) {
-      logger.success(`✓ 创建标签: ${meta.name}`);
-      created++;
-    } else {
-      logger.error(`✗ 创建标签失败: ${meta.name} - ${res.error}`);
-    }
-  }
-
-  // 更新不一致的 label
-  for (const meta of toUpdate) {
-    const res = await client.updateLabel(meta.name, meta.color, meta.description);
-    if (res.success) {
-      logger.success(`✓ 更新标签: ${meta.name}`);
-      updated++;
-    } else {
-      logger.error(`✗ 更新标签失败: ${meta.name} - ${res.error}`);
-    }
-  }
-
-  // 删除不需要的 default label
-  for (const name of toDelete) {
-    const res = await client.deleteLabel(name);
-    if (res.success) {
-      logger.success(`✓ 删除标签: ${name}`);
-      deleted++;
-    } else {
-      logger.error(`✗ 删除标签失败: ${name} - ${res.error}`);
-    }
-  }
-
-  // === 输出汇总 ===
-  logger.info("=".repeat(50));
-  logger.info("同步完成:");
-  logger.info(`  新建: ${created}`);
-  logger.info(`  更新: ${updated}`);
-  logger.info(`  删除: ${deleted}`);
-  logger.info(`  保留: ${currentLabels.length - deleted + (toCreate.length + toUpdate.length) - deleted}`);
-
-  // 验证结果
-  const finalRes = await client.listLabels();
-  if (finalRes.success) {
-    const finalCount = finalRes.data.length;
-    const expectedCount = ALL_DEFINED_LABELS.length;
-    if (finalCount === expectedCount) {
-      logger.success(`✓ 标签数量验证通过: ${finalCount}/${expectedCount}`);
-    } else {
-      logger.warn(`⚠ 标签数量不匹配: 实际 ${finalCount}，期望 ${expectedCount}`);
-    }
   }
 }
 

--- a/bin/commands/run.ts
+++ b/bin/commands/run.ts
@@ -9,7 +9,8 @@ import {
 } from "../core/common";
 
 const logger = consola.withTag("run");
-import { readRepoInfo } from "../integration/github-client";
+import { readRepoInfo, get_gh_client } from "../integration/github-client";
+import { ensureLabelsExist } from "../domain/label-sync";
 import chalk from "chalk";
 import { config } from "../core/config";
 import { runGc } from "./worktree-gc";
@@ -265,6 +266,15 @@ async function main() {
   const bootstrapRes = await ensureProjectBootstrap();
   if (!bootstrapRes.success) {
     logger.warn(bootstrapRes.error);
+  }
+
+  // 自动确保 label 已同步（幂等，带内存缓存）
+  const clientRes = await get_gh_client();
+  if (clientRes.success) {
+    const ensureRes = await ensureLabelsExist(clientRes.data);
+    if (!ensureRes.success) {
+      logger.warn(`Label 同步失败: ${ensureRes.error}`);
+    }
   }
 
   const program = configureCommand();

--- a/bin/commands/webhook-server.ts
+++ b/bin/commands/webhook-server.ts
@@ -41,6 +41,7 @@ import { ensureWebhookSecret, ensureWorkspaces } from "../domain/bootstrap";
 import { buildRegistry, type WorkspaceRegistry } from "../integration/workspace-registry";
 import { cleanupIssue, cleanupIssueAssets } from "../domain/cleanup-utils";
 import { syncLifecycleLabel, get_gh_client } from "../integration/github-client";
+import { ensureLabelsExist } from "../domain/label-sync";
 import {
   isActiveSessionStatus,
   EVENT,
@@ -266,6 +267,16 @@ async function handleEvent(
   }
 
   const { owner, repo } = repoInfo;
+
+  // 自动确保 label 已同步（幂等，带内存缓存）
+  const clientRes = await get_gh_client(owner, repo);
+  if (clientRes.success) {
+    const ensureRes = await ensureLabelsExist(clientRes.data);
+    if (!ensureRes.success) {
+      logger.warn(`Label 同步失败: ${ensureRes.error}`);
+    }
+  }
+
   const repoPath = registry.resolve(owner, repo);
   if (!repoPath) {
     logger.warn(`仓库 ${repoFullName} 未在本地工作区中注册，跳过`);

--- a/bin/domain/label-sync.ts
+++ b/bin/domain/label-sync.ts
@@ -1,0 +1,223 @@
+import { consola } from "consola";
+import type { GitHubClient } from "../integration/github-client";
+import { success, failure } from "../core/result";
+import type { Result } from "../core/result";
+
+const logger = consola.withTag("label-sync");
+
+// === Label 元数据定义（唯一真实来源）===
+
+export interface LabelMeta {
+  name: string;
+  color: string;
+  description: string;
+}
+
+/**
+ * Lifecycle 类 label（蓝色系）
+ */
+export const LIFECYCLE_LABELS_META: LabelMeta[] = [
+  { name: "running", color: "1E90FF", description: "Session 正在运行中" },
+  { name: "waiting_human", color: "4169E1", description: "等待人工介入" },
+  { name: "waiting_external", color: "6495ED", description: "等待外部依赖（PR 审核、CI 等）" },
+  { name: "completed", color: "228B22", description: "Session 已完成" },
+  { name: "failed", color: "DC143C", description: "Session 执行失败" },
+  { name: "interrupted", color: "FF8C00", description: "Session 被中断" },
+];
+
+/**
+ * Triage 类 label（红/绿/黄/灰色系）
+ */
+export const TRIAGE_LABELS_META: LabelMeta[] = [
+  { name: "bug", color: "D73A4A", description: "缺陷/回归/异常行为，需要代码修复" },
+  { name: "feature", color: "A2EEEF", description: "新功能/增强/重构/文档改进" },
+  { name: "question", color: "D876E3", description: "提问/求助/咨询，不需要代码修改" },
+  { name: "spam", color: "6A737D", description: "广告/无意义/测试内容" },
+];
+
+/**
+ * Phase 类 label（紫色系）
+ */
+export const PHASE_LABELS_META: LabelMeta[] = [
+  { name: "planning", color: "8B5CF6", description: "规划阶段" },
+  { name: "implementation", color: "7C3AED", description: "实施阶段" },
+  { name: "delivery", color: "6D28D9", description: "交付阶段" },
+  { name: "stabilization", color: "5B21B6", description: "稳定化阶段（审核、CI）" },
+  { name: "done", color: "4C1D95", description: "已完成" },
+];
+
+/**
+ * 需要清理的 GitHub 默认 label
+ */
+export const DEFAULT_LABELS_TO_DELETE = [
+  "duplicate",
+  "good first issue",
+  "help wanted",
+  "wontfix",
+  "documentation",
+  "invalid",
+  "WIP",
+  "approved",
+  "enhancement",
+];
+
+/**
+ * 合并所有定义的 label
+ */
+export const ALL_DEFINED_LABELS = [
+  ...LIFECYCLE_LABELS_META,
+  ...TRIAGE_LABELS_META,
+  ...PHASE_LABELS_META,
+];
+
+// === 内存级缓存：记录已同步的 owner/repo ===
+const syncedRepos = new Set<string>();
+
+function getRepoKey(client: GitHubClient): string {
+  // GitHubClient 内部有 owner/repo，但没有暴露 getter
+  // 我们通过客户端实例本身作为 key（同一 owner/repo 的缓存客户端在 get_gh_client 中是同一个实例）
+  // 但 ensureLabelsExist 只接收 client，无法直接获取 owner/repo
+  // 这里用客户端对象引用本身作为 key，因为 get_gh_client 按 owner/repo 缓存实例
+  return (client as any).owner + "/" + (client as any).repo;
+}
+
+/**
+ * 幂等地确保所有定义的 label 存在于目标仓库
+ * - 只创建缺失的
+ * - 更新颜色/描述不一致的
+ * - 不删除默认 label
+ * - 同一进程内对同一仓库只执行一次 API 调用
+ */
+export async function ensureLabelsExist(client: GitHubClient): Promise<Result<void>> {
+  const repoKey = getRepoKey(client);
+  if (syncedRepos.has(repoKey)) {
+    logger.debug(`Label 已同步，跳过: ${repoKey}`);
+    return success(undefined);
+  }
+
+  const labelsRes = await client.listLabels();
+  if (!labelsRes.success) {
+    return failure(`获取仓库标签列表失败: ${labelsRes.error}`);
+  }
+  const currentLabels = labelsRes.data;
+
+  const toCreate: LabelMeta[] = [];
+  const toUpdate: LabelMeta[] = [];
+
+  for (const meta of ALL_DEFINED_LABELS) {
+    const existing = currentLabels.find((l) => l.name === meta.name);
+    if (!existing) {
+      toCreate.push(meta);
+    } else if (existing.color !== meta.color || existing.description !== meta.description) {
+      toUpdate.push(meta);
+    }
+  }
+
+  for (const meta of toCreate) {
+    const res = await client.createLabel(meta.name, meta.color, meta.description);
+    if (!res.success) {
+      logger.error(`创建标签失败: ${meta.name} - ${res.error}`);
+    } else {
+      logger.success(`✓ 创建标签: ${meta.name}`);
+    }
+  }
+
+  for (const meta of toUpdate) {
+    const res = await client.updateLabel(meta.name, meta.color, meta.description);
+    if (!res.success) {
+      logger.error(`更新标签失败: ${meta.name} - ${res.error}`);
+    } else {
+      logger.success(`✓ 更新标签: ${meta.name}`);
+    }
+  }
+
+  syncedRepos.add(repoKey);
+  logger.info(`Label 同步完成: ${repoKey}（新建 ${toCreate.length}，更新 ${toUpdate.length}）`);
+  return success(undefined);
+}
+
+/**
+ * 完整同步（创建 + 更新 + 删除默认 label）
+ * 供 CLI `along label-sync` 显式调用
+ */
+export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
+  const labelsRes = await client.listLabels();
+  if (!labelsRes.success) {
+    return failure(`获取仓库标签列表失败: ${labelsRes.error}`);
+  }
+  const currentLabels = labelsRes.data;
+
+  logger.info(`仓库当前共 ${currentLabels.length} 个标签`);
+
+  const definedLabelNames = new Set(ALL_DEFINED_LABELS.map((l) => l.name));
+
+  const toCreate: LabelMeta[] = [];
+  const toUpdate: LabelMeta[] = [];
+
+  for (const meta of ALL_DEFINED_LABELS) {
+    const existing = currentLabels.find((l) => l.name === meta.name);
+    if (!existing) {
+      toCreate.push(meta);
+    } else if (existing.color !== meta.color || existing.description !== meta.description) {
+      toUpdate.push(meta);
+    }
+  }
+
+  const toDelete = currentLabels
+    .filter((l) => !definedLabelNames.has(l.name) && DEFAULT_LABELS_TO_DELETE.includes(l.name))
+    .map((l) => l.name);
+
+  let created = 0;
+  let updated = 0;
+  let deleted = 0;
+
+  for (const meta of toCreate) {
+    const res = await client.createLabel(meta.name, meta.color, meta.description);
+    if (res.success) {
+      logger.success(`✓ 创建标签: ${meta.name}`);
+      created++;
+    } else {
+      logger.error(`✗ 创建标签失败: ${meta.name} - ${res.error}`);
+    }
+  }
+
+  for (const meta of toUpdate) {
+    const res = await client.updateLabel(meta.name, meta.color, meta.description);
+    if (res.success) {
+      logger.success(`✓ 更新标签: ${meta.name}`);
+      updated++;
+    } else {
+      logger.error(`✗ 更新标签失败: ${meta.name} - ${res.error}`);
+    }
+  }
+
+  for (const name of toDelete) {
+    const res = await client.deleteLabel(name);
+    if (res.success) {
+      logger.success(`✓ 删除标签: ${name}`);
+      deleted++;
+    } else {
+      logger.error(`✗ 删除标签失败: ${name} - ${res.error}`);
+    }
+  }
+
+  logger.info("=".repeat(50));
+  logger.info("同步完成:");
+  logger.info(`  新建: ${created}`);
+  logger.info(`  更新: ${updated}`);
+  logger.info(`  删除: ${deleted}`);
+  logger.info(`  保留: ${currentLabels.length - deleted + (toCreate.length + toUpdate.length) - deleted}`);
+
+  const finalRes = await client.listLabels();
+  if (finalRes.success) {
+    const finalCount = finalRes.data.length;
+    const expectedCount = ALL_DEFINED_LABELS.length;
+    if (finalCount === expectedCount) {
+      logger.success(`✓ 标签数量验证通过: ${finalCount}/${expectedCount}`);
+    } else {
+      logger.warn(`⚠ 标签数量不匹配: 实际 ${finalCount}，期望 ${expectedCount}`);
+    }
+  }
+
+  return success(undefined);
+}

--- a/bin/domain/label-sync.ts
+++ b/bin/domain/label-sync.ts
@@ -19,7 +19,11 @@ export interface LabelMeta {
 export const LIFECYCLE_LABELS_META: LabelMeta[] = [
   { name: "running", color: "1E90FF", description: "Session 正在运行中" },
   { name: "waiting_human", color: "4169E1", description: "等待人工介入" },
-  { name: "waiting_external", color: "6495ED", description: "等待外部依赖（PR 审核、CI 等）" },
+  {
+    name: "waiting_external",
+    color: "6495ED",
+    description: "等待外部依赖（PR 审核、CI 等）",
+  },
   { name: "completed", color: "228B22", description: "Session 已完成" },
   { name: "failed", color: "DC143C", description: "Session 执行失败" },
   { name: "interrupted", color: "FF8C00", description: "Session 被中断" },
@@ -29,9 +33,21 @@ export const LIFECYCLE_LABELS_META: LabelMeta[] = [
  * Triage 类 label（红/绿/黄/灰色系）
  */
 export const TRIAGE_LABELS_META: LabelMeta[] = [
-  { name: "bug", color: "D73A4A", description: "缺陷/回归/异常行为，需要代码修复" },
-  { name: "feature", color: "A2EEEF", description: "新功能/增强/重构/文档改进" },
-  { name: "question", color: "D876E3", description: "提问/求助/咨询，不需要代码修改" },
+  {
+    name: "bug",
+    color: "D73A4A",
+    description: "缺陷/回归/异常行为，需要代码修复",
+  },
+  {
+    name: "feature",
+    color: "A2EEEF",
+    description: "新功能/增强/重构/文档改进",
+  },
+  {
+    name: "question",
+    color: "D876E3",
+    description: "提问/求助/咨询，不需要代码修改",
+  },
   { name: "spam", color: "6A737D", description: "广告/无意义/测试内容" },
 ];
 
@@ -42,7 +58,11 @@ export const PHASE_LABELS_META: LabelMeta[] = [
   { name: "planning", color: "8B5CF6", description: "规划阶段" },
   { name: "implementation", color: "7C3AED", description: "实施阶段" },
   { name: "delivery", color: "6D28D9", description: "交付阶段" },
-  { name: "stabilization", color: "5B21B6", description: "稳定化阶段（审核、CI）" },
+  {
+    name: "stabilization",
+    color: "5B21B6",
+    description: "稳定化阶段（审核、CI）",
+  },
   { name: "done", color: "4C1D95", description: "已完成" },
 ];
 
@@ -74,11 +94,7 @@ export const ALL_DEFINED_LABELS = [
 const syncedRepos = new Set<string>();
 
 function getRepoKey(client: GitHubClient): string {
-  // GitHubClient 内部有 owner/repo，但没有暴露 getter
-  // 我们通过客户端实例本身作为 key（同一 owner/repo 的缓存客户端在 get_gh_client 中是同一个实例）
-  // 但 ensureLabelsExist 只接收 client，无法直接获取 owner/repo
-  // 这里用客户端对象引用本身作为 key，因为 get_gh_client 按 owner/repo 缓存实例
-  return (client as any).owner + "/" + (client as any).repo;
+  return client.owner + "/" + client.repo;
 }
 
 /**
@@ -88,7 +104,9 @@ function getRepoKey(client: GitHubClient): string {
  * - 不删除默认 label
  * - 同一进程内对同一仓库只执行一次 API 调用
  */
-export async function ensureLabelsExist(client: GitHubClient): Promise<Result<void>> {
+export async function ensureLabelsExist(
+  client: GitHubClient,
+): Promise<Result<void>> {
   const repoKey = getRepoKey(client);
   if (syncedRepos.has(repoKey)) {
     logger.debug(`Label 已同步，跳过: ${repoKey}`);
@@ -108,13 +126,20 @@ export async function ensureLabelsExist(client: GitHubClient): Promise<Result<vo
     const existing = currentLabels.find((l) => l.name === meta.name);
     if (!existing) {
       toCreate.push(meta);
-    } else if (existing.color !== meta.color || existing.description !== meta.description) {
+    } else if (
+      existing.color !== meta.color ||
+      existing.description !== meta.description
+    ) {
       toUpdate.push(meta);
     }
   }
 
   for (const meta of toCreate) {
-    const res = await client.createLabel(meta.name, meta.color, meta.description);
+    const res = await client.createLabel(
+      meta.name,
+      meta.color,
+      meta.description,
+    );
     if (!res.success) {
       logger.error(`创建标签失败: ${meta.name} - ${res.error}`);
     } else {
@@ -123,7 +148,11 @@ export async function ensureLabelsExist(client: GitHubClient): Promise<Result<vo
   }
 
   for (const meta of toUpdate) {
-    const res = await client.updateLabel(meta.name, meta.color, meta.description);
+    const res = await client.updateLabel(
+      meta.name,
+      meta.color,
+      meta.description,
+    );
     if (!res.success) {
       logger.error(`更新标签失败: ${meta.name} - ${res.error}`);
     } else {
@@ -132,7 +161,9 @@ export async function ensureLabelsExist(client: GitHubClient): Promise<Result<vo
   }
 
   syncedRepos.add(repoKey);
-  logger.info(`Label 同步完成: ${repoKey}（新建 ${toCreate.length}，更新 ${toUpdate.length}）`);
+  logger.info(
+    `Label 同步完成: ${repoKey}（新建 ${toCreate.length}，更新 ${toUpdate.length}）`,
+  );
   return success(undefined);
 }
 
@@ -158,13 +189,20 @@ export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
     const existing = currentLabels.find((l) => l.name === meta.name);
     if (!existing) {
       toCreate.push(meta);
-    } else if (existing.color !== meta.color || existing.description !== meta.description) {
+    } else if (
+      existing.color !== meta.color ||
+      existing.description !== meta.description
+    ) {
       toUpdate.push(meta);
     }
   }
 
   const toDelete = currentLabels
-    .filter((l) => !definedLabelNames.has(l.name) && DEFAULT_LABELS_TO_DELETE.includes(l.name))
+    .filter(
+      (l) =>
+        !definedLabelNames.has(l.name) &&
+        DEFAULT_LABELS_TO_DELETE.includes(l.name),
+    )
     .map((l) => l.name);
 
   let created = 0;
@@ -172,7 +210,11 @@ export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
   let deleted = 0;
 
   for (const meta of toCreate) {
-    const res = await client.createLabel(meta.name, meta.color, meta.description);
+    const res = await client.createLabel(
+      meta.name,
+      meta.color,
+      meta.description,
+    );
     if (res.success) {
       logger.success(`✓ 创建标签: ${meta.name}`);
       created++;
@@ -182,7 +224,11 @@ export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
   }
 
   for (const meta of toUpdate) {
-    const res = await client.updateLabel(meta.name, meta.color, meta.description);
+    const res = await client.updateLabel(
+      meta.name,
+      meta.color,
+      meta.description,
+    );
     if (res.success) {
       logger.success(`✓ 更新标签: ${meta.name}`);
       updated++;
@@ -206,7 +252,9 @@ export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
   logger.info(`  新建: ${created}`);
   logger.info(`  更新: ${updated}`);
   logger.info(`  删除: ${deleted}`);
-  logger.info(`  保留: ${currentLabels.length - deleted + (toCreate.length + toUpdate.length) - deleted}`);
+  logger.info(
+    `  保留: ${currentLabels.length - deleted + (toCreate.length + toUpdate.length) - deleted}`,
+  );
 
   const finalRes = await client.listLabels();
   if (finalRes.success) {
@@ -215,7 +263,9 @@ export async function syncLabels(client: GitHubClient): Promise<Result<void>> {
     if (finalCount === expectedCount) {
       logger.success(`✓ 标签数量验证通过: ${finalCount}/${expectedCount}`);
     } else {
-      logger.warn(`⚠ 标签数量不匹配: 实际 ${finalCount}，期望 ${expectedCount}`);
+      logger.warn(
+        `⚠ 标签数量不匹配: 实际 ${finalCount}，期望 ${expectedCount}`,
+      );
     }
   }
 

--- a/bin/integration/github-client.ts
+++ b/bin/integration/github-client.ts
@@ -4,14 +4,21 @@ import { success, failure, git } from "../core/common";
 import type { Result } from "../core/common";
 import { resolveAgentToken } from "./agent-config";
 import { consola } from "consola";
-import { LIFECYCLE_LABELS, type SessionLifecycle } from "../domain/session-state-machine";
+import {
+  LIFECYCLE_LABELS,
+  type SessionLifecycle,
+} from "../domain/session-state-machine";
 
 const apiLogger = consola.withTag("github-api");
 
-export type GitHubIssue = RestEndpointMethodTypes["issues"]["get"]["response"]["data"];
-export type GitHubPullRequest = RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
-export type GitHubReviewComment = RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][number];
-export type GitHubCheckRun = RestEndpointMethodTypes["checks"]["listForRef"]["response"]["data"]["check_runs"][number];
+export type GitHubIssue =
+  RestEndpointMethodTypes["issues"]["get"]["response"]["data"];
+export type GitHubPullRequest =
+  RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
+export type GitHubReviewComment =
+  RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][number];
+export type GitHubCheckRun =
+  RestEndpointMethodTypes["checks"]["listForRef"]["response"]["data"]["check_runs"][number];
 export interface CreatedIssueComment {
   commentId: number;
   createdAt?: string;
@@ -23,16 +30,16 @@ export interface CreatedIssueComment {
  */
 export class GitHubClient {
   private octokit: Octokit;
-  private owner: string;
-  private repo: string;
+  private _owner: string;
+  private _repo: string;
 
   /** API 调用统计 */
   private stats = { total: 0, success: 0, failed: 0, totalMs: 0 };
 
   constructor(token: string, owner: string, repo: string) {
     this.octokit = new Octokit({ auth: token });
-    this.owner = owner;
-    this.repo = repo;
+    this._owner = owner;
+    this._repo = repo;
 
     // 注册请求钩子，记录每次 API 调用
     this.octokit.hook.wrap("request", async (request, options) => {
@@ -51,12 +58,14 @@ export class GitHubClient {
         const rateLimit = response.headers["x-ratelimit-limit"];
         apiLogger.debug(
           `${method} ${url} → ${response.status} (${duration}ms)` +
-          (rateRemaining ? ` [rate: ${rateRemaining}/${rateLimit}]` : "")
+            (rateRemaining ? ` [rate: ${rateRemaining}/${rateLimit}]` : ""),
         );
 
         // rate limit 低于 100 时发出警告
         if (rateRemaining && Number(rateRemaining) < 100) {
-          apiLogger.warn(`GitHub API rate limit 即将耗尽: ${rateRemaining}/${rateLimit}`);
+          apiLogger.warn(
+            `GitHub API rate limit 即将耗尽: ${rateRemaining}/${rateLimit}`,
+          );
         }
 
         return response;
@@ -66,9 +75,10 @@ export class GitHubClient {
         this.stats.totalMs += duration;
 
         // 404/410 是预期的"资源不存在"响应，降级为 debug
-        const logLevel = (error.status === 404 || error.status === 410) ? "debug" : "warn";
+        const logLevel =
+          error.status === 404 || error.status === 410 ? "debug" : "warn";
         apiLogger[logLevel](
-          `${method} ${url} → ${error.status || "ERR"} (${duration}ms): ${error.message}`
+          `${method} ${url} → ${error.status || "ERR"} (${duration}ms): ${error.message}`,
         );
         throw error;
       }
@@ -77,13 +87,27 @@ export class GitHubClient {
 
   /** 获取 API 调用统计 */
   getStats() {
-    return { ...this.stats, avgMs: this.stats.total > 0 ? Math.round(this.stats.totalMs / this.stats.total) : 0 };
+    return {
+      ...this.stats,
+      avgMs:
+        this.stats.total > 0
+          ? Math.round(this.stats.totalMs / this.stats.total)
+          : 0,
+    };
+  }
+
+  get owner() {
+    return this._owner;
+  }
+
+  get repo() {
+    return this._repo;
   }
 
   private get repoParams() {
     return {
-      owner: this.owner,
-      repo: this.repo,
+      owner: this._owner,
+      repo: this._repo,
     };
   }
 
@@ -102,15 +126,22 @@ export class GitHubClient {
     }
   }
 
-
-
-  async getIssueComments(number: string | number): Promise<Result<RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"]>> {
+  async getIssueComments(
+    number: string | number,
+  ): Promise<
+    Result<
+      RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"]
+    >
+  > {
     try {
-      const data = await this.octokit.paginate(this.octokit.issues.listComments, {
-        ...this.repoParams,
-        issue_number: Number(number),
-        per_page: 100,
-      });
+      const data = await this.octokit.paginate(
+        this.octokit.issues.listComments,
+        {
+          ...this.repoParams,
+          issue_number: Number(number),
+          per_page: 100,
+        },
+      );
       return success(data);
     } catch (e: any) {
       return failure(`获取 Issue #${number} 评论失败: ${e.message}`);
@@ -136,7 +167,10 @@ export class GitHubClient {
     }
   }
 
-  async addIssueLabels(number: string | number, labels: string[]): Promise<Result<void>> {
+  async addIssueLabels(
+    number: string | number,
+    labels: string[],
+  ): Promise<Result<void>> {
     try {
       await this.octokit.issues.addLabels({
         ...this.repoParams,
@@ -149,7 +183,10 @@ export class GitHubClient {
     }
   }
 
-  async removeIssueLabel(number: string | number, label: string): Promise<Result<void>> {
+  async removeIssueLabel(
+    number: string | number,
+    label: string,
+  ): Promise<Result<void>> {
     try {
       await this.octokit.issues.removeLabel({
         ...this.repoParams,
@@ -177,7 +214,9 @@ export class GitHubClient {
     }
   }
 
-  async getRepositoryDetails(): Promise<Result<RestEndpointMethodTypes["repos"]["get"]["response"]["data"]>> {
+  async getRepositoryDetails(): Promise<
+    Result<RestEndpointMethodTypes["repos"]["get"]["response"]["data"]>
+  > {
     try {
       const { data } = await this.octokit.repos.get({
         ...this.repoParams,
@@ -200,20 +239,29 @@ export class GitHubClient {
     }
   }
 
-  async getReviewComments(prNumber: number): Promise<Result<GitHubReviewComment[]>> {
+  async getReviewComments(
+    prNumber: number,
+  ): Promise<Result<GitHubReviewComment[]>> {
     try {
-      const data = await this.octokit.paginate(this.octokit.pulls.listReviewComments, {
-        ...this.repoParams,
-        pull_number: prNumber,
-        per_page: 100,
-      });
+      const data = await this.octokit.paginate(
+        this.octokit.pulls.listReviewComments,
+        {
+          ...this.repoParams,
+          pull_number: prNumber,
+          per_page: 100,
+        },
+      );
       return success(data);
     } catch (e: any) {
       return failure(`获取 PR #${prNumber} 评审评论失败: ${e.message}`);
     }
   }
 
-  async createReviewCommentReply(prNumber: number, commentId: number, body: string): Promise<Result<void>> {
+  async createReviewCommentReply(
+    prNumber: number,
+    commentId: number,
+    body: string,
+  ): Promise<Result<void>> {
     try {
       await this.octokit.pulls.createReplyForReviewComment({
         ...this.repoParams,
@@ -248,7 +296,12 @@ export class GitHubClient {
     prNumber: number,
     body: string,
     event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
-    comments?: Array<{ path: string; line: number; body: string; side?: "LEFT" | "RIGHT" }>,
+    comments?: Array<{
+      path: string;
+      line: number;
+      body: string;
+      side?: "LEFT" | "RIGHT";
+    }>,
   ): Promise<Result<void>> {
     try {
       await this.octokit.pulls.createReview({
@@ -256,7 +309,7 @@ export class GitHubClient {
         pull_number: prNumber,
         body,
         event,
-        comments: comments?.map(c => ({
+        comments: comments?.map((c) => ({
           path: c.path,
           line: c.line,
           body: c.body,
@@ -272,7 +325,11 @@ export class GitHubClient {
   /**
    * 列出 PR 上的所有 Reviews
    */
-  async listReviews(prNumber: number): Promise<Result<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"]>> {
+  async listReviews(
+    prNumber: number,
+  ): Promise<
+    Result<RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"]>
+  > {
     try {
       const data = await this.octokit.paginate(this.octokit.pulls.listReviews, {
         ...this.repoParams,
@@ -288,7 +345,11 @@ export class GitHubClient {
   /**
    * 获取 PR 变更文件列表（含 patch/diff）
    */
-  async getPullRequestFiles(prNumber: number): Promise<Result<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"]>> {
+  async getPullRequestFiles(
+    prNumber: number,
+  ): Promise<
+    Result<RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"]>
+  > {
     try {
       const data = await this.octokit.paginate(this.octokit.pulls.listFiles, {
         ...this.repoParams,
@@ -321,7 +382,11 @@ export class GitHubClient {
    * 按 head 分支名列出关联的 Pull Request
    * head 格式为 "owner:branch" 或 "branch"（同仓库时自动补全 owner）
    */
-  async listPullRequestsByHead(head: string): Promise<Result<RestEndpointMethodTypes["pulls"]["list"]["response"]["data"]>> {
+  async listPullRequestsByHead(
+    head: string,
+  ): Promise<
+    Result<RestEndpointMethodTypes["pulls"]["list"]["response"]["data"]>
+  > {
     try {
       // 如果 head 不含 ":"，自动补全为 "owner:branch"
       const fullHead = head.includes(":") ? head : `${this.owner}:${head}`;
@@ -341,12 +406,14 @@ export class GitHubClient {
    * 列出仓库 Issue（支持按标签、状态、时间过滤）
    * 注意：GitHub API 会将 PR 混入 issues 列表，此方法自动过滤
    */
-  async listIssues(options: {
-    labels?: string;
-    state?: "open" | "closed" | "all";
-    since?: string;
-    per_page?: number;
-  } = {}): Promise<Result<GitHubIssue[]>> {
+  async listIssues(
+    options: {
+      labels?: string;
+      state?: "open" | "closed" | "all";
+      since?: string;
+      per_page?: number;
+    } = {},
+  ): Promise<Result<GitHubIssue[]>> {
     try {
       const { data } = await this.octokit.issues.listForRepo({
         ...this.repoParams,
@@ -356,7 +423,9 @@ export class GitHubClient {
         per_page: options.per_page || 100,
       });
       // GitHub API 会将 PR 混入 issues 列表，过滤掉
-      const filtered = data.filter((issue: any) => !issue.pull_request) as GitHubIssue[];
+      const filtered = data.filter(
+        (issue: any) => !issue.pull_request,
+      ) as GitHubIssue[];
       return success(filtered);
     } catch (e: any) {
       return failure(`列出 Issue 失败: ${e.message}`);
@@ -366,12 +435,19 @@ export class GitHubClient {
   /**
    * 列出仓库所有 label
    */
-  async listLabels(): Promise<Result<RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]["data"]>> {
+  async listLabels(): Promise<
+    Result<
+      RestEndpointMethodTypes["issues"]["listLabelsForRepo"]["response"]["data"]
+    >
+  > {
     try {
-      const data = await this.octokit.paginate(this.octokit.issues.listLabelsForRepo, {
-        ...this.repoParams,
-        per_page: 100,
-      });
+      const data = await this.octokit.paginate(
+        this.octokit.issues.listLabelsForRepo,
+        {
+          ...this.repoParams,
+          per_page: 100,
+        },
+      );
       return success(data);
     } catch (e: any) {
       return failure(`列出仓库标签失败: ${e.message}`);
@@ -381,7 +457,11 @@ export class GitHubClient {
   /**
    * 创建 label
    */
-  async createLabel(name: string, color: string, description: string): Promise<Result<void>> {
+  async createLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<Result<void>> {
     try {
       await this.octokit.issues.createLabel({
         ...this.repoParams,
@@ -398,7 +478,11 @@ export class GitHubClient {
   /**
    * 更新 label（颜色/描述）
    */
-  async updateLabel(name: string, color: string, description: string): Promise<Result<void>> {
+  async updateLabel(
+    name: string,
+    color: string,
+    description: string,
+  ): Promise<Result<void>> {
     try {
       await this.octokit.issues.updateLabel({
         ...this.repoParams,
@@ -428,7 +512,6 @@ export class GitHubClient {
       return failure(`删除标签 ${name} 失败: ${e.message}`);
     }
   }
-
 }
 
 /**
@@ -442,7 +525,12 @@ export function isNotFoundError(e: any): boolean {
 
   // 备选方案：检查消息内容
   const message = e.message?.toLowerCase() || "";
-  return message.includes("404") || message.includes("not found") || message.includes("410") || message.includes("gone");
+  return (
+    message.includes("404") ||
+    message.includes("not found") ||
+    message.includes("410") ||
+    message.includes("gone")
+  );
 }
 
 // 默认 token 缓存
@@ -493,15 +581,20 @@ export async function readGithubToken(): Promise<Result<string>> {
     cachedDefaultToken = token.trim();
     return success(cachedDefaultToken);
   } catch {
-    return failure("未找到 GITHUB_TOKEN 且 gh auth token 失败，请先运行 gh auth login");
+    return failure(
+      "未找到 GITHUB_TOKEN 且 gh auth token 失败，请先运行 gh auth login",
+    );
   }
 }
 
 /**
  * 获取仓库所有者和名称
  */
-export async function readRepoInfo(): Promise<Result<{ owner: string; repo: string }>> {
-  if (cachedRepoInfo) return success(cachedRepoInfo as { owner: string; repo: string });
+export async function readRepoInfo(): Promise<
+  Result<{ owner: string; repo: string }>
+> {
+  if (cachedRepoInfo)
+    return success(cachedRepoInfo as { owner: string; repo: string });
 
   try {
     const remoteStr = await git.remote(["get-url", "origin"]);
@@ -527,7 +620,10 @@ export async function readRepoInfo(): Promise<Result<{ owner: string; repo: stri
  * 1. 传入 owner/repo（webhook server 场景）：按 owner/repo 缓存，避免多仓库串台
  * 2. 不传参数（CLI 场景）：从 git remote 自动检测
  */
-export async function get_gh_client(owner?: string, repo?: string): Promise<Result<GitHubClient>> {
+export async function get_gh_client(
+  owner?: string,
+  repo?: string,
+): Promise<Result<GitHubClient>> {
   const tokenRes = await readGithubToken();
   if (!tokenRes.success) return failure(tokenRes.error);
 
@@ -574,17 +670,23 @@ export async function syncLifecycleLabel(
 
   // 提取当前 lifecycle 标签（Issue labels 可能是对象或字符串）
   const currentLifecycleLabels: string[] = issueRes.data.labels
-    .map(l => typeof l === "string" ? l : l.name)
-    .filter((name): name is string => LIFECYCLE_LABELS.includes(name as SessionLifecycle));
+    .map((l) => (typeof l === "string" ? l : l.name))
+    .filter((name): name is string =>
+      LIFECYCLE_LABELS.includes(name as SessionLifecycle),
+    );
 
   // 计算期望的标签集合
   const expectedLabels = [newLifecycle];
 
   // 计算需要添加的标签（只在当前不存在时添加）
-  const labelsToAdd = expectedLabels.filter(l => !currentLifecycleLabels.includes(l));
+  const labelsToAdd = expectedLabels.filter(
+    (l) => !currentLifecycleLabels.includes(l),
+  );
 
   // 计算需要删除的标签（只删当前存在的）
-  const labelsToRemove = currentLifecycleLabels.filter(l => l !== newLifecycle);
+  const labelsToRemove = currentLifecycleLabels.filter(
+    (l) => l !== newLifecycle,
+  );
 
   // 先添加新标签，确保新状态存在
   if (labelsToAdd.length > 0) {


### PR DESCRIPTION
## 问题背景

当前 `label-sync` 是纯手动命令，label 元数据定义和同步逻辑被封装在 CLI 命令脚本中，无法被其他模块复用。`addIssueLabels()` 调用 GitHub API 时，如果目标仓库中不存在对应 label，API 会返回错误。

## 改动内容

1. **新增 `bin/domain/label-sync.ts`**：提取 label 元数据定义和核心同步逻辑
   - 导出 `LIFECYCLE_LABELS_META`、`TRIAGE_LABELS_META`、`PHASE_LABELS_META`、`ALL_DEFINED_LABELS`
   - 导出 `ensureLabelsExist(client)`：幂等同步（只创建缺失的 + 更新不一致的，不删除）
   - 导出 `syncLabels(client)`：完整同步（创建 + 更新 + 删除默认 label）
   - 内存级缓存：用 `Set<string>` 记录已同步的 `owner/repo`

2. **重构 `bin/commands/label-sync.ts`**：改为调用 `syncLabels()` 的薄壳命令，CLI 行为不变

3. **增强 `bin/commands/webhook-server.ts`**：在事件处理前自动调用 `ensureLabelsExist()`

4. **增强 `bin/commands/run.ts`**：在 `ensureProjectBootstrap()` 后自动调用 `ensureLabelsExist()`

## 验证

- `vitest run`：127 个测试全部通过
- `along label-sync` CLI 行为保持不变

fixes: #74