### PR TITLE
fix(dashboard): 修复 Conversation 面板轮询刷新时无条件覆盖用户手动选择的 tab

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,8 @@ function App() {
   const [conversationMessages, setConversationMessages] = useState<ConversationMessage[]>([]);
   const [convLoading, setConvLoading] = useState(false);
   const convSseRef = useRef<EventSource | null>(null);
+  const userSelectedConvFile = useRef(false);
+  const activeConvFileRef = useRef<string | null>(null);
 
   // Poll sessions
   useEffect(() => {
@@ -138,7 +140,9 @@ function App() {
     if (!selectedSession || selectedLogTab !== 'conversation') {
       setConversationFiles([]);
       setActiveConvFile(null);
+      activeConvFileRef.current = null;
       setConversationMessages([]);
+      userSelectedConvFile.current = false;
       return;
     }
 
@@ -155,7 +159,18 @@ function App() {
           const files: ConversationFileInfo[] = await res.json();
           setConversationFiles(files);
           if (files.length > 0) {
-            setActiveConvFile(files[files.length - 1].filename);
+            if (userSelectedConvFile.current) {
+              const stillExists = files.some(f => f.filename === activeConvFileRef.current);
+              if (!stillExists) {
+                const latest = files[files.length - 1].filename;
+                setActiveConvFile(latest);
+                activeConvFileRef.current = latest;
+              }
+            } else {
+              const latest = files[files.length - 1].filename;
+              setActiveConvFile(latest);
+              activeConvFileRef.current = latest;
+            }
           }
         }
       } catch {}
@@ -506,7 +521,11 @@ function App() {
                     ? 'bg-white/10 text-white border-border-color'
                     : 'bg-transparent text-text-secondary border-transparent hover:bg-white/5'
                 }`}
-                onClick={() => setActiveConvFile(f.filename)}
+                onClick={() => {
+                  userSelectedConvFile.current = true;
+                  activeConvFileRef.current = f.filename;
+                  setActiveConvFile(f.filename);
+                }}
               >
                 {f.phase}/{f.workflow}
               </button>


### PR DESCRIPTION
## Summary

- 修复 Conversation 面板每 5 秒轮询刷新时无条件执行 `setActiveConvFile(files[files.length - 1].filename)`，导致用户手动选择的 tab 被覆盖的问题
- 新增 `userSelectedConvFile` ref 追踪用户是否手动选择了 tab，以及 `activeConvFileRef` ref 在轮询闭包中读取当前选中文件
- 用户手动选择 tab 后，轮询不再覆盖选择（除非该文件已被删除）；未手动选择时保持原有自动跟随最新 tab 的行为；切换 session 或离开 conversation tab 时自动重置

## Test Plan

- [ ] 打开 Conversation 面板 → 选择非最新 tab → 等待 >5 秒 → 确认 tab 不跳转
- [ ] 不手动选择 tab → 确认自动跟随最新 tab 的行为不变
- [ ] 切换 session → 确认 tab 重置为最新
- [ ] 用户选择的文件被删除后 → 确认自动回退到最新文件

fixes: #81