### PR TITLE
feat(cleanup): PR 合并后自动更新本地默认分支

### DIFF
--- a/bin/__tests__/cleanup-utils.test.ts
+++ b/bin/__tests__/cleanup-utils.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../core/common", () => ({
+  success: (data: any) => ({ success: true, data }),
+  failure: (error: string) => ({ success: false, error }),
+  git: {
+    fetch: vi.fn(),
+    raw: vi.fn(),
+  },
+  getGit: vi.fn(() => ({
+    fetch: vi.fn(),
+    raw: vi.fn(),
+  })),
+  check_process_running: vi.fn(),
+}));
+
+vi.mock("consola", () => ({
+  consola: {
+    withTag: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../domain/worktree-init", () => ({
+  getDefaultBranch: vi.fn(),
+}));
+
+vi.mock("../integration/github-client", () => ({
+  readRepoInfo: vi.fn(),
+}));
+
+vi.mock("../core/config", () => ({
+  config: {
+    USER_ALONG_DIR: "/mock/.along",
+    getLogTag: vi.fn(() => ({ success: true, data: "along" })),
+  },
+}));
+
+vi.mock("../logging/log-writer", () => ({
+  logWriter: {
+    writeSession: vi.fn(),
+    writeGlobal: vi.fn(),
+    flush: vi.fn(),
+  },
+}));
+
+vi.mock("../core/session-paths", () => ({
+  SessionPathManager: vi.fn(() => ({
+    getWorktreeDir: vi.fn(() => "/mock/worktree"),
+    getIssueDir: vi.fn(() => "/mock/issue"),
+  })),
+}));
+
+vi.mock("../domain/session-manager", () => ({
+  SessionManager: vi.fn(() => ({
+    logEvent: vi.fn(),
+  })),
+}));
+
+vi.mock("../core/db", () => ({
+  readSession: vi.fn(() => ({ success: true, data: null })),
+  upsertSession: vi.fn(() => ({ success: true })),
+  transactSession: vi.fn(),
+}));
+
+vi.mock("../domain/session-state-machine", () => ({
+  isActiveSessionStatus: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    existsSync: vi.fn(),
+    rmSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    createWriteStream: vi.fn(() => ({
+      write: vi.fn(),
+      end: vi.fn(),
+      destroyed: false,
+    })),
+  },
+}));
+
+vi.mock("bun", () => ({
+  $: vi.fn(),
+}));
+
+import { pullDefaultBranch } from "../domain/cleanup-utils";
+import { getDefaultBranch } from "../domain/worktree-init";
+import { git, getGit } from "../core/common";
+
+describe("cleanup-utils.ts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("pullDefaultBranch()", () => {
+    it("正常更新本地默认分支", async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({ success: true, data: "master" });
+      vi.mocked(git.fetch).mockResolvedValue(undefined as any);
+      vi.mocked(git.raw).mockResolvedValue("");
+
+      const result = await pullDefaultBranch();
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("master");
+      expect(git.fetch).toHaveBeenCalledWith("origin", "master");
+      expect(git.raw).toHaveBeenCalledWith(["branch", "-f", "master", "origin/master"]);
+    });
+
+    it("使用自定义 repoPath 时调用 getGit", async () => {
+      const mockGitInstance = { fetch: vi.fn(), raw: vi.fn() };
+      vi.mocked(getGit).mockReturnValue(mockGitInstance as any);
+      vi.mocked(getDefaultBranch).mockResolvedValue({ success: true, data: "main" });
+      mockGitInstance.fetch.mockResolvedValue(undefined);
+      mockGitInstance.raw.mockResolvedValue("");
+
+      const result = await pullDefaultBranch("/custom/repo");
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("main");
+      expect(getGit).toHaveBeenCalledWith("/custom/repo");
+    });
+
+    it("获取默认分支失败时返回 failure", async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({ success: false, error: "remote 不可达" });
+
+      const result = await pullDefaultBranch();
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain("remote 不可达");
+      expect(git.fetch).not.toHaveBeenCalled();
+    });
+
+    it("fetch 失败时返回 failure", async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({ success: true, data: "master" });
+      vi.mocked(git.fetch).mockRejectedValue(new Error("network error"));
+
+      const result = await pullDefaultBranch();
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain("fetch 失败");
+    });
+
+    it("当前在默认分支上时 branch -f 失败，降级为仅 fetch 成功", async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({ success: true, data: "master" });
+      vi.mocked(git.fetch).mockResolvedValue(undefined as any);
+      vi.mocked(git.raw).mockRejectedValue(new Error("cannot force update the current branch"));
+
+      const result = await pullDefaultBranch();
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("master");
+    });
+  });
+});

