### PR TITLE
feat(task): 优化任务规划创建入口

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -1,43 +1,69 @@
 import { TaskDetail } from './task-planning/TaskDetail';
-import { NewTaskForm, TaskListPanel } from './task-planning/TaskSidebar';
+import { RepositorySelector, TaskListPanel } from './task-planning/TaskSidebar';
 import { useTaskPlanningController } from './task-planning/useTaskPlanningController';
+
+type TaskPlanningController = ReturnType<typeof useTaskPlanningController>;
+
+function TaskPlanningSidebar({
+  taskPlanning,
+}: {
+  taskPlanning: TaskPlanningController;
+}) {
+  return (
+    <div className="min-h-[360px] xl:min-h-0 xl:h-full border-b xl:border-b-0 xl:border-r border-border-color flex flex-col bg-bg-glass">
+      <RepositorySelector
+        draft={taskPlanning.draft}
+        repositories={taskPlanning.repositories}
+        selectedRepository={taskPlanning.selectedRepository}
+        repositoriesRefreshing={taskPlanning.repositoriesRefreshing}
+        error={taskPlanning.error}
+        onDraftChange={taskPlanning.updateDraft}
+        onRefreshRepositories={taskPlanning.refreshRepositories}
+      />
+      <TaskListPanel
+        tasks={taskPlanning.tasks}
+        loading={taskPlanning.loading}
+        selectedTaskId={taskPlanning.selected?.task.taskId}
+        isNewTaskOpen={taskPlanning.isNewTaskOpen}
+        onNewTask={taskPlanning.openNewTask}
+        onSelect={taskPlanning.selectTask}
+      />
+    </div>
+  );
+}
+
+function TaskPlanningMain({
+  taskPlanning,
+}: {
+  taskPlanning: TaskPlanningController;
+}) {
+  return (
+    <div className="min-h-[560px] xl:min-h-0 flex flex-col bg-bg-secondary">
+      <TaskDetail
+        selected={taskPlanning.selected}
+        isNewTaskOpen={taskPlanning.isNewTaskOpen}
+        draft={taskPlanning.draft}
+        selectedRepository={taskPlanning.selectedRepository}
+        sortedArtifacts={taskPlanning.sortedArtifacts}
+        messageBody={taskPlanning.messageBody}
+        busyAction={taskPlanning.busyAction}
+        onDraftChange={taskPlanning.updateDraft}
+        onCreateTask={taskPlanning.createTask}
+        onMessageChange={taskPlanning.setMessageBody}
+        onSubmitMessage={taskPlanning.submitMessageFromFlow}
+        onAction={taskPlanning.handleFlowAction}
+      />
+    </div>
+  );
+}
 
 export function TaskPlanningView() {
   const taskPlanning = useTaskPlanningController();
 
   return (
     <div className="flex-1 min-h-0 grid grid-cols-1 xl:grid-cols-[420px_minmax(0,1fr)] border-t border-border-color overflow-auto xl:overflow-hidden">
-      <div className="min-h-[360px] xl:min-h-0 xl:h-full border-b xl:border-b-0 xl:border-r border-border-color flex flex-col bg-bg-glass">
-        <NewTaskForm
-          draft={taskPlanning.draft}
-          repositories={taskPlanning.repositories}
-          selectedRepository={taskPlanning.selectedRepository}
-          busyAction={taskPlanning.busyAction}
-          repositoriesRefreshing={taskPlanning.repositoriesRefreshing}
-          error={taskPlanning.error}
-          onSubmit={taskPlanning.createTask}
-          onDraftChange={taskPlanning.updateDraft}
-          onRefreshRepositories={taskPlanning.refreshRepositories}
-        />
-        <TaskListPanel
-          tasks={taskPlanning.tasks}
-          loading={taskPlanning.loading}
-          selectedTaskId={taskPlanning.selected?.task.taskId}
-          onSelect={taskPlanning.selectTask}
-        />
-      </div>
-
-      <div className="min-h-[560px] xl:min-h-0 flex flex-col bg-bg-secondary">
-        <TaskDetail
-          selected={taskPlanning.selected}
-          sortedArtifacts={taskPlanning.sortedArtifacts}
-          messageBody={taskPlanning.messageBody}
-          busyAction={taskPlanning.busyAction}
-          onMessageChange={taskPlanning.setMessageBody}
-          onSubmitMessage={taskPlanning.submitMessageFromFlow}
-          onAction={taskPlanning.handleFlowAction}
-        />
-      </div>
+      <TaskPlanningSidebar taskPlanning={taskPlanning} />
+      <TaskPlanningMain taskPlanning={taskPlanning} />
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -1,10 +1,24 @@
+import {
+  type FormEvent,
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 import type {
   TaskArtifactRecord,
   TaskFlowAction,
+  TaskFlowSnapshot,
   TaskPlanningSnapshot,
 } from '../types';
 import { AgentStagesPanel } from './AgentStagesPanel';
-import { formatTime, getTaskStatusLabel, getThreadStatusLabel } from './format';
+import type { DraftTaskInput, RepositoryOption } from './api';
+import {
+  formatTime,
+  getFlowActionClass,
+  getTaskStatusLabel,
+  getThreadStatusLabel,
+} from './format';
 import { TaskFlowPanel } from './TaskFlowPanel';
 import { TaskProgressPanel } from './TaskProgressPanel';
 import { TaskRecordsPanel } from './TaskRecords';
@@ -97,31 +111,262 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
   );
 }
 
-export function TaskDetail({
-  selected,
-  sortedArtifacts,
+function getMessageActions(flow: TaskFlowSnapshot) {
+  const submitFeedbackAction = flow.actions.find(
+    (action) => action.id === 'submit_feedback',
+  );
+  const requestRevisionAction = flow.actions.find(
+    (action) => action.id === 'request_revision',
+  );
+  const requestChangesAction = flow.actions.find(
+    (action) => action.id === 'request_changes',
+  );
+  return requestChangesAction?.enabled
+    ? [requestChangesAction]
+    : [submitFeedbackAction, requestRevisionAction].filter(
+        (action): action is TaskFlowAction => Boolean(action),
+      );
+}
+
+function ExistingTaskComposer({
+  flow,
   messageBody,
   busyAction,
   onMessageChange,
   onSubmitMessage,
-  onAction,
 }: {
-  selected: TaskPlanningSnapshot | null;
-  sortedArtifacts: TaskArtifactRecord[];
+  flow: TaskFlowSnapshot;
   messageBody: string;
   busyAction: string | null;
   onMessageChange: (value: string) => void;
   onSubmitMessage: () => void;
-  onAction: (action: TaskFlowAction) => void;
 }) {
-  if (!selected) {
-    return (
-      <div className="flex-1 min-h-[320px] flex items-center justify-center text-text-muted text-sm">
-        请选择任务。
+  const messageActions = getMessageActions(flow);
+  const canSubmitMessage = messageActions.some((action) => action.enabled);
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmitMessage();
+      }}
+      className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3"
+    >
+      <div className="text-sm font-semibold text-text-secondary">继续输入</div>
+      <textarea
+        value={messageBody}
+        onChange={(event) => onMessageChange(event.target.value)}
+        placeholder="补充反馈、继续提问或说明交付后的修改要求"
+        rows={5}
+        disabled={!canSubmitMessage}
+        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
+      />
+      <div className="flex flex-wrap gap-2">
+        {messageActions.map((action) => (
+          <button
+            key={action.id}
+            type="submit"
+            disabled={
+              !action.enabled || !messageBody.trim() || Boolean(busyAction)
+            }
+            title={!action.enabled ? action.disabledReason : action.description}
+            className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
+              action,
+            )}`}
+          >
+            {busyAction === 'message' ? '发送中' : action.label}
+          </button>
+        ))}
       </div>
-    );
+    </form>
+  );
+}
+
+function NewTaskComposer({
+  draft,
+  selectedRepository,
+  busyAction,
+  onDraftChange,
+  onCreateTask,
+}: {
+  draft: DraftTaskInput;
+  selectedRepository?: RepositoryOption;
+  busyAction: string | null;
+  onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onCreateTask: (event: FormEvent) => void;
+}) {
+  return (
+    <form
+      onSubmit={onCreateTask}
+      className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-sm font-semibold text-text-secondary">
+          继续输入
+        </div>
+        {selectedRepository && (
+          <span className="text-xs text-text-muted truncate">
+            {selectedRepository.fullName}
+          </span>
+        )}
+      </div>
+      <input
+        type="text"
+        value={draft.title}
+        onChange={(event) => onDraftChange('title', event.target.value)}
+        placeholder="标题"
+        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
+      />
+      <textarea
+        value={draft.body}
+        onChange={(event) => onDraftChange('body', event.target.value)}
+        placeholder="输入任务目标或问题"
+        rows={6}
+        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
+      />
+      <div className="flex items-center justify-between gap-3">
+        <span className="min-w-0 text-xs text-text-muted">
+          {selectedRepository ? '将创建到当前仓库。' : '请先选择仓库。'}
+        </span>
+        <button
+          type="submit"
+          disabled={
+            !selectedRepository || !draft.body.trim() || busyAction === 'create'
+          }
+          className="shrink-0 px-3 py-2 rounded-lg text-xs font-semibold bg-brand text-white border border-brand hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {busyAction === 'create' ? '发送中' : '发送'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function scrollToLatest(element: HTMLDivElement | null) {
+  if (!element) return;
+  element.scrollTop = element.scrollHeight;
+}
+
+type TaskDetailProps = {
+  selected: TaskPlanningSnapshot | null;
+  isNewTaskOpen: boolean;
+  draft: DraftTaskInput;
+  selectedRepository?: RepositoryOption;
+  sortedArtifacts: TaskArtifactRecord[];
+  messageBody: string;
+  busyAction: string | null;
+  onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onCreateTask: (event: FormEvent) => void;
+  onMessageChange: (value: string) => void;
+  onSubmitMessage: () => void;
+  onAction: (action: TaskFlowAction) => void;
+};
+
+function useLatestScroll(detailKey: string, artifactCount: number) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const shouldFollowLatestRef = useRef(true);
+  const onScroll = (element: HTMLDivElement) => {
+    shouldFollowLatestRef.current =
+      element.scrollHeight - element.scrollTop - element.clientHeight < 96;
+  };
+
+  useLayoutEffect(() => {
+    void detailKey;
+    shouldFollowLatestRef.current = true;
+    scrollToLatest(scrollRef.current);
+  }, [detailKey]);
+
+  useEffect(() => {
+    void artifactCount;
+    if (shouldFollowLatestRef.current) scrollToLatest(scrollRef.current);
+  }, [artifactCount]);
+
+  return { scrollRef, onScroll };
+}
+
+export function TaskDetail(props: TaskDetailProps) {
+  const detailKey =
+    props.selected?.task.taskId || (props.isNewTaskOpen ? 'new' : 'empty');
+  const { scrollRef, onScroll } = useLatestScroll(
+    detailKey,
+    props.sortedArtifacts.length,
+  );
+
+  if (!props.selected) {
+    if (props.isNewTaskOpen) {
+      return (
+        <NewTaskDetail
+          detail={props}
+          scrollRef={scrollRef}
+          onScroll={onScroll}
+        />
+      );
+    }
+    return <EmptyTaskDetail />;
   }
 
+  return (
+    <SelectedTaskDetail
+      detail={props}
+      selected={props.selected}
+      scrollRef={scrollRef}
+      onScroll={onScroll}
+    />
+  );
+}
+
+function EmptyTaskDetail() {
+  return (
+    <div className="flex-1 min-h-[320px] flex items-center justify-center text-text-muted text-sm">
+      请选择任务，或点击新任务。
+    </div>
+  );
+}
+
+function NewTaskDetail({
+  detail,
+  scrollRef,
+  onScroll,
+}: {
+  detail: TaskDetailProps;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: (element: HTMLDivElement) => void;
+}) {
+  return (
+    <>
+      <div className="shrink-0 p-4 md:p-6 border-b border-border-color flex flex-col gap-2">
+        <div className="text-xs text-text-muted">新任务会话</div>
+        <h2 className="text-lg md:text-xl font-semibold">新任务</h2>
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={(event) => onScroll(event.currentTarget)}
+        className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
+      >
+        <TaskRecordsPanel artifacts={[]}>
+          <NewTaskComposer
+            draft={detail.draft}
+            selectedRepository={detail.selectedRepository}
+            busyAction={detail.busyAction}
+            onDraftChange={detail.onDraftChange}
+            onCreateTask={detail.onCreateTask}
+          />
+        </TaskRecordsPanel>
+      </div>
+    </>
+  );
+}
+
+function SelectedTaskDetail({
+  detail,
+  selected,
+  scrollRef,
+  onScroll,
+}: {
+  detail: TaskDetailProps;
+  selected: TaskPlanningSnapshot;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: (element: HTMLDivElement) => void;
+}) {
   return (
     <>
       <div className="shrink-0 p-4 md:p-6 border-b border-border-color flex flex-col gap-4">
@@ -154,20 +399,29 @@ export function TaskDetail({
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-auto p-4 md:p-6 grid grid-cols-1 2xl:grid-cols-[minmax(0,1fr)_360px] gap-5">
+      <div
+        ref={scrollRef}
+        onScroll={(event) => onScroll(event.currentTarget)}
+        className="flex-1 min-h-0 overflow-auto p-4 md:p-6 grid grid-cols-1 2xl:grid-cols-[minmax(0,1fr)_360px] gap-5"
+      >
         <div className="min-w-0 flex flex-col gap-5">
           <TaskFlowPanel
             flow={selected.flow}
-            messageBody={messageBody}
-            busyAction={busyAction}
-            onMessageChange={onMessageChange}
-            onSubmitMessage={onSubmitMessage}
-            onAction={onAction}
+            busyAction={detail.busyAction}
+            onAction={detail.onAction}
           />
           <CurrentPlanPanel selected={selected} />
           <TaskProgressPanel snapshot={selected} />
           <AgentStagesPanel stages={selected.agentStages || []} />
-          <TaskRecordsPanel artifacts={sortedArtifacts} />
+          <TaskRecordsPanel artifacts={detail.sortedArtifacts}>
+            <ExistingTaskComposer
+              flow={selected.flow}
+              messageBody={detail.messageBody}
+              busyAction={detail.busyAction}
+              onMessageChange={detail.onMessageChange}
+              onSubmitMessage={detail.onSubmitMessage}
+            />
+          </TaskRecordsPanel>
         </div>
         <TaskInfoPanel selected={selected} />
       </div>

--- a/packages/along-web/src/task-planning/TaskFlowPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowPanel.tsx
@@ -60,164 +60,144 @@ function FlowActionButton({
 
 export function TaskFlowPanel({
   flow,
-  messageBody,
   busyAction,
-  onMessageChange,
-  onSubmitMessage,
   onAction,
 }: {
   flow: TaskFlowSnapshot;
-  messageBody: string;
   busyAction: string | null;
-  onMessageChange: (value: string) => void;
-  onSubmitMessage: () => void;
   onAction: (action: TaskFlowAction) => void;
 }) {
-  const submitFeedbackAction = flow.actions.find(
-    (action) => action.id === 'submit_feedback',
-  );
-  const requestRevisionAction = flow.actions.find(
-    (action) => action.id === 'request_revision',
-  );
-  const requestChangesAction = flow.actions.find(
-    (action) => action.id === 'request_changes',
-  );
-  const messageActions = requestChangesAction?.enabled
-    ? [requestChangesAction]
-    : [submitFeedbackAction, requestRevisionAction].filter(
-        (action): action is TaskFlowAction => Boolean(action),
-      );
   const commandActions = flow.actions.filter(
     (action) =>
       !['submit_feedback', 'request_revision', 'request_changes'].includes(
         action.id,
       ),
   );
-  const canSubmitMessage = messageActions.some((action) => action.enabled);
 
   return (
     <section className="rounded-lg border border-border-color bg-black/25 p-4 md:p-5 flex flex-col gap-4">
-      <div className="flex flex-col gap-3">
-        <div
-          className={`rounded-lg border px-4 py-3 ${getFlowSeverityClass(
-            flow.severity,
-          )}`}
-        >
-          <div className="text-xs text-text-muted mb-1">当前节奏</div>
-          <div className="text-base font-semibold">{flow.conclusion}</div>
-        </div>
-        {flow.blockers.length > 0 && (
-          <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-xs leading-5 text-amber-100">
-            {flow.blockers.map((blocker) => (
-              <div key={blocker}>{blocker}</div>
-            ))}
-          </div>
-        )}
-      </div>
+      <FlowSummary flow={flow} />
+      <FlowStages stages={flow.stages} />
+      <FlowActions
+        actions={flow.actions}
+        commandActions={commandActions}
+        busyAction={busyAction}
+        onAction={onAction}
+      />
+      <FlowHistory flow={flow} />
+    </section>
+  );
+}
 
-      <div className="flex gap-3 overflow-x-auto pb-1">
-        {flow.stages.map((stage) => (
-          <FlowStageItem key={stage.id} stage={stage} />
+function FlowSummary({ flow }: { flow: TaskFlowSnapshot }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        className={`rounded-lg border px-4 py-3 ${getFlowSeverityClass(
+          flow.severity,
+        )}`}
+      >
+        <div className="text-xs text-text-muted mb-1">当前节奏</div>
+        <div className="text-base font-semibold">{flow.conclusion}</div>
+      </div>
+      {flow.blockers.length > 0 && (
+        <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-xs leading-5 text-amber-100">
+          {flow.blockers.map((blocker) => (
+            <div key={blocker}>{blocker}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FlowStages({ stages }: { stages: TaskFlowStage[] }) {
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-1">
+      {stages.map((stage) => (
+        <FlowStageItem key={stage.id} stage={stage} />
+      ))}
+    </div>
+  );
+}
+
+function FlowActions({
+  actions,
+  commandActions,
+  busyAction,
+  onAction,
+}: {
+  actions: TaskFlowAction[];
+  commandActions: TaskFlowAction[];
+  busyAction: string | null;
+  onAction: (action: TaskFlowAction) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-sm font-semibold text-text-secondary">
+        可执行操作
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {commandActions.map((action) => (
+          <FlowActionButton
+            key={action.id}
+            action={action}
+            busy={Boolean(busyAction)}
+            onClick={onAction}
+          />
         ))}
       </div>
+      <FlowDisabledReasons actions={actions} />
+    </div>
+  );
+}
 
-      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_minmax(260px,360px)] gap-4">
-        <div className="flex flex-col gap-3">
-          <div className="text-sm font-semibold text-text-secondary">
-            可执行操作
+function FlowDisabledReasons({ actions }: { actions: TaskFlowAction[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+      {actions
+        .filter((action) => !action.enabled && action.disabledReason)
+        .map((action) => (
+          <div
+            key={action.id}
+            className="rounded-md border border-border-color bg-black/20 px-3 py-2 text-xs leading-5 text-text-muted"
+          >
+            <span className="text-text-secondary">{action.label}</span>：
+            {action.disabledReason}
           </div>
-          <div className="flex flex-wrap gap-2">
-            {commandActions.map((action) => (
-              <FlowActionButton
-                key={action.id}
-                action={action}
-                busy={Boolean(busyAction)}
-                onClick={onAction}
-              />
-            ))}
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-            {flow.actions
-              .filter((action) => !action.enabled && action.disabledReason)
-              .map((action) => (
-                <div
-                  key={action.id}
-                  className="rounded-md border border-border-color bg-black/20 px-3 py-2 text-xs leading-5 text-text-muted"
-                >
-                  <span className="text-text-secondary">{action.label}</span>：
-                  {action.disabledReason}
-                </div>
-              ))}
-          </div>
-        </div>
+        ))}
+    </div>
+  );
+}
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            onSubmitMessage();
-          }}
-          className="flex flex-col gap-3"
-        >
-          <div className="text-sm font-semibold text-text-secondary">
-            讨论与修改
-          </div>
-          <textarea
-            value={messageBody}
-            onChange={(event) => onMessageChange(event.target.value)}
-            placeholder="补充反馈、继续提问或说明交付后的修改要求"
-            rows={5}
-            disabled={!canSubmitMessage}
-            className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
-          />
-          <div className="flex flex-wrap gap-2">
-            {messageActions.map((action) => (
-              <button
-                key={action.id}
-                type="submit"
-                disabled={
-                  !action.enabled || !messageBody.trim() || Boolean(busyAction)
-                }
-                title={
-                  !action.enabled ? action.disabledReason : action.description
-                }
-                className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
-                  action,
-                )}`}
-              >
-                {busyAction === 'message' ? '发送中' : action.label}
-              </button>
-            ))}
-          </div>
-        </form>
+function FlowHistory({ flow }: { flow: TaskFlowSnapshot }) {
+  return (
+    <details className="rounded-lg border border-border-color bg-black/20">
+      <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-text-secondary">
+        历史流转
+      </summary>
+      <div className="px-4 pb-4 flex flex-col gap-2">
+        {flow.events.length === 0 ? (
+          <div className="text-sm text-text-muted">暂无历史事件。</div>
+        ) : (
+          flow.events.map((event) => (
+            <div
+              key={event.eventId}
+              className="grid grid-cols-[86px_1fr] gap-3 rounded-md border border-white/5 bg-black/20 px-3 py-2 text-xs"
+            >
+              <span className="text-text-muted">
+                {formatTime(event.occurredAt)}
+              </span>
+              <span className="min-w-0">
+                <span className="text-text-secondary">{event.title}</span>
+                {event.summary && (
+                  <span className="text-text-muted"> · {event.summary}</span>
+                )}
+              </span>
+            </div>
+          ))
+        )}
       </div>
-
-      <details className="rounded-lg border border-border-color bg-black/20">
-        <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-text-secondary">
-          历史流转
-        </summary>
-        <div className="px-4 pb-4 flex flex-col gap-2">
-          {flow.events.length === 0 ? (
-            <div className="text-sm text-text-muted">暂无历史事件。</div>
-          ) : (
-            flow.events.map((event) => (
-              <div
-                key={event.eventId}
-                className="grid grid-cols-[86px_1fr] gap-3 rounded-md border border-white/5 bg-black/20 px-3 py-2 text-xs"
-              >
-                <span className="text-text-muted">
-                  {formatTime(event.occurredAt)}
-                </span>
-                <span className="min-w-0">
-                  <span className="text-text-secondary">{event.title}</span>
-                  {event.summary && (
-                    <span className="text-text-muted"> · {event.summary}</span>
-                  )}
-                </span>
-              </div>
-            ))
-          )}
-        </div>
-      </details>
-    </section>
+    </details>
   );
 }

--- a/packages/along-web/src/task-planning/TaskRecords.tsx
+++ b/packages/along-web/src/task-planning/TaskRecords.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { TaskArtifactRecord } from '../types';
 import { formatTime, getArtifactClass, getArtifactLabel } from './format';
 
@@ -21,8 +22,10 @@ export function ArtifactItem({ artifact }: { artifact: TaskArtifactRecord }) {
 
 export function TaskRecordsPanel({
   artifacts,
+  children,
 }: {
   artifacts: TaskArtifactRecord[];
+  children?: ReactNode;
 }) {
   return (
     <section className="flex flex-col gap-3">
@@ -36,6 +39,7 @@ export function TaskRecordsPanel({
           ))
         )}
       </div>
+      {children}
     </section>
   );
 }

