### PR TITLE
fix(agent): 引入 AgentExecutionSummary 抽象并修复 Claude SDK 错误检测漏洞

### DIFF
--- a/bin/domain/issue-agent.ts
+++ b/bin/domain/issue-agent.ts
@@ -97,6 +97,13 @@ export function syncPromptsToWorktree(worktreePath: string): Result<void> {
   return success(undefined);
 }
 
+// ─── Agent 执行结果抽象 ─────────────────────────────────────
+
+export interface AgentExecutionSummary {
+  exitCode: number;
+  nativeError?: { message: string; details?: string };
+}
+
 // ─── execAgent ──────────────────────────────────────────────
 
 type WritableTarget = { write(data: string): any };
@@ -171,6 +178,11 @@ function formatSDKMessage(message: SDKMessage): string | null {
     return null;
   }
   if (message.type === "result") {
+    const msgAny = message as any;
+    if (msgAny.is_error === true) {
+      const errors = Array.isArray(msgAny.errors) ? msgAny.errors : ["未知错误"];
+      return `[result] 错误: ${errors.join(", ")} (${message.num_turns} turns)`;
+    }
     if (message.subtype === "success") {
       return `[result] 完成 (${message.num_turns} turns, $${message.total_cost_usd.toFixed(4)})`;
     }
@@ -187,7 +199,7 @@ export async function execAgent(
   logFile?: string,
   sessionManager?: SessionManager,
   conversationFile?: string,
-): Promise<Result<number>> {
+): Promise<Result<AgentExecutionSummary>> {
   const isPlanningSymlink = (() => {
     try {
       return fs.lstatSync(worktreePath).isSymbolicLink();
@@ -221,7 +233,7 @@ async function execClaudeAgent(
   sessionManager?: SessionManager,
   logFile?: string,
   conversationFile?: string,
-): Promise<Result<number>> {
+): Promise<Result<AgentExecutionSummary>> {
   const promptPath = path.join(worktreePath, `.claude/commands/${workflow}.md`);
   if (!fs.existsSync(promptPath)) {
     return failure(`workflow prompt 文件不存在: ${promptPath}`);
@@ -272,6 +284,7 @@ async function execClaudeAgent(
 
   try {
     const conversation = query({ prompt, options });
+    let receivedResult = false;
 
     for await (const message of conversation) {
       if (!sessionId && "session_id" in message) {
@@ -286,29 +299,57 @@ async function execClaudeAgent(
       if (formatted) out.write(formatted + "\n");
 
       if (message.type === "result") {
+        receivedResult = true;
+
         if (sessionId && sessionManager) {
           sessionManager.updateClaudeSessionId(sessionId);
           logger.info(`已捕获 Claude sessionId: ${sessionId}`);
         }
 
-        if (message.subtype !== "success") {
-          logger.warn(`Claude Agent 异常结束: ${message.subtype}`);
-          return success(1);
+        const msgAny = message as any;
+        const isError = msgAny.is_error === true;
+        const hasErrors = Array.isArray(msgAny.errors) && msgAny.errors.length > 0;
+
+        if (isError || hasErrors) {
+          const errorMessage = hasErrors ? msgAny.errors.join(", ") : "Agent 执行出错";
+          logger.error(`Claude Agent SDK 报告错误: ${errorMessage}`);
+          return success({
+            exitCode: 1,
+            nativeError: {
+              message: errorMessage,
+              details: JSON.stringify(message),
+            },
+          });
         }
 
-        return success(0);
+        if (message.subtype !== "success") {
+          logger.warn(`Claude Agent 异常结束: ${message.subtype}`);
+          return success({ exitCode: 1 });
+        }
+
+        return success({ exitCode: 0 });
       }
+    }
+
+    if (!receivedResult) {
+      const errorMessage = "Agent 执行流结束但未收到结果";
+      logger.error(errorMessage);
+      return success({
+        exitCode: 1,
+        nativeError: { message: errorMessage },
+      });
     }
   } catch (error: any) {
     logger.error(`Claude Agent SDK 执行异常: ${error.message}`);
-    return success(1);
+    return success({
+      exitCode: 1,
+      nativeError: { message: error.message, details: error.stack },
+    });
   } finally {
     fileWriter?.flush();
     fileHandle?.end();
     convHandle?.end();
   }
-
-  return success(0);
 }
 
 async function execSpawnAgent(
@@ -320,7 +361,7 @@ async function execSpawnAgent(
   onPid?: (pid: number) => void,
   logFile?: string,
   _sessionManager?: SessionManager,
-): Promise<Result<number>> {
+): Promise<Result<AgentExecutionSummary>> {
   let cmd = editor?.runTemplate || "{tag} --prompt-template {workflow} {num}";
   cmd = cmd
     .replace("{tag}", logTag)
@@ -367,7 +408,7 @@ async function execSpawnAgent(
   if (exitCode !== 0) {
     logger.warn(`Agent 退出码: ${exitCode}`);
   }
-  return success(exitCode);
+  return success({ exitCode });
 }
 
 // ─── launchIssueAgent ───────────────────────────────────────
@@ -601,7 +642,8 @@ export async function launchIssueAgent(
     );
 
     if (!agentRes.success) return agentRes;
-    const exitCode = agentRes.data;
+    const summary = agentRes.data;
+    const exitCode = summary.exitCode;
 
     if (exitCode !== 0) {
       let crashLog = "";
@@ -612,8 +654,11 @@ export async function launchIssueAgent(
             content.length > 3000 ? "..." + content.slice(-3000) : content;
         }
       } catch (e) {}
+      const nativeErrorMsg = summary.nativeError
+        ? ` [SDK 错误: ${summary.nativeError.message}]`
+        : "";
       await session.markAsCrashed(
-        `Agent 意外退出 (退出码: ${exitCode})`,
+        `Agent 意外退出 (退出码: ${exitCode})${nativeErrorMsg}`,
         crashLog || "无法获取日志文件内容",
         exitCode,
       );

--- a/bin/integration/webhook-handlers.ts
+++ b/bin/integration/webhook-handlers.ts
@@ -179,9 +179,10 @@ async function doReviewPr(owner: string, repo: string, prNumber: number): Promis
     await session.markAsCrashed(agentRes.error);
     return;
   }
-  if (agentRes.data !== 0) {
-    logger.error(`Reviewer Agent 异常退出 (退出码: ${agentRes.data})`);
-    await session.markAsCrashed(`Reviewer Agent 异常退出 (退出码: ${agentRes.data})`);
+  if (agentRes.data.exitCode !== 0) {
+    const nativeMsg = agentRes.data.nativeError ? ` [${agentRes.data.nativeError.message}]` : "";
+    logger.error(`Reviewer Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
+    await session.markAsCrashed(`Reviewer Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
     return;
   }
 
@@ -322,9 +323,10 @@ async function doResolveReview(owner: string, repo: string, prNumber: number): P
     await session.markAsCrashed(agentRes.error);
     return;
   }
-  if (agentRes.data !== 0) {
-    logger.error(`Agent 异常退出 (退出码: ${agentRes.data})`);
-    await session.markAsCrashed(`Agent 异常退出 (退出码: ${agentRes.data})`);
+  if (agentRes.data.exitCode !== 0) {
+    const nativeMsg = agentRes.data.nativeError ? ` [${agentRes.data.nativeError.message}]` : "";
+    logger.error(`Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
+    await session.markAsCrashed(`Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
     return;
   }
 
@@ -465,9 +467,10 @@ async function doResolveCi(owner: string, repo: string, prNumber: number): Promi
     await session.markAsCrashed(agentRes.error);
     return;
   }
-  if (agentRes.data !== 0) {
-    logger.error(`Agent 异常退出 (退出码: ${agentRes.data})`);
-    await session.markAsCrashed(`Agent 异常退出 (退出码: ${agentRes.data})`);
+  if (agentRes.data.exitCode !== 0) {
+    const nativeMsg = agentRes.data.nativeError ? ` [${agentRes.data.nativeError.message}]` : "";
+    logger.error(`Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
+    await session.markAsCrashed(`Agent 异常退出 (退出码: ${agentRes.data.exitCode})${nativeMsg}`);
     return;
   }
 


### PR DESCRIPTION
## 问题

Claude Agent SDK 的迭代消息流在遭遇 API 致命错误时，可能通过 is_error=true 的 result 消息报告，或直接中断。当前代码仅检查 subtype != "success" 且兜底返回成功，导致 launchIssueAgent() 误判为 AGENT_EXITED_SUCCESS，session 被错误推进到 waiting_human / delivery / draft_pr。

fixes: #75

## 变更

1. **引入可扩展的 Agent 执行结果抽象**
   - 新增 AgentExecutionSummary 接口
   - 将 execAgent、execClaudeAgent、execSpawnAgent 的返回类型从 Result<number> 统一改为 Result<AgentExecutionSummary>

2. **修复 execClaudeAgent 错误检测**
   - 处理 message.type === "result" 时，优先检查 is_error === true 和 errors?.length > 0
   - 若检测到 SDK 报告错误：构造 nativeError，返回 exitCode: 1
   - 修正兜底逻辑：若 for await 循环正常结束却从未收到 result 消息，返回 exitCode: 1

3. **增强日志记录**
   - 修改 formatSDKMessage()：当 result 消息的 is_error 为 true 时，输出错误详情

4. **下游调用适配**
   - launchIssueAgent、webhook-handlers.ts 中各 execAgent 消费点适配新接口

## 验证

- 单元测试通过：vitest run 127/127 passed

fixes: #75