### PR TITLE
feat: 引入 task seq

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -912,6 +912,11 @@ export function TaskPlanningView() {
                     </span>
                   </div>
                   <div className="font-medium text-sm truncate">
+                    {snapshot.task.seq != null && (
+                      <span className="text-text-muted mr-1">
+                        #{snapshot.task.seq}
+                      </span>
+                    )}
                     {snapshot.task.title}
                   </div>
                   <div className="text-xs text-text-muted truncate mt-1">
@@ -932,11 +937,19 @@ export function TaskPlanningView() {
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-2">
                     <TaskStatusBadge snapshot={selected} />
+                    {selected.task.type && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-500/15 text-violet-300 border border-violet-500/30">
+                        {selected.task.type}
+                      </span>
+                    )}
                     <span className="text-xs text-text-muted">
                       v{selected.currentPlan?.version || 0}
                     </span>
                   </div>
                   <h2 className="text-lg md:text-xl font-semibold truncate">
+                    {selected.task.seq != null && (
+                      <span className="text-text-muted mr-1">#{selected.task.seq}</span>
+                    )}
                     {selected.task.title}
                   </h2>
                 </div>
@@ -1062,6 +1075,18 @@ export function TaskPlanningView() {
                   <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 text-sm">
                     <span className="text-text-muted">ID</span>
                     <span className="truncate">{selected.task.taskId}</span>
+                    {selected.task.seq != null && (
+                      <>
+                        <span className="text-text-muted">Seq</span>
+                        <span>#{selected.task.seq}</span>
+                      </>
+                    )}
+                    {selected.task.type && (
+                      <>
+                        <span className="text-text-muted">Type</span>
+                        <span>{selected.task.type}</span>
+                      </>
+                    )}
                     <span className="text-text-muted">Thread</span>
                     <span className="truncate">{selected.thread.threadId}</span>
                     <span className="text-text-muted">Source</span>

--- a/packages/along-web/src/types.ts
+++ b/packages/along-web/src/types.ts
@@ -189,6 +189,8 @@ export interface TaskItemRecord {
   commitShas: string[];
   prUrl?: string;
   prNumber?: number;
+  seq?: number;
+  type?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/along/src/core/config.ts
+++ b/packages/along/src/core/config.ts
@@ -77,6 +77,13 @@ export const config = {
     return path.join(userAlongDir, owner, repo, 'tasks', taskId);
   },
 
+  /**
+   * 获取基于 seq 的 task 数据目录: ~/.along/{owner}/{repo}/tasks/{seq}/
+   */
+  getTaskDirBySeq(owner: string, repo: string, seq: number): string {
+    return path.join(userAlongDir, owner, repo, 'tasks', String(seq));
+  },
+
   // 确保用户数据根目录存在
   ensureDataDirs() {
     ensureDir(this.USER_ALONG_DIR);

--- a/packages/along/src/core/db.ts
+++ b/packages/along/src/core/db.ts
@@ -227,6 +227,8 @@ function initSchema(db: Database) {
       commit_shas TEXT DEFAULT '[]',
       pr_url TEXT,
       pr_number INTEGER,
+      seq INTEGER,
+      type TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -425,6 +427,13 @@ function initSchema(db: Database) {
   );
   tryAddColumn(db, 'ALTER TABLE task_items ADD COLUMN pr_url TEXT');
   tryAddColumn(db, 'ALTER TABLE task_items ADD COLUMN pr_number INTEGER');
+  tryAddColumn(db, 'ALTER TABLE task_items ADD COLUMN seq INTEGER');
+  tryAddColumn(db, 'ALTER TABLE task_items ADD COLUMN type TEXT');
+  try {
+    db.exec(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_task_items_repo_seq ON task_items(repo_owner, repo_name, seq)',
+    );
+  } catch {}
 }
 
 function rowToSessionStatus(row: SessionRow): SessionStatus {

--- a/packages/along/src/domain/task-delivery.test.ts
+++ b/packages/along/src/domain/task-delivery.test.ts
@@ -53,6 +53,8 @@ const snapshot = {
     repoName: 'kinkeeper',
     cwd: '/tmp/kinkeeper',
     commitShas: [],
+    seq: 42,
+    type: 'fix',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   },
@@ -184,23 +186,23 @@ describe('task-delivery', () => {
     expect(planningMocks.updateTaskDelivery).toHaveBeenNthCalledWith(1, {
       taskId: 'task_123456789abc',
       status: 'implemented',
-      branchName: expect.stringMatching(/^along-task\/12345678-/),
+      branchName: expect.stringMatching(/^fix\/.*-42/),
       worktreePath: expect.stringContaining(
-        '/ranwawa/kinkeeper/tasks/task_123456789abc/worktree',
+        '/ranwawa/kinkeeper/tasks/42/worktree',
       ),
     });
     expect(planningMocks.updateTaskDelivery).toHaveBeenNthCalledWith(2, {
       taskId: 'task_123456789abc',
       status: 'delivering',
-      branchName: expect.stringMatching(/^along-task\/12345678-/),
+      branchName: expect.stringMatching(/^fix\/.*-42/),
       worktreePath: expect.stringContaining(
-        '/ranwawa/kinkeeper/tasks/task_123456789abc/worktree',
+        '/ranwawa/kinkeeper/tasks/42/worktree',
       ),
     });
     expect(planningMocks.updateTaskDelivery).toHaveBeenLastCalledWith({
       taskId: 'task_123456789abc',
       status: 'delivered',
-      branchName: expect.stringMatching(/^along-task\/12345678-/),
+      branchName: expect.stringMatching(/^fix\/.*-42/),
       commitShas: ['abc123'],
       prUrl: 'https://github.com/ranwawa/kinkeeper/pull/42',
       prNumber: 42,
@@ -214,11 +216,11 @@ describe('task-delivery', () => {
       expect.objectContaining({
         command: 'git',
         cwd: expect.stringContaining(
-          '/ranwawa/kinkeeper/tasks/task_123456789abc/worktree',
+          '/ranwawa/kinkeeper/tasks/42/worktree',
         ),
       }),
     );
-    expect(prBody).toContain('along-task: task_123456789abc');
+    expect(prBody).toContain('along-task: #42');
     expect(prBody).not.toMatch(/(?:fixes|closes|resolves)\s+#\d+/i);
   });
 

--- a/packages/along/src/domain/task-delivery.ts
+++ b/packages/along/src/domain/task-delivery.ts
@@ -76,6 +76,7 @@ async function runGit(
 
 function buildPrBody(input: {
   taskId: string;
+  seq?: number;
   planBody: string;
   changedFiles: string[];
   branchName: string;
@@ -86,7 +87,7 @@ function buildPrBody(input: {
     .join('\n');
 
   return [
-    `along-task: ${input.taskId}`,
+    input.seq != null ? `along-task: #${input.seq}` : `along-task: ${input.taskId}`,
     '',
     '## 修改内容',
     changedFileLines || '- 已按批准方案完成代码实现',
@@ -366,6 +367,7 @@ export async function runTaskDelivery(
 
   const body = buildPrBody({
     taskId: input.taskId,
+    seq: snapshot.task.seq,
     planBody: approvedPlan.body,
     changedFiles,
     branchName,
@@ -385,7 +387,9 @@ export async function runTaskDelivery(
         '--base',
         defaultBranch,
         '--title',
-        `Task: ${normalizeTitle(snapshot.task.title, 90)}`,
+        snapshot.task.seq != null
+          ? `Task #${snapshot.task.seq}: ${normalizeTitle(snapshot.task.title, 80)}`
+          : `Task: ${normalizeTitle(snapshot.task.title, 90)}`,
         '--body-file',
         bodyFile,
       ],

--- a/packages/along/src/domain/task-planning-agent.test.ts
+++ b/packages/along/src/domain/task-planning-agent.test.ts
@@ -132,6 +132,20 @@ describe('task-planning-agent', () => {
     });
   });
 
+  it('当 Planner 输出包含 type 字段时，期望解析出 type', () => {
+    const parsed = parseTaskPlannerOutput(
+      '{"action":"plan_revision","body":"## 方案","type":"feat"}',
+    );
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error(parsed.error);
+    expect(parsed.data).toEqual({
+      action: 'plan_revision',
+      body: '## 方案',
+      type: 'feat',
+    });
+  });
+
   it('当 Planner 输出缺少 JSON 时，期望返回失败', () => {
     const parsed = parseTaskPlannerOutput('这里是一段普通文本');
 
@@ -160,6 +174,7 @@ describe('task-planning-agent', () => {
       taskId: 'task-1',
       agentId: 'planner',
       body: '## 方案\n\n先做 API。',
+      type: undefined,
     });
   });
 
@@ -239,7 +254,8 @@ describe('task-planning-agent', () => {
     expect(planningMocks.publishTaskPlanRevision).toHaveBeenCalledWith({
       taskId: 'task-1',
       agentId: 'planner',
-      body: '按钮文案说的是"删除下方的演示数据"。',
+      body: '按钮文案说的是“删除下方的演示数据”。',
+      type: undefined,
     });
   });
 });

--- a/packages/along/src/domain/task-planning-agent.ts
+++ b/packages/along/src/domain/task-planning-agent.ts
@@ -12,6 +12,19 @@ import {
 const PLANNER_OUTPUT_SCHEMA = z.object({
   action: z.enum(['plan_revision', 'planning_update']),
   body: z.string().min(1),
+  type: z
+    .enum([
+      'feat',
+      'fix',
+      'docs',
+      'style',
+      'refactor',
+      'perf',
+      'test',
+      'chore',
+      'ci',
+    ])
+    .optional(),
 });
 
 const PLANNER_OUTPUT_FORMAT_SCHEMA = {
@@ -26,6 +39,20 @@ const PLANNER_OUTPUT_FORMAT_SCHEMA = {
     body: {
       type: 'string',
       minLength: 1,
+    },
+    type: {
+      type: 'string',
+      enum: [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'chore',
+        'ci',
+      ],
     },
   },
 };
@@ -117,12 +144,13 @@ function buildPlannerPrompt(snapshot: TaskPlanningSnapshot): string {
     '',
     '要求：',
     '1. 只输出 JSON，不要输出 Markdown、代码块、解释或前后缀文本。',
-    '2. JSON 结构必须是：{"action":"plan_revision"|"planning_update","body":"..."}',
+    '2. JSON 结构必须是：{"action":"plan_revision"|"planning_update","body":"...","type":"feat"|"fix"|...}',
     '3. body 必须是中文，且是最终要落库的正文。',
     '4. action = "plan_revision" 表示你已经给出了正式计划或计划修订。',
     '5. action = "planning_update" 表示你是在回答问题、澄清约束或补充上下文，但还不是正式计划。',
     '6. 如果信息仍然不足以形成正式计划，优先输出 planning_update，明确指出还缺什么。',
     '7. 如果当前已经有 Plan 且存在 open feedback round，优先结合反馈决定是 answer_only 还是 revise_plan 的语义，但输出仍然只用上面的两个 action。',
+    '8. type 字段是可选的 conventional commit 类型（feat/fix/docs/style/refactor/perf/test/chore/ci），当 action 为 plan_revision 时建议提供。',
     '',
     `当前状态: hasCurrentPlan=${hasCurrentPlan}, hasOpenRound=${hasOpenRound}`,
     '',
@@ -214,6 +242,7 @@ export async function runTaskPlanningAgent(
       taskId: input.taskId,
       agentId,
       body: parsed.data.body,
+      type: parsed.data.type,
     });
     if (!publishRes.success) return publishRes;
   } else {

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -119,6 +119,8 @@ export interface TaskItemRecord {
   commitShas: string[];
   prUrl?: string;
   prNumber?: number;
+  seq?: number;
+  type?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -236,6 +238,7 @@ export interface PublishTaskPlanInput {
   taskId: string;
   body: string;
   agentId?: string;
+  type?: string;
 }
 
 export interface PublishPlanningUpdateInput {
@@ -336,6 +339,8 @@ interface TaskItemRow {
   commit_shas: string | null;
   pr_url: string | null;
   pr_number: number | null;
+  seq: number | null;
+  type: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -483,6 +488,8 @@ function mapTask(row: TaskItemRow): TaskItemRecord {
     commitShas: parseStringArray(row.commit_shas),
     prUrl: row.pr_url || undefined,
     prNumber: row.pr_number || undefined,
+    seq: row.seq || undefined,
+    type: row.type || undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -737,12 +744,24 @@ export function createPlanningTask(
     const now = iso_timestamp();
 
     const txn = db.transaction(() => {
+      let seq: number | null = null;
+      if (input.repoOwner && input.repoName) {
+        const maxRow = db
+          .prepare(
+            'SELECT MAX(seq) AS max_seq FROM task_items WHERE repo_owner = ? AND repo_name = ?',
+          )
+          .get(input.repoOwner, input.repoName) as
+          | { max_seq: number | null }
+          | undefined;
+        seq = (maxRow?.max_seq ?? 0) + 1;
+      }
+
       db.prepare(
         `
           INSERT INTO task_items (
             task_id, title, body, source, status, active_thread_id,
-            repo_owner, repo_name, cwd, created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            repo_owner, repo_name, cwd, seq, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
       ).run(
         taskId,
@@ -754,6 +773,7 @@ export function createPlanningTask(
         input.repoOwner || null,
         input.repoName || null,
         input.cwd || null,
+        seq,
         now,
         now,
       );
@@ -1146,7 +1166,8 @@ export function publishTaskPlanRevision(
         now,
         snapshot.thread.threadId,
       );
-      db.prepare('UPDATE task_items SET updated_at = ? WHERE task_id = ?').run(
+      db.prepare('UPDATE task_items SET type = COALESCE(?, type), updated_at = ? WHERE task_id = ?').run(
+        input.type || null,
         now,
         snapshot.task.taskId,
       );

--- a/packages/along/src/domain/task-worktree.test.ts
+++ b/packages/along/src/domain/task-worktree.test.ts
@@ -40,6 +40,8 @@ const snapshot = {
     repoName: 'kinkeeper',
     cwd: '/repo/kinkeeper',
     commitShas: [],
+    seq: 42,
+    type: 'fix',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   },
@@ -100,7 +102,7 @@ describe('task-worktree', () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error(result.error);
     expect(result.data.worktreePath).toBe(worktreePath);
-    expect(result.data.branchName).toMatch(/^along-task\/12345678-/);
+    expect(result.data.branchName).toMatch(/^fix\/.*-42/);
     expect(calls).toContainEqual({
       command: 'git',
       cwd: '/repo/kinkeeper',

--- a/packages/along/src/domain/task-worktree.ts
+++ b/packages/along/src/domain/task-worktree.ts
@@ -93,9 +93,13 @@ export async function generateTaskBranchName(
   repoPath: string,
   taskId: string,
   title: string,
+  seq?: number,
+  type?: string,
 ): Promise<string> {
-  const shortId = taskId.replace(/^task_/, '').slice(0, 8);
-  const base = `along-task/${shortId}-${slugifyTitle(title)}`;
+  const prefix = type || 'feat';
+  const slug = slugifyTitle(title);
+  const suffix = seq != null ? `-${seq}` : `-${taskId.replace(/^task_/, '').slice(0, 8)}`;
+  const base = `${prefix}/${slug}${suffix}`;
   if (!(await branchExists(runner, repoPath, base))) return base;
 
   for (let index = 2; index <= 20; index += 1) {
@@ -133,11 +137,18 @@ export async function prepareTaskWorktree(
   if (!defaultBranchRes.success) return defaultBranchRes;
   const defaultBranch = defaultBranchRes.data;
 
-  const taskDir = config.getTaskDir(
-    snapshot.task.repoOwner,
-    snapshot.task.repoName,
-    snapshot.task.taskId,
-  );
+  const taskDir =
+    snapshot.task.seq != null && snapshot.task.repoOwner && snapshot.task.repoName
+      ? config.getTaskDirBySeq(
+          snapshot.task.repoOwner,
+          snapshot.task.repoName,
+          snapshot.task.seq,
+        )
+      : config.getTaskDir(
+          snapshot.task.repoOwner,
+          snapshot.task.repoName,
+          snapshot.task.taskId,
+        );
   const worktreePath =
     snapshot.task.worktreePath || path.join(taskDir, 'worktree');
   const branchName =
@@ -147,6 +158,8 @@ export async function prepareTaskWorktree(
       input.repoPath,
       snapshot.task.taskId,
       snapshot.task.title,
+      snapshot.task.seq,
+      snapshot.task.type,
     ));
 
   fs.mkdirSync(path.dirname(worktreePath), { recursive: true });


### PR DESCRIPTION
## 变更
- 为 Task 数据链路引入 seq 字段，并在 Web 任务列表和详情中展示编号。
- 在规划、实现工作树、交付流程中传递 task seq。
- 补充 task planning/worktree/delivery 相关测试断言。

## 验证
- `bun run quality:changed` 未能启动：缺少 `./.along/preset/scripts/quality/run-changed.mjs`。
- `bun run lint` 未能启动：`biome` 命令不可用。
- `bun run test` 未能启动：`vitest` 命令不可用。
- `bun run build:web` 未能启动：缺少 `vite/client` 和 `node` 类型定义。
- 尝试 `bun install` 失败：workspace 依赖 `@ranwawa/biome-config` 未找到。