--- a/packages/along-web/src/task-planning/TaskSidebar.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.tsx
@@ -1,59 +1,31 @@
-import type { FormEvent } from 'react';
 import type { TaskPlanningSnapshot } from '../types';
 import type { DraftTaskInput, RepositoryOption } from './api';
 import { formatTime, getLatestFailedStage } from './format';
 import { TaskStatusBadge } from './TaskStatusBadge';
 
-export function NewTaskForm({
+export function RepositorySelector({
   draft,
   repositories,
   selectedRepository,
-  busyAction,
   repositoriesRefreshing,
   error,
-  onSubmit,
   onDraftChange,
   onRefreshRepositories,
 }: {
   draft: DraftTaskInput;
   repositories: RepositoryOption[];
   selectedRepository?: RepositoryOption;
-  busyAction: string | null;
   repositoriesRefreshing: boolean;
   error: string | null;
-  onSubmit: (event: FormEvent) => void;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
   onRefreshRepositories: () => void;
 }) {
   return (
-    <form
-      onSubmit={onSubmit}
-      className="shrink-0 p-4 md:p-5 border-b border-border-color flex flex-col gap-3"
-    >
+    <div className="shrink-0 p-4 md:p-5 border-b border-border-color flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="font-semibold text-sm md:text-base">新任务</div>
-        <button
-          type="submit"
-          disabled={!draft.body.trim() || busyAction === 'create'}
-          className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-brand text-white border border-brand hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {busyAction === 'create' ? '处理中' : '发送'}
-        </button>
+        <div className="font-semibold text-sm md:text-base">仓库</div>
+        <span className="text-xs text-text-muted">主入口</span>
       </div>
-      <input
-        type="text"
-        value={draft.title}
-        onChange={(event) => onDraftChange('title', event.target.value)}
-        placeholder="标题"
-        className="bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
-      />
-      <textarea
-        value={draft.body}
-        onChange={(event) => onDraftChange('body', event.target.value)}
-        placeholder="输入任务目标或问题"
-        rows={5}
-        className="bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
-      />
       <div className="flex gap-2">
         <select
           value={draft.repository}
@@ -61,7 +33,7 @@ export function NewTaskForm({
           className="min-w-0 flex-1 bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
         >
           {repositories.length === 0 ? (
-            <option value="">当前默认项目</option>
+            <option value="">暂无已注册仓库</option>
           ) : (
             repositories.map((repository) => (
               <option key={repository.fullName} value={repository.fullName}>
@@ -93,7 +65,7 @@ export function NewTaskForm({
           {error}
         </div>
       )}
-    </form>
+    </div>
   );
 }
 
@@ -101,19 +73,24 @@ export function TaskListPanel({
   tasks,
   loading,
   selectedTaskId,
+  isNewTaskOpen,
+  onNewTask,
   onSelect,
 }: {
   tasks: TaskPlanningSnapshot[];
   loading: boolean;
   selectedTaskId?: string;
+  isNewTaskOpen: boolean;
+  onNewTask: () => void;
   onSelect: (snapshot: TaskPlanningSnapshot) => void;
 }) {
   return (
     <>
-      <div className="px-4 md:px-5 py-3 border-b border-border-color flex items-center justify-between">
-        <span className="text-sm font-semibold">任务列表</span>
-        <span className="text-xs text-text-muted">{tasks.length}</span>
-      </div>
+      <TaskListHeader
+        taskCount={tasks.length}
+        isNewTaskOpen={isNewTaskOpen}
+        onNewTask={onNewTask}
+      />
       <div className="flex-1 min-h-0 overflow-auto">
         {loading && tasks.length === 0 ? (
           <div className="p-5 text-text-muted text-sm">加载中...</div>
@@ -163,5 +140,35 @@ export function TaskListPanel({
         )}
       </div>
     </>
+  );
+}
+
+function TaskListHeader({
+  taskCount,
+  isNewTaskOpen,
+  onNewTask,
+}: {
+  taskCount: number;
+  isNewTaskOpen: boolean;
+  onNewTask: () => void;
+}) {
+  return (
+    <div className="px-4 md:px-5 py-3 border-b border-border-color flex items-center justify-between gap-3">
+      <div className="min-w-0 flex items-center gap-2">
+        <span className="text-sm font-semibold">任务列表</span>
+        <span className="text-xs text-text-muted">{taskCount}</span>
+      </div>
+      <button
+        type="button"
+        onClick={onNewTask}
+        className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
+          isNewTaskOpen
+            ? 'bg-brand text-white border-brand'
+            : 'border-border-color text-text-secondary hover:bg-white/5'
+        }`}
+      >
+        新任务
+      </button>
+    </div>
   );
 }

--- a/packages/along-web/src/task-planning/actionTypes.ts
+++ b/packages/along-web/src/task-planning/actionTypes.ts
@@ -29,6 +29,7 @@ export interface UseTaskPlanningActionsInput {
   setDraft: React.Dispatch<React.SetStateAction<DraftTaskInput>>;
   setTasks: React.Dispatch<React.SetStateAction<TaskPlanningSnapshot[]>>;
   setSelectedTaskId: React.Dispatch<React.SetStateAction<string | null>>;
+  setIsNewTaskOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedSnapshot: React.Dispatch<
     React.SetStateAction<TaskPlanningSnapshot | null>
   >;

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -68,7 +68,26 @@ async function postCreateTask(payload: Record<string, string | boolean>) {
 
 function useDraftActions(input: UseTaskPlanningActionsInput) {
   const updateDraft = (key: keyof DraftTaskInput, value: string) => {
-    input.setDraft((previous) => ({ ...previous, [key]: value }));
+    input.setDraft((previous) => {
+      if (key !== 'repository') return { ...previous, [key]: value };
+      return { ...emptyDraft, repository: value };
+    });
+    if (key === 'repository') {
+      input.setSelectedTaskId(null);
+      input.setSelectedSnapshot(null);
+      input.setMessageBody('');
+      input.setIsNewTaskOpen(false);
+    }
+  };
+  const openNewTask = () => {
+    input.setDraft((previous) => ({
+      ...emptyDraft,
+      repository: previous.repository,
+    }));
+    input.setSelectedTaskId(null);
+    input.setSelectedSnapshot(null);
+    input.setMessageBody('');
+    input.setIsNewTaskOpen(true);
   };
   const createTask = async (event: FormEvent) => {
     event.preventDefault();
@@ -76,12 +95,16 @@ function useDraftActions(input: UseTaskPlanningActionsInput) {
     if (!body || input.busyAction) return;
     await runBusy(input, 'create', async () => {
       const result = await postCreateTask(buildCreatePayload(input, body));
-      input.setDraft(emptyDraft);
+      input.setDraft((previous) => ({
+        ...emptyDraft,
+        repository: previous.repository,
+      }));
+      input.setIsNewTaskOpen(false);
       input.setSelectedTaskId(result.taskId);
       applySnapshot(result.snapshot, input);
     });
   };
-  return { createTask, updateDraft };
+  return { createTask, openNewTask, updateDraft };
 }
 
 function useRepositoryActions(input: UseTaskPlanningActionsInput) {
@@ -106,8 +129,10 @@ function useRepositoryActions(input: UseTaskPlanningActionsInput) {
 
 function useSelectionActions(input: UseTaskPlanningActionsInput) {
   const selectTask = (snapshot: TaskPlanningSnapshot) => {
+    input.setIsNewTaskOpen(false);
     input.setSelectedTaskId(snapshot.task.taskId);
     input.setSelectedSnapshot(snapshot);
+    input.setMessageBody('');
   };
   return { selectTask };
 }

--- a/packages/along-web/src/task-planning/useTaskPlanningController.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningController.ts
@@ -1,156 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { TaskFlowActionId, TaskPlanningSnapshot } from '../types';
-import {
-  type DraftTaskInput,
-  emptyDraft,
-  mergeSnapshotIntoList,
-  type RepositoryListResponse,
-  type RepositoryOption,
-  readJsonResponse,
-} from './api';
+import type { RepositoryOption } from './api';
 import { useTaskPlanningActions } from './useTaskPlanningActions';
-
-function getErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function useTaskState() {
-  const [tasks, setTasks] = useState<TaskPlanningSnapshot[]>([]);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [selectedSnapshot, setSelectedSnapshot] =
-    useState<TaskPlanningSnapshot | null>(null);
-  const selected =
-    selectedSnapshot ||
-    tasks.find((snapshot) => snapshot.task.taskId === selectedTaskId) ||
-    null;
-  return {
-    tasks,
-    setTasks,
-    selected,
-    selectedTaskId,
-    setSelectedTaskId,
-    selectedSnapshot,
-    setSelectedSnapshot,
-  };
-}
-
-function useRepositories() {
-  const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
-  const [draft, setDraft] = useState<DraftTaskInput>(emptyDraft);
-  const loadRepositories = useCallback(async () => {
-    const response = await fetch('/api/repositories');
-    const result = await readJsonResponse<RepositoryListResponse>(response);
-    setRepositories(result.repositories);
-    setDraft((previous) => {
-      if (previous.repository) return previous;
-      return {
-        ...previous,
-        repository:
-          result.defaultRepository || result.repositories[0]?.fullName || '',
-      };
-    });
-  }, []);
-  return { repositories, setRepositories, draft, setDraft, loadRepositories };
-}
-
-type TaskLoaderInput = {
-  selectedTaskId: string | null;
-  setTasks: React.Dispatch<React.SetStateAction<TaskPlanningSnapshot[]>>;
-  setSelectedTaskId: React.Dispatch<React.SetStateAction<string | null>>;
-  setSelectedSnapshot: React.Dispatch<
-    React.SetStateAction<TaskPlanningSnapshot | null>
-  >;
-};
-
-function useTaskLoaders(input: TaskLoaderInput) {
-  return {
-    loadTasks: useLoadTasks(input),
-    loadSelectedTask: useLoadSelectedTask(input),
-  };
-}
-
-function useLoadTasks(input: TaskLoaderInput) {
-  const loadTasks = useCallback(async () => {
-    const response = await fetch('/api/tasks?limit=100');
-    const snapshots = await readJsonResponse<TaskPlanningSnapshot[]>(response);
-    input.setTasks(snapshots);
-    if (!input.selectedTaskId && snapshots.length > 0) {
-      input.setSelectedTaskId(snapshots[0].task.taskId);
-      input.setSelectedSnapshot(snapshots[0]);
-    }
-  }, [
-    input.selectedTaskId,
-    input.setSelectedSnapshot,
-    input.setSelectedTaskId,
-    input.setTasks,
-  ]);
-  return loadTasks;
-}
-
-function useLoadSelectedTask(input: TaskLoaderInput) {
-  const loadSelectedTask = useCallback(
-    async (taskId: string) => {
-      const response = await fetch(`/api/tasks/${taskId}`);
-      const snapshot = await readJsonResponse<TaskPlanningSnapshot>(response);
-      input.setSelectedSnapshot(snapshot);
-      input.setTasks((previous) => mergeSnapshotIntoList(previous, snapshot));
-    },
-    [input.setSelectedSnapshot, input.setTasks],
-  );
-  return loadSelectedTask;
-}
-
-function useInitialRepositories(
-  loadRepositories: () => Promise<void>,
-  setError: (value: string) => void,
-) {
-  useEffect(() => {
-    loadRepositories().catch((err: unknown) => setError(getErrorMessage(err)));
-  }, [loadRepositories, setError]);
-}
-
-function useTaskPolling(
-  loadTasks: () => Promise<void>,
-  setError: (value: string) => void,
-) {
-  const [loading, setLoading] = useState(false);
-  useEffect(() => {
-    let active = true;
-    setLoading(true);
-    loadTasks()
-      .catch((err: unknown) => active && setError(getErrorMessage(err)))
-      .finally(() => active && setLoading(false));
-    const timer = setInterval(() => {
-      loadTasks().catch((err: unknown) => setError(getErrorMessage(err)));
-    }, 3000);
-    return () => {
-      active = false;
-      clearInterval(timer);
-    };
-  }, [loadTasks, setError]);
-  return loading;
-}
-
-function useSelectedTaskPolling(
-  selectedTaskId: string | null,
-  loadSelectedTask: (taskId: string) => Promise<void>,
-  setError: (value: string) => void,
-) {
-  useEffect(() => {
-    if (!selectedTaskId) return;
-    let active = true;
-    const refresh = () =>
-      loadSelectedTask(selectedTaskId).catch((err: unknown) => {
-        if (active) setError(getErrorMessage(err));
-      });
-    refresh();
-    const timer = setInterval(refresh, 3000);
-    return () => {
-      active = false;
-      clearInterval(timer);
-    };
-  }, [selectedTaskId, loadSelectedTask, setError]);
-}
+import {
+  useInitialRepositories,
+  useRepositories,
+  useSelectedTaskPolling,
+  useTaskLoaders,
+  useTaskPolling,
+  useTaskState,
+} from './useTaskPlanningState';
 
 function getFlowFlags(getAction: (id: TaskFlowActionId) => unknown) {
   return {
@@ -221,8 +80,14 @@ function sortArtifacts(selected: TaskPlanningSnapshot | null) {
 }
 
 function usePlanningLoaders(base: ReturnType<typeof usePlanningBaseState>) {
+  const selectedRepository = findSelectedRepository(
+    base.repositoryState.repositories,
+    base.repositoryState.draft.repository,
+  );
   const loaders = useTaskLoaders({
     selectedTaskId: base.taskState.selectedTaskId,
+    isNewTaskOpen: base.taskState.isNewTaskOpen,
+    selectedRepository,
     setTasks: base.taskState.setTasks,
     setSelectedTaskId: base.taskState.setSelectedTaskId,
     setSelectedSnapshot: base.taskState.setSelectedSnapshot,
@@ -261,6 +126,7 @@ function usePlanningActions(
     setDraft: base.repositoryState.setDraft,
     setTasks: base.taskState.setTasks,
     setSelectedTaskId: base.taskState.setSelectedTaskId,
+    setIsNewTaskOpen: base.taskState.setIsNewTaskOpen,
     setSelectedSnapshot: base.taskState.setSelectedSnapshot,
     setMessageBody: base.setMessageBody,
     setBusyAction: base.setBusyAction,

--- a/packages/along-web/src/task-planning/useTaskPlanningState.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningState.ts
@@ -1,0 +1,214 @@
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { TaskPlanningSnapshot } from '../types';
+import {
+  type DraftTaskInput,
+  emptyDraft,
+  mergeSnapshotIntoList,
+  type RepositoryListResponse,
+  type RepositoryOption,
+  readJsonResponse,
+} from './api';
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function useTaskState() {
+  const [tasks, setTasks] = useState<TaskPlanningSnapshot[]>([]);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [isNewTaskOpen, setIsNewTaskOpen] = useState(false);
+  const [selectedSnapshot, setSelectedSnapshot] =
+    useState<TaskPlanningSnapshot | null>(null);
+  const selected = isNewTaskOpen
+    ? null
+    : selectedSnapshot ||
+      tasks.find((snapshot) => snapshot.task.taskId === selectedTaskId) ||
+      null;
+  return {
+    tasks,
+    setTasks,
+    selected,
+    selectedTaskId,
+    setSelectedTaskId,
+    isNewTaskOpen,
+    setIsNewTaskOpen,
+    selectedSnapshot,
+    setSelectedSnapshot,
+  };
+}
+
+export function useRepositories() {
+  const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
+  const [draft, setDraft] = useState<DraftTaskInput>(emptyDraft);
+  const loadRepositories = useCallback(async () => {
+    const response = await fetch('/api/repositories');
+    const result = await readJsonResponse<RepositoryListResponse>(response);
+    setRepositories(result.repositories);
+    setDraft((previous) => {
+      if (previous.repository) return previous;
+      return {
+        ...previous,
+        repository:
+          result.defaultRepository || result.repositories[0]?.fullName || '',
+      };
+    });
+  }, []);
+  return { repositories, setRepositories, draft, setDraft, loadRepositories };
+}
+
+export type TaskLoaderInput = {
+  selectedTaskId: string | null;
+  isNewTaskOpen: boolean;
+  selectedRepository?: RepositoryOption;
+  setTasks: Dispatch<SetStateAction<TaskPlanningSnapshot[]>>;
+  setSelectedTaskId: Dispatch<SetStateAction<string | null>>;
+  setSelectedSnapshot: Dispatch<SetStateAction<TaskPlanningSnapshot | null>>;
+};
+
+export function useTaskLoaders(input: TaskLoaderInput) {
+  return {
+    loadTasks: useLoadTasks(input),
+    loadSelectedTask: useLoadSelectedTask(input),
+  };
+}
+
+function useLoadTasks(input: TaskLoaderInput) {
+  const state = useLoadTaskState(input);
+  return useCallback(() => loadTasksForState(state), [state]);
+}
+
+function useLoadTaskState(input: TaskLoaderInput) {
+  const {
+    isNewTaskOpen,
+    selectedRepository,
+    selectedTaskId,
+    setSelectedSnapshot,
+    setSelectedTaskId,
+    setTasks,
+  } = input;
+  return useMemo(
+    () => ({
+      isNewTaskOpen,
+      selectedRepository,
+      selectedTaskId,
+      setSelectedSnapshot,
+      setSelectedTaskId,
+      setTasks,
+    }),
+    [
+      isNewTaskOpen,
+      selectedRepository,
+      selectedTaskId,
+      setSelectedSnapshot,
+      setSelectedTaskId,
+      setTasks,
+    ],
+  );
+}
+
+async function loadTasksForState(input: TaskLoaderInput) {
+  if (!input.selectedRepository) {
+    input.setTasks([]);
+    input.setSelectedTaskId(null);
+    input.setSelectedSnapshot(null);
+    return;
+  }
+  const params = new URLSearchParams({
+    limit: '100',
+    owner: input.selectedRepository.owner,
+    repo: input.selectedRepository.repo,
+  });
+  const response = await fetch(`/api/tasks?${params.toString()}`);
+  const snapshots = await readJsonResponse<TaskPlanningSnapshot[]>(response);
+  input.setTasks(snapshots);
+  updateSelectedTaskAfterLoad(input, snapshots);
+}
+
+function updateSelectedTaskAfterLoad(
+  input: TaskLoaderInput,
+  snapshots: TaskPlanningSnapshot[],
+) {
+  const selectedStillVisible = snapshots.some(
+    (snapshot) => snapshot.task.taskId === input.selectedTaskId,
+  );
+  if (input.selectedTaskId && !selectedStillVisible) {
+    input.setSelectedTaskId(null);
+    input.setSelectedSnapshot(null);
+  }
+  if (!input.selectedTaskId && !input.isNewTaskOpen && snapshots.length > 0) {
+    input.setSelectedTaskId(snapshots[0].task.taskId);
+    input.setSelectedSnapshot(snapshots[0]);
+  }
+}
+
+function useLoadSelectedTask(input: TaskLoaderInput) {
+  const loadSelectedTask = useCallback(
+    async (taskId: string) => {
+      const response = await fetch(`/api/tasks/${taskId}`);
+      const snapshot = await readJsonResponse<TaskPlanningSnapshot>(response);
+      input.setSelectedSnapshot(snapshot);
+      input.setTasks((previous) => mergeSnapshotIntoList(previous, snapshot));
+    },
+    [input.setSelectedSnapshot, input.setTasks],
+  );
+  return loadSelectedTask;
+}
+
+export function useInitialRepositories(
+  loadRepositories: () => Promise<void>,
+  setError: (value: string) => void,
+) {
+  useEffect(() => {
+    loadRepositories().catch((err: unknown) => setError(getErrorMessage(err)));
+  }, [loadRepositories, setError]);
+}
+
+export function useTaskPolling(
+  loadTasks: () => Promise<void>,
+  setError: (value: string) => void,
+) {
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    loadTasks()
+      .catch((err: unknown) => active && setError(getErrorMessage(err)))
+      .finally(() => active && setLoading(false));
+    const timer = setInterval(() => {
+      loadTasks().catch((err: unknown) => setError(getErrorMessage(err)));
+    }, 3000);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [loadTasks, setError]);
+  return loading;
+}
+
+export function useSelectedTaskPolling(
+  selectedTaskId: string | null,
+  loadSelectedTask: (taskId: string) => Promise<void>,
+  setError: (value: string) => void,
+) {
+  useEffect(() => {
+    if (!selectedTaskId) return;
+    let active = true;
+    const refresh = () =>
+      loadSelectedTask(selectedTaskId).catch((err: unknown) => {
+        if (active) setError(getErrorMessage(err));
+      });
+    refresh();
+    const timer = setInterval(refresh, 3000);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [selectedTaskId, loadSelectedTask, setError]);
+}

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -120,6 +120,20 @@ const mockDbState = vi.hoisted(() => {
             .slice(0, Number(args[0]))
             .map((row) => ({ task_id: row.task_id }));
         }
+        if (
+          normalized ===
+          'SELECT task_id FROM task_items WHERE repo_owner = ? AND repo_name = ? ORDER BY updated_at DESC LIMIT ?'
+        ) {
+          return state.tasks
+            .filter(
+              (row) => row.repo_owner === args[0] && row.repo_name === args[1],
+            )
+            .sort((a, b) =>
+              String(b.updated_at).localeCompare(String(a.updated_at)),
+            )
+            .slice(0, Number(args[2]))
+            .map((row) => ({ task_id: row.task_id }));
+        }
         if (normalized.includes('FROM task_artifacts WHERE thread_id = ?')) {
           return state.artifacts.filter((row) => row.thread_id === args[0]);
         }
@@ -1073,5 +1087,32 @@ describe('task-planning', () => {
     expect(list.data.map((item) => item.task.title)).toEqual(
       expect.arrayContaining(['第一个任务', '第二个任务']),
     );
+  });
+
+  it('当按仓库列出 Task Planning 快照时，期望只返回当前仓库任务', () => {
+    const first = createPlanningTask({
+      title: 'Along 任务',
+      body: '当前仓库的 planning task。',
+      source: 'test',
+      repoOwner: 'ranwawa',
+      repoName: 'along',
+    });
+    expect(first.success).toBe(true);
+    const second = createPlanningTask({
+      title: '其他仓库任务',
+      body: '另一个仓库的 planning task。',
+      source: 'test',
+      repoOwner: 'ranwawa',
+      repoName: 'other',
+    });
+    expect(second.success).toBe(true);
+
+    const list = listTaskPlanningSnapshots(10, {
+      repoOwner: 'ranwawa',
+      repoName: 'along',
+    });
+    expect(list.success).toBe(true);
+    if (!list.success) throw new Error(list.error);
+    expect(list.data.map((item) => item.task.title)).toEqual(['Along 任务']);
   });
 });

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -1796,6 +1796,7 @@ export function readTaskPlanningSnapshot(
 
 export function listTaskPlanningSnapshots(
   limit = 100,
+  filter: { repoOwner?: string; repoName?: string } = {},
 ): Result<TaskPlanningSnapshot[]> {
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
@@ -1803,11 +1804,21 @@ export function listTaskPlanningSnapshots(
 
   try {
     const safeLimit = Math.max(1, Math.min(500, Math.floor(limit)));
-    const rows = db
-      .prepare(
-        'SELECT task_id FROM task_items ORDER BY updated_at DESC LIMIT ?',
-      )
-      .all(safeLimit) as TaskIdRow[];
+    const rows =
+      filter.repoOwner && filter.repoName
+        ? (db
+            .prepare(
+              `SELECT task_id FROM task_items
+               WHERE repo_owner = ? AND repo_name = ?
+               ORDER BY updated_at DESC
+               LIMIT ?`,
+            )
+            .all(filter.repoOwner, filter.repoName, safeLimit) as TaskIdRow[])
+        : (db
+            .prepare(
+              'SELECT task_id FROM task_items ORDER BY updated_at DESC LIMIT ?',
+            )
+            .all(safeLimit) as TaskIdRow[]);
     const snapshots: TaskPlanningSnapshot[] = [];
 
     for (const row of rows) {

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -1,0 +1,261 @@
+import type { Result } from '../core/result';
+import {
+  approveCurrentTaskPlan,
+  completeDeliveredTask,
+  completeTaskAgentStageManually,
+  createPlanningTask,
+  listTaskPlanningSnapshots,
+  readTaskPlanningSnapshot,
+  submitTaskMessage,
+  type TaskPlanningSnapshot,
+} from '../domain/task-planning';
+import type { TaskApiContext } from './task-api';
+import {
+  deriveTitle,
+  errorResponse,
+  getTaskRepositoryFields,
+  jsonResponse,
+  readJsonObject,
+  readOptionalPositiveIntField,
+  readPositiveInt,
+  readStringField,
+  readTaskAgentStageField,
+  resolveTaskCwd,
+  scheduleDeliveryIfNeeded,
+  scheduleImplementationIfNeeded,
+  schedulePlannerIfNeeded,
+  type UnknownRecord,
+} from './task-api-utils';
+
+export function handleTaskListRequest(url: URL): Response {
+  const limit = readPositiveInt(url.searchParams.get('limit'), 100);
+  const repoOwner = url.searchParams.get('owner')?.trim() || undefined;
+  const repoName = url.searchParams.get('repo')?.trim() || undefined;
+  const listRes = listTaskPlanningSnapshots(limit, { repoOwner, repoName });
+  return listRes.success
+    ? jsonResponse(listRes.data)
+    : errorResponse(listRes.error, 500);
+}
+
+export async function handleTaskCreateRequest(
+  req: Request,
+  context: TaskApiContext,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+
+  const taskBody = readStringField(bodyRes.data, 'body');
+  if (!taskBody) return errorResponse('Task 内容不能为空', 400);
+
+  const createRes = createTaskFromPayload(bodyRes.data, context, taskBody);
+  if (!createRes.success) return errorResponse(createRes.error, 400);
+
+  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
+    taskId: createRes.data.task.taskId,
+    reason: 'task_created',
+  });
+  if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
+
+  return jsonResponse(
+    buildScheduledPayload(createRes.data.task.taskId, scheduledRes.data, {
+      snapshot: createRes.data,
+    }),
+    scheduledRes.data ? 202 : 201,
+  );
+}
+
+function createTaskFromPayload(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  taskBody: string,
+): Result<TaskPlanningSnapshot> {
+  const cwdRes = resolveTaskCwd(payload, context);
+  if (!cwdRes.success) return cwdRes;
+  const repository = getTaskRepositoryFields(payload, context, cwdRes.data);
+  return createPlanningTask({
+    title: readStringField(payload, 'title') || deriveTitle(taskBody),
+    body: taskBody,
+    source: readStringField(payload, 'source') || 'web',
+    repoOwner: repository.repoOwner,
+    repoName: repository.repoName,
+    cwd: cwdRes.data,
+  });
+}
+
+export function handleTaskGetRequest(taskId: string): Response {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  return jsonResponse(snapshotRes.data);
+}
+
+export async function handleTaskMessageRequest(
+  req: Request,
+  taskId: string,
+  context: TaskApiContext,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+
+  const message = readStringField(bodyRes.data, 'body');
+  if (!message) return errorResponse('用户消息不能为空', 400);
+
+  const submitRes = submitTaskMessage({ taskId, body: message });
+  if (!submitRes.success) return errorResponse(submitRes.error, 409);
+
+  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
+    taskId,
+    reason: 'user_message',
+  });
+  if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
+
+  return readSnapshotForMessage(taskId, scheduledRes.data, submitRes.data);
+}
+
+function readSnapshotForMessage(
+  taskId: string,
+  scheduled: boolean,
+  submitted: unknown,
+): Response {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  return jsonResponse(
+    buildScheduledPayload(taskId, scheduled, {
+      submitted,
+      snapshot: snapshotRes.data,
+    }),
+    scheduled ? 202 : 200,
+  );
+}
+
+export function handleTaskApproveRequest(taskId: string): Response {
+  const approveRes = approveCurrentTaskPlan(taskId);
+  if (!approveRes.success) return errorResponse(approveRes.error, 409);
+
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+
+  return jsonResponse({
+    taskId,
+    approvedPlan: approveRes.data,
+    snapshot: snapshotRes.data,
+  });
+}
+
+export async function handleTaskPlannerRequest(
+  req: Request,
+  taskId: string,
+  context: TaskApiContext,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+  const snapshotError = readExistingTaskError(taskId);
+  if (snapshotError) return snapshotError;
+
+  const scheduledRes = schedulePlannerIfNeeded(
+    { ...bodyRes.data, autoRun: true },
+    context,
+    { taskId, reason: 'manual' },
+  );
+  if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
+  if (!scheduledRes.data) return errorResponse('Planner 调度器未启用', 503);
+
+  return jsonResponse({ taskId, scheduled: true }, 202);
+}
+
+export async function handleTaskImplementationRequest(
+  req: Request,
+  taskId: string,
+  context: TaskApiContext,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  if (!snapshotRes.data.thread.approvedPlanId) {
+    return errorResponse('当前 Task 没有已批准方案，不能开始实现', 409);
+  }
+
+  const scheduledRes = scheduleImplementationIfNeeded(bodyRes.data, context, {
+    taskId,
+    reason: 'manual',
+  });
+  return scheduledResponse(taskId, scheduledRes, 'Implementation 调度器未启用');
+}
+
+export async function handleTaskDeliveryRequest(
+  req: Request,
+  taskId: string,
+  context: TaskApiContext,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  if (snapshotRes.data.task.status !== 'implemented') {
+    return errorResponse('当前 Task 只有在已实现后才能交付', 409);
+  }
+
+  const scheduledRes = scheduleDeliveryIfNeeded(bodyRes.data, context, {
+    taskId,
+    reason: 'manual',
+  });
+  return scheduledResponse(taskId, scheduledRes, 'Delivery 调度器未启用');
+}
+
+export async function handleTaskManualCompleteRequest(
+  req: Request,
+  taskId: string,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+
+  const stage = readTaskAgentStageField(bodyRes.data, 'stage');
+  if (!stage) {
+    return errorResponse('stage 必须是 planning/implementation/delivery', 400);
+  }
+
+  const completeRes = completeTaskAgentStageManually({
+    taskId,
+    stage,
+    message: readStringField(bodyRes.data, 'message'),
+    prUrl: readStringField(bodyRes.data, 'prUrl'),
+    prNumber: readOptionalPositiveIntField(bodyRes.data, 'prNumber'),
+  });
+  if (!completeRes.success) return errorResponse(completeRes.error, 409);
+
+  return jsonResponse({ taskId, snapshot: completeRes.data });
+}
+
+export function handleTaskCompleteRequest(taskId: string): Response {
+  const completeRes = completeDeliveredTask(taskId);
+  if (!completeRes.success) return errorResponse(completeRes.error, 409);
+  return jsonResponse({ taskId, snapshot: completeRes.data });
+}
+
+function readExistingTaskError(taskId: string): Response | null {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  return null;
+}
+
+function scheduledResponse(
+  taskId: string,
+  scheduledRes: Result<boolean>,
+  disabledMessage: string,
+): Response {
+  if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
+  if (!scheduledRes.data) return errorResponse(disabledMessage, 503);
+  return jsonResponse({ taskId, scheduled: true }, 202);
+}
+
+function buildScheduledPayload(
+  taskId: string,
+  scheduled: boolean,
+  extra: UnknownRecord,
+) {
+  return { taskId, scheduled, ...extra };
+}

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { handleTaskApiRequest } from './task-api';
+import {
+  expectScheduledDelivery,
+  expectScheduledRunner,
+  jsonRequest,
+  type PlanningMocks,
+  resetPlanningMocks,
+  snapshot,
+} from './task-api.test-utils';
+
+const planningMocks: PlanningMocks = vi.hoisted(() => ({
+  approveCurrentTaskPlan: vi.fn(),
+  completeDeliveredTask: vi.fn(),
+  completeTaskAgentStageManually: vi.fn(),
+  createPlanningTask: vi.fn(),
+  listTaskPlanningSnapshots: vi.fn(),
+  readTaskAgentBinding: vi.fn(),
+  readTaskPlanningSnapshot: vi.fn(),
+  submitTaskMessage: vi.fn(),
+}));
+
+vi.mock('../domain/task-planning', () => ({
+  TASK_AGENT_STAGE: {
+    PLANNING: 'planning',
+    IMPLEMENTATION: 'implementation',
+    DELIVERY: 'delivery',
+  },
+  approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  completeDeliveredTask: planningMocks.completeDeliveredTask,
+  completeTaskAgentStageManually: planningMocks.completeTaskAgentStageManually,
+  createPlanningTask: planningMocks.createPlanningTask,
+  listTaskPlanningSnapshots: planningMocks.listTaskPlanningSnapshots,
+  readTaskAgentBinding: planningMocks.readTaskAgentBinding,
+  readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
+  submitTaskMessage: planningMocks.submitTaskMessage,
+}));
+
+beforeEach(() => resetPlanningMocks(planningMocks));
+
+it('当手动重新规划且请求未带 cwd 时，期望复用 Task 保存的 cwd', async () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: {
+      ...snapshot,
+      task: { ...snapshot.task, cwd: '/tmp/kinkeeper' },
+    },
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/planner', {}),
+    new URL('http://localhost/api/tasks/task-1/planner'),
+    {
+      defaultCwd: '/tmp/default',
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expectScheduledRunner(scheduled, '/tmp/kinkeeper', 'manual');
+});
+
+it('当旧 Task 未保存 cwd 时，期望手动重新规划复用 Agent Binding cwd', async () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskAgentBinding.mockReturnValue({
+    success: true,
+    data: {
+      threadId: 'thread-1',
+      agentId: 'planner',
+      provider: 'claude',
+      cwd: '/tmp/binding-repo',
+      updatedAt: '2026-01-01T00:00:01.000Z',
+    },
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/planner', {}),
+    new URL('http://localhost/api/tasks/task-1/planner'),
+    {
+      defaultCwd: '/tmp/default',
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expectScheduledRunner(scheduled, '/tmp/binding-repo', 'manual');
+});
+
+it('当 Task 方案已批准时，期望可以调度 implementation', async () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: approvedSnapshot('/tmp/project', 'planning_approved'),
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/implementation', {}),
+    new URL('http://localhost/api/tasks/task-1/implementation'),
+    {
+      defaultCwd: '/tmp/default',
+      scheduleImplementation: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expectScheduledRunner(scheduled, '/tmp/project', 'manual');
+});
+
+it('当 Task 已实现时，期望可以调度 delivery', async () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: approvedSnapshot('/tmp/project', 'implemented'),
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/delivery', {}),
+    new URL('http://localhost/api/tasks/task-1/delivery'),
+    {
+      defaultCwd: '/tmp/default',
+      scheduleDelivery: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expectScheduledDelivery(scheduled, '/tmp/project');
+});
+
+function approvedSnapshot(cwd: string, status: string) {
+  return {
+    ...snapshot,
+    task: {
+      ...snapshot.task,
+      status,
+      cwd,
+      repoOwner: 'ranwawa',
+      repoName: 'along',
+    },
+    thread: {
+      ...snapshot.thread,
+      status: 'approved',
+      approvedPlanId: 'plan-1',
+    },
+  };
+}

--- a/packages/along/src/integration/task-api-utils.ts
+++ b/packages/along/src/integration/task-api-utils.ts
@@ -1,0 +1,244 @@
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
+import {
+  readTaskAgentBinding,
+  readTaskPlanningSnapshot,
+  TASK_AGENT_STAGE,
+  type TaskAgentStage,
+  type TaskPlanningSnapshot,
+} from '../domain/task-planning';
+import type {
+  ScheduledTaskDeliveryRun,
+  ScheduledTaskImplementationRun,
+  ScheduledTaskPlanningRun,
+  TaskApiContext,
+} from './task-api';
+
+export type UnknownRecord = Record<string, unknown>;
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}
+
+export function errorResponse(error: string, status = 400): Response {
+  return jsonResponse({ error }, status);
+}
+
+export async function readJsonObject(
+  req: Request,
+): Promise<Result<UnknownRecord>> {
+  try {
+    const parsed = await req.json();
+    return isRecord(parsed)
+      ? success(parsed)
+      : failure('请求体必须是 JSON 对象');
+  } catch {
+    return failure('请求体必须是合法 JSON');
+  }
+}
+
+export function readStringField(
+  payload: UnknownRecord,
+  key: string,
+): string | undefined {
+  const value = payload[key];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function readBooleanField(
+  payload: UnknownRecord,
+  key: string,
+): boolean | undefined {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+export function readTaskAgentStageField(
+  payload: UnknownRecord,
+  key: string,
+): TaskAgentStage | undefined {
+  const value = readStringField(payload, key);
+  if (
+    value === TASK_AGENT_STAGE.PLANNING ||
+    value === TASK_AGENT_STAGE.IMPLEMENTATION ||
+    value === TASK_AGENT_STAGE.DELIVERY
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+export function readOptionalPositiveIntField(
+  payload: UnknownRecord,
+  key: string,
+): number | undefined {
+  const value = payload[key];
+  if (typeof value !== 'number') return undefined;
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+export function readPositiveInt(
+  value: string | null,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+export function deriveTitle(body: string): string {
+  const firstLine = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean);
+  const title = firstLine || 'Untitled Task';
+  return title.length > 80 ? `${title.slice(0, 80)}...` : title;
+}
+
+export function resolveTaskCwd(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  taskId?: string,
+): Result<string> {
+  const explicitCwd = readStringField(payload, 'cwd');
+  if (explicitCwd) return success(explicitCwd);
+
+  const repoPathRes = resolveRepoPathFromPayload(payload, context);
+  if (repoPathRes) return repoPathRes;
+
+  if (taskId) {
+    const savedCwdRes = resolveTaskSavedCwd(payload, taskId);
+    if (!savedCwdRes.success || savedCwdRes.data) return savedCwdRes;
+  }
+
+  return success(context.defaultCwd);
+}
+
+function resolveRepoPathFromPayload(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+): Result<string> | null {
+  const owner = readStringField(payload, 'owner');
+  const repo = readStringField(payload, 'repo');
+  if (!owner || !repo || !context.resolveRepoPath) return null;
+  const repoPath = context.resolveRepoPath(owner, repo);
+  if (!repoPath) return failure(`仓库 ${owner}/${repo} 未在本地工作区中注册`);
+  return success(repoPath);
+}
+
+function resolveTaskSavedCwd(
+  payload: UnknownRecord,
+  taskId: string,
+): Result<string | undefined> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  const snapshot = snapshotRes.data;
+  if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  if (snapshot.task.cwd) return success(snapshot.task.cwd);
+  return resolveTaskBindingCwd(payload, snapshot);
+}
+
+function resolveTaskBindingCwd(
+  payload: UnknownRecord,
+  snapshot: TaskPlanningSnapshot,
+): Result<string | undefined> {
+  const bindingRes = readTaskAgentBinding(
+    snapshot.thread.threadId,
+    readStringField(payload, 'agentId') || 'planner',
+    'claude',
+  );
+  if (!bindingRes.success) return bindingRes;
+  return success(bindingRes.data?.cwd);
+}
+
+export function schedulePlannerIfNeeded(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  input: Omit<
+    ScheduledTaskPlanningRun,
+    'cwd' | 'agentId' | 'model' | 'personalityVersion'
+  >,
+): Result<boolean> {
+  const autoRun = readBooleanField(payload, 'autoRun');
+  if (autoRun === false || !context.schedulePlanner) return success(false);
+
+  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
+  if (!cwdRes.success) return cwdRes;
+
+  context.schedulePlanner({
+    ...input,
+    cwd: cwdRes.data,
+    ...readRunnerOptions(payload),
+  });
+  return success(true);
+}
+
+export function scheduleImplementationIfNeeded(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  input: Omit<
+    ScheduledTaskImplementationRun,
+    'cwd' | 'agentId' | 'model' | 'personalityVersion'
+  >,
+): Result<boolean> {
+  if (!context.scheduleImplementation) return success(false);
+
+  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
+  if (!cwdRes.success) return cwdRes;
+
+  context.scheduleImplementation({
+    ...input,
+    cwd: cwdRes.data,
+    ...readRunnerOptions(payload),
+  });
+  return success(true);
+}
+
+function readRunnerOptions(payload: UnknownRecord) {
+  return {
+    agentId: readStringField(payload, 'agentId'),
+    editor: readStringField(payload, 'editor'),
+    model: readStringField(payload, 'model'),
+    personalityVersion: readStringField(payload, 'personalityVersion'),
+  };
+}
+
+export function scheduleDeliveryIfNeeded(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  input: ScheduledTaskDeliveryRun,
+): Result<boolean> {
+  if (!context.scheduleDelivery) return success(false);
+
+  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
+  if (!cwdRes.success) return cwdRes;
+
+  context.scheduleDelivery({ ...input, cwd: cwdRes.data });
+  return success(true);
+}
+
+export function getTaskRepositoryFields(
+  payload: UnknownRecord,
+  context: TaskApiContext,
+  cwd: string,
+): Pick<TaskPlanningSnapshot['task'], 'repoOwner' | 'repoName'> {
+  const repoOwner = readStringField(payload, 'owner');
+  const repoName = readStringField(payload, 'repo');
+  if (repoOwner && repoName) return { repoOwner, repoName };
+
+  return context.resolveRepositoryForPath?.(cwd) || {};
+}

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -1,0 +1,155 @@
+import { expect, vi } from 'vitest';
+
+type PlanningMock = ReturnType<typeof vi.fn>;
+
+export type PlanningMocks = {
+  approveCurrentTaskPlan: PlanningMock;
+  completeDeliveredTask: PlanningMock;
+  completeTaskAgentStageManually: PlanningMock;
+  createPlanningTask: PlanningMock;
+  listTaskPlanningSnapshots: PlanningMock;
+  readTaskAgentBinding: PlanningMock;
+  readTaskPlanningSnapshot: PlanningMock;
+  submitTaskMessage: PlanningMock;
+};
+
+export const snapshot = {
+  task: {
+    taskId: 'task-1',
+    title: '实现 Task API',
+    body: '通过 Web API 创建 planning task。',
+    source: 'web',
+    status: 'planning',
+    activeThreadId: 'thread-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  thread: {
+    threadId: 'thread-1',
+    taskId: 'task-1',
+    purpose: 'planning',
+    status: 'drafting',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  currentPlan: null,
+  openRound: null,
+  artifacts: [],
+  plans: [],
+};
+
+export function resetPlanningMocks(planningMocks: PlanningMocks) {
+  vi.clearAllMocks();
+  mockTaskReads(planningMocks);
+  mockTaskMessage(planningMocks);
+  mockPlanApproval(planningMocks);
+  mockManualComplete(planningMocks);
+  mockDeliveredComplete(planningMocks);
+}
+
+function mockTaskReads(planningMocks: PlanningMocks) {
+  planningMocks.createPlanningTask.mockReturnValue({
+    success: true,
+    data: snapshot,
+  });
+  planningMocks.listTaskPlanningSnapshots.mockReturnValue({
+    success: true,
+    data: [snapshot],
+  });
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: snapshot,
+  });
+  planningMocks.readTaskAgentBinding.mockReturnValue({
+    success: true,
+    data: null,
+  });
+}
+
+function mockTaskMessage(planningMocks: PlanningMocks) {
+  planningMocks.submitTaskMessage.mockReturnValue({
+    success: true,
+    data: {
+      artifact: {
+        artifactId: 'art-user',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        type: 'user_message',
+        role: 'user',
+        body: '继续讨论',
+        metadata: {},
+        createdAt: '2026-01-01T00:00:01.000Z',
+      },
+      round: null,
+    },
+  });
+}
+
+function mockPlanApproval(planningMocks: PlanningMocks) {
+  planningMocks.approveCurrentTaskPlan.mockReturnValue({
+    success: true,
+    data: {
+      planId: 'plan-1',
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      version: 1,
+      status: 'approved',
+      artifactId: 'art-plan',
+      body: '## Plan',
+      createdAt: '2026-01-01T00:00:01.000Z',
+    },
+  });
+}
+
+function mockManualComplete(planningMocks: PlanningMocks) {
+  planningMocks.completeTaskAgentStageManually.mockReturnValue({
+    success: true,
+    data: {
+      ...snapshot,
+      task: { ...snapshot.task, status: 'implemented' },
+    },
+  });
+}
+
+function mockDeliveredComplete(planningMocks: PlanningMocks) {
+  planningMocks.completeDeliveredTask.mockReturnValue({
+    success: true,
+    data: {
+      ...snapshot,
+      task: { ...snapshot.task, status: 'completed' },
+    },
+  });
+}
+
+export function jsonRequest(
+  pathname: string,
+  body: Record<string, unknown>,
+): Request {
+  return new Request(`http://localhost${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function expectScheduledRunner(
+  scheduled: unknown[],
+  cwd: string,
+  reason: 'task_created' | 'user_message' | 'manual',
+) {
+  expect(scheduled).toEqual([
+    {
+      taskId: 'task-1',
+      cwd,
+      reason,
+      agentId: undefined,
+      editor: undefined,
+      model: undefined,
+      personalityVersion: undefined,
+    },
+  ]);
+}
+
+export function expectScheduledDelivery(scheduled: unknown[], cwd: string) {
+  expect(scheduled).toEqual([{ taskId: 'task-1', cwd, reason: 'manual' }]);
+}

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -1,6 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { handleTaskApiRequest, isTaskApiPath } from './task-api';
+import {
+  expectScheduledRunner,
+  jsonRequest,
+  type PlanningMocks,
+  resetPlanningMocks,
+  type snapshot,
+} from './task-api.test-utils';
 
-const planningMocks = vi.hoisted(() => ({
+const planningMocks: PlanningMocks = vi.hoisted(() => ({
   approveCurrentTaskPlan: vi.fn(),
   completeDeliveredTask: vi.fn(),
   completeTaskAgentStageManually: vi.fn(),
@@ -27,459 +35,194 @@ vi.mock('../domain/task-planning', () => ({
   submitTaskMessage: planningMocks.submitTaskMessage,
 }));
 
-import { handleTaskApiRequest, isTaskApiPath } from './task-api';
+beforeEach(() => resetPlanningMocks(planningMocks));
 
-const snapshot = {
-  task: {
+it('当路径属于 Task API 时，期望能识别', () => {
+  expect(isTaskApiPath('/api/tasks')).toBe(true);
+  expect(isTaskApiPath('/api/tasks/task-1/messages')).toBe(true);
+  expect(isTaskApiPath('/api/sessions')).toBe(false);
+});
+
+it('当读取 Task 列表带仓库参数时，期望按仓库传给查询层', async () => {
+  const url = 'http://localhost/api/tasks?limit=20&owner=ranwawa&repo=along';
+  const response = await handleTaskApiRequest(new Request(url), new URL(url), {
+    defaultCwd: '/tmp/default',
+  });
+
+  expect(response.status).toBe(200);
+  expect(planningMocks.listTaskPlanningSnapshots).toHaveBeenCalledWith(20, {
+    repoOwner: 'ranwawa',
+    repoName: 'along',
+  });
+});
+
+it('当创建 Task 时，期望返回 202 并调度 planner', async () => {
+  const scheduled: unknown[] = [];
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks', {
+      body: '通过 Web API 创建 planning task。',
+      owner: 'ranwawa',
+      repo: 'along',
+    }),
+    new URL('http://localhost/api/tasks'),
+    {
+      defaultCwd: '/tmp/default',
+      resolveRepoPath: () => '/tmp/along',
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  await expectCreatedTask(response, true);
+  expectCreatedTaskFields('/tmp/along');
+  expectScheduledRunner(scheduled, '/tmp/along', 'task_created');
+});
+
+it('当创建 Task 未带 owner/repo 时，期望从默认 cwd 反查仓库并落库', async () => {
+  const scheduled: unknown[] = [];
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks', { body: '通过默认仓库创建 planning task。' }),
+    new URL('http://localhost/api/tasks'),
+    {
+      defaultCwd: '/tmp/along/packages/along',
+      resolveRepositoryForPath: expectDefaultRepositoryLookup,
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expectDefaultCreatedTaskFields();
+  expectScheduledRunner(scheduled, '/tmp/along/packages/along', 'task_created');
+});
+
+it('当追加用户消息时，期望记录消息并调度同一个 Task planner', async () => {
+  const scheduled: unknown[] = [];
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/messages', {
+      body: '继续讨论这个方案。',
+      cwd: '/tmp/project',
+    }),
+    new URL('http://localhost/api/tasks/task-1/messages'),
+    {
+      defaultCwd: '/tmp/default',
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expect(planningMocks.submitTaskMessage).toHaveBeenCalledWith({
     taskId: 'task-1',
-    title: '实现 Task API',
+    body: '继续讨论这个方案。',
+  });
+  expectScheduledRunner(scheduled, '/tmp/project', 'user_message');
+});
+
+it('当批准 Task Plan 时，期望不再调度 planner', async () => {
+  const scheduled: unknown[] = [];
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/approve', {}),
+    new URL('http://localhost/api/tasks/task-1/approve'),
+    {
+      defaultCwd: '/tmp/default',
+      schedulePlanner: (input) => scheduled.push(input),
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(planningMocks.approveCurrentTaskPlan).toHaveBeenCalledWith('task-1');
+  expect(scheduled).toEqual([]);
+});
+
+it('当人工标记实现阶段已处理时，期望返回更新后的 snapshot', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/manual-complete', {
+      stage: 'implementation',
+      message: '已在 editor 中完成验证。',
+    }),
+    new URL('http://localhost/api/tasks/task-1/manual-complete'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as {
+    taskId: string;
+    snapshot: typeof snapshot;
+  };
+
+  expect(response.status).toBe(200);
+  expect(payload.taskId).toBe('task-1');
+  expect(planningMocks.completeTaskAgentStageManually).toHaveBeenCalledWith({
+    taskId: 'task-1',
+    stage: 'implementation',
+    message: '已在 editor 中完成验证。',
+    prUrl: undefined,
+    prNumber: undefined,
+  });
+});
+
+it('当验收已交付 Task 时，期望返回完成后的 snapshot', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/complete', {}),
+    new URL('http://localhost/api/tasks/task-1/complete'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as {
+    taskId: string;
+    snapshot: typeof snapshot;
+  };
+
+  expect(response.status).toBe(200);
+  expect(payload.taskId).toBe('task-1');
+  expect(planningMocks.completeDeliveredTask).toHaveBeenCalledWith('task-1');
+});
+
+it('当读取不存在的 Task 时，期望返回 404', async () => {
+  planningMocks.readTaskPlanningSnapshot.mockReturnValueOnce({
+    success: true,
+    data: null,
+  });
+
+  const response = await handleTaskApiRequest(
+    new Request('http://localhost/api/tasks/missing'),
+    new URL('http://localhost/api/tasks/missing'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as { error: string };
+
+  expect(response.status).toBe(404);
+  expect(payload.error).toBe('Task 不存在: missing');
+});
+
+async function expectCreatedTask(response: Response, scheduled: boolean) {
+  const payload = (await response.json()) as {
+    taskId: string;
+    scheduled: boolean;
+  };
+  expect(response.status).toBe(scheduled ? 202 : 201);
+  expect(payload.taskId).toBe('task-1');
+  expect(payload.scheduled).toBe(scheduled);
+}
+
+function expectCreatedTaskFields(cwd: string) {
+  expect(planningMocks.createPlanningTask).toHaveBeenCalledWith({
+    title: '通过 Web API 创建 planning task。',
     body: '通过 Web API 创建 planning task。',
     source: 'web',
-    status: 'planning',
-    activeThreadId: 'thread-1',
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  },
-  thread: {
-    threadId: 'thread-1',
-    taskId: 'task-1',
-    purpose: 'planning',
-    status: 'drafting',
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-  },
-  currentPlan: null,
-  openRound: null,
-  artifacts: [],
-  plans: [],
-};
-
-function jsonRequest(pathname: string, body: Record<string, unknown>): Request {
-  return new Request(`http://localhost${pathname}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    repoOwner: 'ranwawa',
+    repoName: 'along',
+    cwd,
   });
 }
 
-describe('task-api', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    planningMocks.createPlanningTask.mockReturnValue({
-      success: true,
-      data: snapshot,
-    });
-    planningMocks.listTaskPlanningSnapshots.mockReturnValue({
-      success: true,
-      data: [snapshot],
-    });
-    planningMocks.readTaskPlanningSnapshot.mockReturnValue({
-      success: true,
-      data: snapshot,
-    });
-    planningMocks.readTaskAgentBinding.mockReturnValue({
-      success: true,
-      data: null,
-    });
-    planningMocks.submitTaskMessage.mockReturnValue({
-      success: true,
-      data: {
-        artifact: {
-          artifactId: 'art-user',
-          taskId: 'task-1',
-          threadId: 'thread-1',
-          type: 'user_message',
-          role: 'user',
-          body: '继续讨论',
-          metadata: {},
-          createdAt: '2026-01-01T00:00:01.000Z',
-        },
-        round: null,
-      },
-    });
-    planningMocks.approveCurrentTaskPlan.mockReturnValue({
-      success: true,
-      data: {
-        planId: 'plan-1',
-        taskId: 'task-1',
-        threadId: 'thread-1',
-        version: 1,
-        status: 'approved',
-        artifactId: 'art-plan',
-        body: '## Plan',
-        createdAt: '2026-01-01T00:00:01.000Z',
-      },
-    });
-    planningMocks.completeTaskAgentStageManually.mockReturnValue({
-      success: true,
-      data: {
-        ...snapshot,
-        task: {
-          ...snapshot.task,
-          status: 'implemented',
-        },
-      },
-    });
-    planningMocks.completeDeliveredTask.mockReturnValue({
-      success: true,
-      data: {
-        ...snapshot,
-        task: {
-          ...snapshot.task,
-          status: 'completed',
-        },
-      },
-    });
+function expectDefaultRepositoryLookup(cwd: string) {
+  expect(cwd).toBe('/tmp/along/packages/along');
+  return { repoOwner: 'ranwawa', repoName: 'along' };
+}
+
+function expectDefaultCreatedTaskFields() {
+  expect(planningMocks.createPlanningTask).toHaveBeenCalledWith({
+    title: '通过默认仓库创建 planning task。',
+    body: '通过默认仓库创建 planning task。',
+    source: 'web',
+    repoOwner: 'ranwawa',
+    repoName: 'along',
+    cwd: '/tmp/along/packages/along',
   });
-
-  it('当路径属于 Task API 时，期望能识别', () => {
-    expect(isTaskApiPath('/api/tasks')).toBe(true);
-    expect(isTaskApiPath('/api/tasks/task-1/messages')).toBe(true);
-    expect(isTaskApiPath('/api/sessions')).toBe(false);
-  });
-
-  it('当创建 Task 时，期望返回 202 并调度 planner', async () => {
-    const scheduled: unknown[] = [];
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks', {
-        body: '通过 Web API 创建 planning task。',
-        owner: 'ranwawa',
-        repo: 'along',
-      }),
-      new URL('http://localhost/api/tasks'),
-      {
-        defaultCwd: '/tmp/default',
-        resolveRepoPath: () => '/tmp/along',
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-    const payload = (await response.json()) as {
-      taskId: string;
-      scheduled: boolean;
-    };
-
-    expect(response.status).toBe(202);
-    expect(payload.taskId).toBe('task-1');
-    expect(payload.scheduled).toBe(true);
-    expect(planningMocks.createPlanningTask).toHaveBeenCalledWith({
-      title: '通过 Web API 创建 planning task。',
-      body: '通过 Web API 创建 planning task。',
-      source: 'web',
-      repoOwner: 'ranwawa',
-      repoName: 'along',
-      cwd: '/tmp/along',
-    });
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/along',
-        reason: 'task_created',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当创建 Task 未带 owner/repo 时，期望从默认 cwd 反查仓库并落库', async () => {
-    const scheduled: unknown[] = [];
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks', {
-        body: '通过默认仓库创建 planning task。',
-      }),
-      new URL('http://localhost/api/tasks'),
-      {
-        defaultCwd: '/tmp/along/packages/along',
-        resolveRepositoryForPath: (cwd) => {
-          expect(cwd).toBe('/tmp/along/packages/along');
-          return { repoOwner: 'ranwawa', repoName: 'along' };
-        },
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(planningMocks.createPlanningTask).toHaveBeenCalledWith({
-      title: '通过默认仓库创建 planning task。',
-      body: '通过默认仓库创建 planning task。',
-      source: 'web',
-      repoOwner: 'ranwawa',
-      repoName: 'along',
-      cwd: '/tmp/along/packages/along',
-    });
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/along/packages/along',
-        reason: 'task_created',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当追加用户消息时，期望记录消息并调度同一个 Task planner', async () => {
-    const scheduled: unknown[] = [];
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/messages', {
-        body: '继续讨论这个方案。',
-        cwd: '/tmp/project',
-      }),
-      new URL('http://localhost/api/tasks/task-1/messages'),
-      {
-        defaultCwd: '/tmp/default',
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(planningMocks.submitTaskMessage).toHaveBeenCalledWith({
-      taskId: 'task-1',
-      body: '继续讨论这个方案。',
-    });
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/project',
-        reason: 'user_message',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当手动重新规划且请求未带 cwd 时，期望复用 Task 保存的 cwd', async () => {
-    const scheduled: unknown[] = [];
-    planningMocks.readTaskPlanningSnapshot.mockReturnValue({
-      success: true,
-      data: {
-        ...snapshot,
-        task: {
-          ...snapshot.task,
-          cwd: '/tmp/kinkeeper',
-          repoOwner: 'ranwawa',
-          repoName: 'kinkeeper',
-        },
-      },
-    });
-
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/planner', {}),
-      new URL('http://localhost/api/tasks/task-1/planner'),
-      {
-        defaultCwd: '/tmp/default',
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/kinkeeper',
-        reason: 'manual',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当旧 Task 未保存 cwd 时，期望手动重新规划复用 Agent Binding cwd', async () => {
-    const scheduled: unknown[] = [];
-    planningMocks.readTaskAgentBinding.mockReturnValue({
-      success: true,
-      data: {
-        threadId: 'thread-1',
-        agentId: 'planner',
-        provider: 'claude',
-        cwd: '/tmp/binding-repo',
-        updatedAt: '2026-01-01T00:00:01.000Z',
-      },
-    });
-
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/planner', {}),
-      new URL('http://localhost/api/tasks/task-1/planner'),
-      {
-        defaultCwd: '/tmp/default',
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/binding-repo',
-        reason: 'manual',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当 Task 方案已批准时，期望可以调度 implementation', async () => {
-    const scheduled: unknown[] = [];
-    planningMocks.readTaskPlanningSnapshot.mockReturnValue({
-      success: true,
-      data: {
-        ...snapshot,
-        task: {
-          ...snapshot.task,
-          status: 'planning_approved',
-          cwd: '/tmp/project',
-        },
-        thread: {
-          ...snapshot.thread,
-          status: 'approved',
-          approvedPlanId: 'plan-1',
-        },
-      },
-    });
-
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/implementation', {}),
-      new URL('http://localhost/api/tasks/task-1/implementation'),
-      {
-        defaultCwd: '/tmp/default',
-        scheduleImplementation: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/project',
-        reason: 'manual',
-        agentId: undefined,
-        editor: undefined,
-        model: undefined,
-        personalityVersion: undefined,
-      },
-    ]);
-  });
-
-  it('当 Task 已实现时，期望可以调度 delivery', async () => {
-    const scheduled: unknown[] = [];
-    planningMocks.readTaskPlanningSnapshot.mockReturnValue({
-      success: true,
-      data: {
-        ...snapshot,
-        task: {
-          ...snapshot.task,
-          status: 'implemented',
-          cwd: '/tmp/project',
-          repoOwner: 'ranwawa',
-          repoName: 'along',
-        },
-        thread: {
-          ...snapshot.thread,
-          status: 'approved',
-          approvedPlanId: 'plan-1',
-        },
-      },
-    });
-
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/delivery', {}),
-      new URL('http://localhost/api/tasks/task-1/delivery'),
-      {
-        defaultCwd: '/tmp/default',
-        scheduleDelivery: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(202);
-    expect(scheduled).toEqual([
-      {
-        taskId: 'task-1',
-        cwd: '/tmp/project',
-        reason: 'manual',
-      },
-    ]);
-  });
-
-  it('当批准 Task Plan 时，期望不再调度 planner', async () => {
-    const scheduled: unknown[] = [];
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/approve', {}),
-      new URL('http://localhost/api/tasks/task-1/approve'),
-      {
-        defaultCwd: '/tmp/default',
-        schedulePlanner: (input) => scheduled.push(input),
-      },
-    );
-
-    expect(response.status).toBe(200);
-    expect(planningMocks.approveCurrentTaskPlan).toHaveBeenCalledWith('task-1');
-    expect(scheduled).toEqual([]);
-  });
-
-  it('当人工标记实现阶段已处理时，期望返回更新后的 snapshot', async () => {
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/manual-complete', {
-        stage: 'implementation',
-        message: '已在 editor 中完成验证。',
-      }),
-      new URL('http://localhost/api/tasks/task-1/manual-complete'),
-      { defaultCwd: '/tmp/default' },
-    );
-    const payload = (await response.json()) as {
-      taskId: string;
-      snapshot: typeof snapshot;
-    };
-
-    expect(response.status).toBe(200);
-    expect(payload.taskId).toBe('task-1');
-    expect(planningMocks.completeTaskAgentStageManually).toHaveBeenCalledWith({
-      taskId: 'task-1',
-      stage: 'implementation',
-      message: '已在 editor 中完成验证。',
-      prUrl: undefined,
-      prNumber: undefined,
-    });
-  });
-
-  it('当验收已交付 Task 时，期望返回完成后的 snapshot', async () => {
-    const response = await handleTaskApiRequest(
-      jsonRequest('/api/tasks/task-1/complete', {}),
-      new URL('http://localhost/api/tasks/task-1/complete'),
-      { defaultCwd: '/tmp/default' },
-    );
-    const payload = (await response.json()) as {
-      taskId: string;
-      snapshot: typeof snapshot;
-    };
-
-    expect(response.status).toBe(200);
-    expect(payload.taskId).toBe('task-1');
-    expect(planningMocks.completeDeliveredTask).toHaveBeenCalledWith('task-1');
-  });
-
-  it('当读取不存在的 Task 时，期望返回 404', async () => {
-    planningMocks.readTaskPlanningSnapshot.mockReturnValueOnce({
-      success: true,
-      data: null,
-    });
-
-    const response = await handleTaskApiRequest(
-      new Request('http://localhost/api/tasks/missing'),
-      new URL('http://localhost/api/tasks/missing'),
-      { defaultCwd: '/tmp/default' },
-    );
-    const payload = (await response.json()) as { error: string };
-
-    expect(response.status).toBe(404);
-    expect(payload.error).toBe('Task 不存在: missing');
-  });
-});
+}

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -1,18 +1,17 @@
-import type { Result } from '../core/result';
-import { failure, success } from '../core/result';
+import type { TaskPlanningSnapshot } from '../domain/task-planning';
 import {
-  approveCurrentTaskPlan,
-  completeDeliveredTask,
-  completeTaskAgentStageManually,
-  createPlanningTask,
-  listTaskPlanningSnapshots,
-  readTaskAgentBinding,
-  readTaskPlanningSnapshot,
-  submitTaskMessage,
-  TASK_AGENT_STAGE,
-  type TaskAgentStage,
-  type TaskPlanningSnapshot,
-} from '../domain/task-planning';
+  handleTaskApproveRequest,
+  handleTaskCompleteRequest,
+  handleTaskCreateRequest,
+  handleTaskDeliveryRequest,
+  handleTaskGetRequest,
+  handleTaskImplementationRequest,
+  handleTaskListRequest,
+  handleTaskManualCompleteRequest,
+  handleTaskMessageRequest,
+  handleTaskPlannerRequest,
+} from './task-api-handlers';
+import { errorResponse } from './task-api-utils';
 
 export interface ScheduledTaskPlanningRun {
   taskId: string;
@@ -51,208 +50,22 @@ export interface TaskApiContext {
   ) => Pick<TaskPlanningSnapshot['task'], 'repoOwner' | 'repoName'> | undefined;
 }
 
-type UnknownRecord = Record<string, unknown>;
+type TaskActionHandler = (
+  req: Request,
+  taskId: string,
+  context: TaskApiContext,
+) => Response | Promise<Response>;
 
-const JSON_HEADERS = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
+const ACTION_ROUTES: Record<string, TaskActionHandler> = {
+  approve: (_req, taskId) => handleTaskApproveRequest(taskId),
+  complete: (_req, taskId) => handleTaskCompleteRequest(taskId),
+  delivery: handleTaskDeliveryRequest,
+  implementation: handleTaskImplementationRequest,
+  'manual-complete': (req, taskId) =>
+    handleTaskManualCompleteRequest(req, taskId),
+  messages: handleTaskMessageRequest,
+  planner: handleTaskPlannerRequest,
 };
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function jsonResponse(payload: unknown, status = 200): Response {
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: JSON_HEADERS,
-  });
-}
-
-function errorResponse(error: string, status = 400): Response {
-  return jsonResponse({ error }, status);
-}
-
-async function readJsonObject(req: Request): Promise<Result<UnknownRecord>> {
-  try {
-    const parsed = await req.json();
-    return isRecord(parsed)
-      ? success(parsed)
-      : failure('请求体必须是 JSON 对象');
-  } catch {
-    return failure('请求体必须是合法 JSON');
-  }
-}
-
-function readStringField(
-  payload: UnknownRecord,
-  key: string,
-): string | undefined {
-  const value = payload[key];
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed || undefined;
-}
-
-function readBooleanField(
-  payload: UnknownRecord,
-  key: string,
-): boolean | undefined {
-  const value = payload[key];
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function readTaskAgentStageField(
-  payload: UnknownRecord,
-  key: string,
-): TaskAgentStage | undefined {
-  const value = readStringField(payload, key);
-  if (
-    value === TASK_AGENT_STAGE.PLANNING ||
-    value === TASK_AGENT_STAGE.IMPLEMENTATION ||
-    value === TASK_AGENT_STAGE.DELIVERY
-  ) {
-    return value;
-  }
-  return undefined;
-}
-
-function readOptionalPositiveIntField(
-  payload: UnknownRecord,
-  key: string,
-): number | undefined {
-  const value = payload[key];
-  if (typeof value !== 'number') return undefined;
-  return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
-}
-
-function readPositiveInt(value: string | null, fallback: number): number {
-  if (!value) return fallback;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
-}
-
-function deriveTitle(body: string): string {
-  const firstLine = body
-    .split('\n')
-    .map((line) => line.trim())
-    .find(Boolean);
-  const title = firstLine || 'Untitled Task';
-  return title.length > 80 ? `${title.slice(0, 80)}...` : title;
-}
-
-function resolveTaskCwd(
-  payload: UnknownRecord,
-  context: TaskApiContext,
-  taskId?: string,
-): Result<string> {
-  const explicitCwd = readStringField(payload, 'cwd');
-  if (explicitCwd) return success(explicitCwd);
-
-  const owner = readStringField(payload, 'owner');
-  const repo = readStringField(payload, 'repo');
-  if (owner && repo && context.resolveRepoPath) {
-    const repoPath = context.resolveRepoPath(owner, repo);
-    if (!repoPath) return failure(`仓库 ${owner}/${repo} 未在本地工作区中注册`);
-    return success(repoPath);
-  }
-
-  if (taskId) {
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return snapshotRes;
-    const snapshot = snapshotRes.data;
-    if (!snapshot) return failure(`Task 不存在: ${taskId}`);
-    if (snapshot.task.cwd) return success(snapshot.task.cwd);
-
-    const bindingRes = readTaskAgentBinding(
-      snapshot.thread.threadId,
-      readStringField(payload, 'agentId') || 'planner',
-      'claude',
-    );
-    if (!bindingRes.success) return bindingRes;
-    if (bindingRes.data?.cwd) return success(bindingRes.data.cwd);
-  }
-
-  return success(context.defaultCwd);
-}
-
-function schedulePlannerIfNeeded(
-  payload: UnknownRecord,
-  context: TaskApiContext,
-  input: Omit<
-    ScheduledTaskPlanningRun,
-    'cwd' | 'agentId' | 'model' | 'personalityVersion'
-  >,
-): Result<boolean> {
-  const autoRun = readBooleanField(payload, 'autoRun');
-  if (autoRun === false || !context.schedulePlanner) return success(false);
-
-  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
-  if (!cwdRes.success) return cwdRes;
-
-  context.schedulePlanner({
-    ...input,
-    cwd: cwdRes.data,
-    agentId: readStringField(payload, 'agentId'),
-    editor: readStringField(payload, 'editor'),
-    model: readStringField(payload, 'model'),
-    personalityVersion: readStringField(payload, 'personalityVersion'),
-  });
-  return success(true);
-}
-
-function scheduleImplementationIfNeeded(
-  payload: UnknownRecord,
-  context: TaskApiContext,
-  input: Omit<
-    ScheduledTaskImplementationRun,
-    'cwd' | 'agentId' | 'model' | 'personalityVersion'
-  >,
-): Result<boolean> {
-  if (!context.scheduleImplementation) return success(false);
-
-  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
-  if (!cwdRes.success) return cwdRes;
-
-  context.scheduleImplementation({
-    ...input,
-    cwd: cwdRes.data,
-    agentId: readStringField(payload, 'agentId'),
-    editor: readStringField(payload, 'editor'),
-    model: readStringField(payload, 'model'),
-    personalityVersion: readStringField(payload, 'personalityVersion'),
-  });
-  return success(true);
-}
-
-function scheduleDeliveryIfNeeded(
-  payload: UnknownRecord,
-  context: TaskApiContext,
-  input: ScheduledTaskDeliveryRun,
-): Result<boolean> {
-  if (!context.scheduleDelivery) return success(false);
-
-  const cwdRes = resolveTaskCwd(payload, context, input.taskId);
-  if (!cwdRes.success) return cwdRes;
-
-  context.scheduleDelivery({
-    ...input,
-    cwd: cwdRes.data,
-  });
-  return success(true);
-}
-
-function getTaskRepositoryFields(
-  payload: UnknownRecord,
-  context: TaskApiContext,
-  cwd: string,
-): Pick<TaskPlanningSnapshot['task'], 'repoOwner' | 'repoName'> {
-  const repoOwner = readStringField(payload, 'owner');
-  const repoName = readStringField(payload, 'repo');
-  if (repoOwner && repoName) return { repoOwner, repoName };
-
-  return context.resolveRepositoryForPath?.(cwd) || {};
-}
 
 export function isTaskApiPath(pathname: string): boolean {
   return pathname === '/api/tasks' || pathname.startsWith('/api/tasks/');
@@ -263,213 +76,38 @@ export async function handleTaskApiRequest(
   url: URL,
   context: TaskApiContext,
 ): Promise<Response> {
+  const collectionResponse = await handleCollectionRequest(req, url, context);
+  if (collectionResponse) return collectionResponse;
+
   const parts = url.pathname.split('/').filter(Boolean);
   const taskId = parts[2];
   const action = parts[3];
-
-  if (url.pathname === '/api/tasks' && req.method === 'GET') {
-    const limit = readPositiveInt(url.searchParams.get('limit'), 100);
-    const listRes = listTaskPlanningSnapshots(limit);
-    if (!listRes.success) return errorResponse(listRes.error, 500);
-    return jsonResponse(listRes.data);
-  }
-
-  if (url.pathname === '/api/tasks' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const taskBody = readStringField(bodyRes.data, 'body');
-    if (!taskBody) return errorResponse('Task 内容不能为空', 400);
-
-    const cwdRes = resolveTaskCwd(bodyRes.data, context);
-    if (!cwdRes.success) return errorResponse(cwdRes.error, 400);
-    const repository = getTaskRepositoryFields(
-      bodyRes.data,
-      context,
-      cwdRes.data,
-    );
-    const createRes = createPlanningTask({
-      title: readStringField(bodyRes.data, 'title') || deriveTitle(taskBody),
-      body: taskBody,
-      source: readStringField(bodyRes.data, 'source') || 'web',
-      repoOwner: repository.repoOwner,
-      repoName: repository.repoName,
-      cwd: cwdRes.data,
-    });
-    if (!createRes.success) return errorResponse(createRes.error, 400);
-
-    const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
-      taskId: createRes.data.task.taskId,
-      reason: 'task_created',
-    });
-    if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
-
-    return jsonResponse(
-      {
-        taskId: createRes.data.task.taskId,
-        scheduled: scheduledRes.data,
-        snapshot: createRes.data,
-      },
-      scheduledRes.data ? 202 : 201,
-    );
-  }
-
   if (!taskId) return errorResponse('缺少 taskId', 404);
+  if (!action && req.method === 'GET') return handleTaskGetRequest(taskId);
 
-  if (!action && req.method === 'GET') {
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-    if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-    return jsonResponse(snapshotRes.data);
-  }
+  return handleTaskActionRequest(req, taskId, action, context);
+}
 
-  if (action === 'messages' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const message = readStringField(bodyRes.data, 'body');
-    if (!message) return errorResponse('用户消息不能为空', 400);
-
-    const submitRes = submitTaskMessage({ taskId, body: message });
-    if (!submitRes.success) return errorResponse(submitRes.error, 409);
-
-    const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
-      taskId,
-      reason: 'user_message',
-    });
-    if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
-
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-
-    return jsonResponse(
-      {
-        taskId,
-        scheduled: scheduledRes.data,
-        submitted: submitRes.data,
-        snapshot: snapshotRes.data,
-      },
-      scheduledRes.data ? 202 : 200,
-    );
-  }
-
-  if (action === 'approve' && req.method === 'POST') {
-    const approveRes = approveCurrentTaskPlan(taskId);
-    if (!approveRes.success) return errorResponse(approveRes.error, 409);
-
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-
-    return jsonResponse({
-      taskId,
-      approvedPlan: approveRes.data,
-      snapshot: snapshotRes.data,
-    });
-  }
-
-  if (action === 'planner' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-    if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-
-    const scheduledRes = schedulePlannerIfNeeded(
-      { ...bodyRes.data, autoRun: true },
-      context,
-      {
-        taskId,
-        reason: 'manual',
-      },
-    );
-    if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
-    if (!scheduledRes.data) return errorResponse('Planner 调度器未启用', 503);
-
-    return jsonResponse({ taskId, scheduled: true }, 202);
-  }
-
-  if (action === 'implementation' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-    if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-    if (!snapshotRes.data.thread.approvedPlanId) {
-      return errorResponse('当前 Task 没有已批准方案，不能开始实现', 409);
-    }
-
-    const scheduledRes = scheduleImplementationIfNeeded(bodyRes.data, context, {
-      taskId,
-      reason: 'manual',
-    });
-    if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
-    if (!scheduledRes.data) {
-      return errorResponse('Implementation 调度器未启用', 503);
-    }
-
-    return jsonResponse({ taskId, scheduled: true }, 202);
-  }
-
-  if (action === 'delivery' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const snapshotRes = readTaskPlanningSnapshot(taskId);
-    if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
-    if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-    if (snapshotRes.data.task.status !== 'implemented') {
-      return errorResponse('当前 Task 只有在已实现后才能交付', 409);
-    }
-
-    const scheduledRes = scheduleDeliveryIfNeeded(bodyRes.data, context, {
-      taskId,
-      reason: 'manual',
-    });
-    if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
-    if (!scheduledRes.data) {
-      return errorResponse('Delivery 调度器未启用', 503);
-    }
-
-    return jsonResponse({ taskId, scheduled: true }, 202);
-  }
-
-  if (action === 'manual-complete' && req.method === 'POST') {
-    const bodyRes = await readJsonObject(req);
-    if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
-
-    const stage = readTaskAgentStageField(bodyRes.data, 'stage');
-    if (!stage)
-      return errorResponse(
-        'stage 必须是 planning/implementation/delivery',
-        400,
-      );
-
-    const completeRes = completeTaskAgentStageManually({
-      taskId,
-      stage,
-      message: readStringField(bodyRes.data, 'message'),
-      prUrl: readStringField(bodyRes.data, 'prUrl'),
-      prNumber: readOptionalPositiveIntField(bodyRes.data, 'prNumber'),
-    });
-    if (!completeRes.success) return errorResponse(completeRes.error, 409);
-
-    return jsonResponse({
-      taskId,
-      snapshot: completeRes.data,
-    });
-  }
-
-  if (action === 'complete' && req.method === 'POST') {
-    const completeRes = completeDeliveredTask(taskId);
-    if (!completeRes.success) return errorResponse(completeRes.error, 409);
-
-    return jsonResponse({
-      taskId,
-      snapshot: completeRes.data,
-    });
-  }
-
+async function handleCollectionRequest(
+  req: Request,
+  url: URL,
+  context: TaskApiContext,
+): Promise<Response | null> {
+  if (url.pathname !== '/api/tasks') return null;
+  if (req.method === 'GET') return handleTaskListRequest(url);
+  if (req.method === 'POST') return handleTaskCreateRequest(req, context);
   return errorResponse('未找到 Task API', 404);
+}
+
+function handleTaskActionRequest(
+  req: Request,
+  taskId: string,
+  action: string | undefined,
+  context: TaskApiContext,
+): Response | Promise<Response> {
+  const handler = action ? ACTION_ROUTES[action] : undefined;
+  if (!handler || req.method !== 'POST') {
+    return errorResponse('未找到 Task API', 404);
+  }
+  return handler(req, taskId, context);
 }


### PR DESCRIPTION
## 变更内容
- 将新任务输入移动到任务详情区，侧边栏保留仓库选择和任务列表
- 支持按仓库过滤 Task 列表，并保留创建/调度时的仓库上下文
- 拆分 Task API 处理器与测试，覆盖创建、调度、交付和完成流程

## 验证
- bun run quality:changed