--- a/bin/domain/cleanup-utils.ts
+++ b/bin/domain/cleanup-utils.ts
@@ -4,9 +4,12 @@ import {
   check_process_running,
   success,
   failure,
+  getGit,
+  git,
 } from "../core/common";
 import type { Result } from "../core/common";
 import { readRepoInfo } from "../integration/github-client";
+import { getDefaultBranch } from "./worktree-init";
 
 const logger = consola.withTag("cleanup-utils");
 import { config } from "../core/config";
@@ -108,6 +111,37 @@ export function readBranchName(owner: string, repo: string, issueNumber: number)
 }
 
 /**
+ * 将本地默认分支 fast-forward 到远程最新状态
+ * 使用 git branch -f 避免影响主仓库工作区
+ */
+export async function pullDefaultBranch(repoPath?: string): Promise<Result<string>> {
+  const defaultBranchRes = await getDefaultBranch(repoPath);
+  if (!defaultBranchRes.success) {
+    logger.warn(`获取默认分支失败: ${defaultBranchRes.error}`);
+    return failure(defaultBranchRes.error);
+  }
+  const defaultBranch = defaultBranchRes.data;
+  const g = repoPath ? getGit(repoPath) : git;
+
+  try {
+    await g.fetch("origin", defaultBranch);
+  } catch (e: any) {
+    logger.warn(`fetch origin/${defaultBranch} 失败: ${e.message}`);
+    return failure(`fetch 失败: ${e.message}`);
+  }
+
+  try {
+    await g.raw(["branch", "-f", defaultBranch, `origin/${defaultBranch}`]);
+    logger.info(`本地默认分支 ${defaultBranch} 已更新到 origin/${defaultBranch}`);
+    return success(defaultBranch);
+  } catch {
+    // 当前 checkout 在默认分支上时 git branch -f 会失败，降级为仅 fetch
+    logger.warn(`git branch -f ${defaultBranch} 失败（可能当前在该分支上），已完成 fetch`);
+    return success(defaultBranch);
+  }
+}
+
+/**
  * 完整清理一个 Issue 的所有资源
  */
 export async function cleanupIssue(
@@ -150,6 +184,12 @@ export async function cleanupIssue(
 
   // 删除本地分支
   await cleanupBranch(branchName, options.silent, session, repoPath);
+
+  // 更新本地默认分支到远程最新
+  const pullRes = await pullDefaultBranch(repoPath);
+  if (pullRes.success) {
+    session.logEvent("default-branch-updated", { branch: pullRes.data });
+  }
 
   session.logEvent("cleanup-completed", { issueNumber, reason, branchName });
   return success(undefined);
@@ -201,6 +241,9 @@ export async function cleanupIssueAssets(
 
   await cleanupWorktree(worktreePath, options.silent, session, repoPath);
   await cleanupBranch(branchName, options.silent, session, repoPath);
+
+  // 更新本地默认分支到远程最新
+  await pullDefaultBranch(repoPath);
 
   const issueDir = paths.getIssueDir();
   if (fs.existsSync(issueDir)) {


### PR DESCRIPTION
## Summary

- 在 `cleanup-utils.ts` 中新增 `pullDefaultBranch()` 函数，使用 `git fetch + git branch -f` 安全更新本地默认分支指针
- 在 `cleanupIssue()` 和 `cleanupIssueAssets()` 中集成调用，三个触发路径（webhook、fallback sync、worktree-gc）自动受益
- 当前 checkout 在默认分支上时自动降级为仅 fetch，网络失败时仅记录警告不阻断清理

## Changes

- `bin/domain/cleanup-utils.ts`: 新增 `pullDefaultBranch()` 并集成到两个清理函数
- `bin/__tests__/cleanup-utils.test.ts`: 新增 5 个单元测试覆盖正常更新、自定义 repoPath、获取分支失败、fetch 失败、branch -f 降级

## Test Plan

- [x] 新增 5 个单元测试全部通过
- [x] 全量测试套件 132 个测试通过，无回归

fixes: #83