### PR TITLE
Task #4: 实施阶段逻辑调整

### DIFF
--- a/docs/task-thread-planning-session-implementation.md
+++ b/docs/task-thread-planning-session-implementation.md
@@ -10,7 +10,7 @@
 - Claude Code 的 `session_id` 只作为执行器会话，用于同一个 Agent 在同一个 Thread 中优先 resume。
 - 即使 Claude Code 原生 session 丢失，系统也能用 Along 自己保存的 Artifact 重建上下文继续。
 
-本轮不实现完整多 Agent、长期记忆和 Linear 集成。Task 在 Plan 批准后支持启动 implementation agent：按批准方案修改工作区代码并记录结果；实现完成后由 delivery 流程负责提交、推送并创建 PR。
+本轮不实现完整多 Agent、长期记忆和 Linear 集成。Task 在 Plan 批准后支持启动 implementation agent：按批准方案修改工作区代码并记录结果；实现完成后由 implementation 阶段的 auto-commit 子步骤提交本地变更，delivery 流程只负责基于已有本地 commit 推送并创建 PR。
 
 ## 2. 设计原则
 
@@ -290,7 +290,8 @@ Approve 后：
 - Web API 支持创建 Task、读取 Task、追加用户消息、批准 Plan、手动触发 planner。
 - Web API 支持批准后手动触发 implementation agent。
 - Implementation 开始前创建 Task 专属 Git worktree，并在该 worktree 内创建 Task 分支。
-- Delivery 流程在 Task worktree 内提交、rebase、推送并创建 PR。
+- Implementation 流程在 Task worktree 内完成代码修改，并由系统 auto-commit 子步骤提交本地变更。
+- Delivery 流程在 Task worktree 内确认已有本地 commit 后 rebase、推送并创建 PR。
 - webhook-server 复用现有 agent 队列，并按 `taskId` 串行化 Task planner。
 - 单元测试覆盖核心 planning 规则和 session binding。
 
@@ -355,4 +356,4 @@ POST /api/tasks/:taskId/implementation
 POST /api/tasks/:taskId/delivery
 ```
 
-`approve` 只批准当前 active Plan，且要求没有未处理 feedback round。`planner` 是给 Web UI 或排障使用的手动重跑入口，不要求用户记 CLI。`implementation` 会在 Task 已有批准方案后调度 implementation agent，并且只允许在 Task 专属 worktree 中修改代码。`delivery` 会在同一个 Task worktree 中提交、推送并创建 PR，PR body 使用 `along-task: <taskId>` 标记，不写 `fixes/closes/resolves #...`，避免触发 GitHub Issue session 生命周期逻辑。
+`approve` 只批准当前 active Plan，且要求没有未处理 feedback round。`planner` 是给 Web UI 或排障使用的手动重跑入口，不要求用户记 CLI。`implementation` 会在 Task 已有批准方案后调度 implementation agent，并且只允许在 Task 专属 worktree 中修改代码；agent 完成后系统会自动生成 Conventional Commit message、执行本地 commit，并在 hook/biome 失败时把裁剪后的错误摘要反馈给新的修复回合，完整日志记录为 artifact。`delivery` 会在同一个 Task worktree 中确认已有本地 commit 后推送并创建 PR，若仍存在未提交变更则中止，PR body 使用 `along-task: <taskId>` 标记，不写 `fixes/closes/resolves #...`，避免触发 GitHub Issue session 生命周期逻辑。

--- a/packages/along/src/domain/task-auto-commit-types.ts
+++ b/packages/along/src/domain/task-auto-commit-types.ts
@@ -1,0 +1,31 @@
+import type { TaskPlanningSnapshot } from './task-planning';
+import type { TaskWorktreeCommandRunner } from './task-worktree';
+
+export interface RunTaskAutoCommitInput {
+  snapshot: TaskPlanningSnapshot;
+  worktreePath: string;
+  branchName: string;
+  defaultBranch: string;
+  commandRunner: TaskWorktreeCommandRunner;
+  assistantText?: string;
+}
+
+export interface RunTaskAutoCommitOutput {
+  commitShas: string[];
+  changedFiles: string[];
+  commitMessage: string;
+  alreadyCommitted: boolean;
+}
+
+export interface TaskAutoCommitFailure {
+  success: false;
+  error: string;
+  command: string;
+  summary: string;
+  changedFiles: string[];
+  failureArtifactId?: string;
+}
+
+export type TaskAutoCommitResult =
+  | { success: true; data: RunTaskAutoCommitOutput }
+  | TaskAutoCommitFailure;

--- a/packages/along/src/domain/task-auto-commit-utils.ts
+++ b/packages/along/src/domain/task-auto-commit-utils.ts
@@ -1,0 +1,63 @@
+import type { TaskPlanningSnapshot } from './task-planning';
+
+const CONVENTIONAL_TYPES = new Set([
+  'feat',
+  'fix',
+  'docs',
+  'style',
+  'refactor',
+  'perf',
+  'test',
+  'chore',
+  'ci',
+]);
+
+function normalizeTitle(title: string, maxLength = 52): string {
+  const text = title.replace(/\s+/g, ' ').trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}...`;
+}
+
+function normalizeCommitType(type?: string): string {
+  const normalized = type?.trim().toLowerCase();
+  return normalized && CONVENTIONAL_TYPES.has(normalized) ? normalized : 'feat';
+}
+
+export function buildCommitMessage(snapshot: TaskPlanningSnapshot): string {
+  return `${normalizeCommitType(snapshot.task.type)}(task): 完成${normalizeTitle(
+    snapshot.task.title,
+  )}`;
+}
+
+export function parseChangedFiles(status: string): string[] {
+  return [
+    ...new Set(
+      status
+        .split('\n')
+        .map((line) => line.trimEnd())
+        .filter(Boolean)
+        .map((line) => {
+          const file = line.slice(3).trim();
+          return file.split(' -> ').pop() || file;
+        })
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+function truncateMiddle(value: string, maxLength: number): string {
+  const text = value.trim();
+  if (text.length <= maxLength) return text;
+  const half = Math.floor((maxLength - 36) / 2);
+  return `${text.slice(0, half)}\n...（中间内容已截断）...\n${text.slice(
+    -half,
+  )}`;
+}
+
+export function summarizeFailure(error: string): string {
+  return truncateMiddle(error, 6000);
+}
+
+export function artifactLog(error: string): string {
+  return truncateMiddle(error, 80_000);
+}

--- a/packages/along/src/domain/task-auto-commit.test.ts
+++ b/packages/along/src/domain/task-auto-commit.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Result } from '../core/result';
+
+const planningMocks = vi.hoisted(() => ({
+  recordTaskAgentResult: vi.fn(),
+  updateTaskDelivery: vi.fn(),
+}));
+
+vi.mock('./task-planning', () => ({
+  TASK_STATUS: {
+    IMPLEMENTED: 'implemented',
+  },
+  recordTaskAgentResult: planningMocks.recordTaskAgentResult,
+  updateTaskDelivery: planningMocks.updateTaskDelivery,
+}));
+
+import { runTaskAutoCommit } from './task-auto-commit';
+import type { TaskWorktreeCommandRunner } from './task-worktree';
+
+const snapshot = {
+  task: {
+    taskId: 'task-1',
+    title: '移动演示数据按钮',
+    body: '删除下方的演示数据按钮应该位于礼薄列表上方。',
+    source: 'web',
+    status: 'implementing',
+    activeThreadId: 'thread-1',
+    repoOwner: 'ranwawa',
+    repoName: 'along',
+    cwd: '/tmp/along',
+    commitShas: [],
+    type: 'fix',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  thread: {
+    threadId: 'thread-1',
+    taskId: 'task-1',
+    purpose: 'planning',
+    status: 'approved',
+    currentPlanId: 'plan-1',
+    approvedPlanId: 'plan-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  currentPlan: null,
+  openRound: null,
+  artifacts: [],
+  plans: [],
+};
+
+function ok(data = ''): Result<string> {
+  return { success: true, data };
+}
+
+function err(error: string): Result<string> {
+  return { success: false, error };
+}
+
+describe('task-auto-commit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningMocks.updateTaskDelivery.mockReturnValue({
+      success: true,
+      data: undefined,
+    });
+    planningMocks.recordTaskAgentResult.mockReturnValue({
+      success: true,
+      data: {
+        artifactId: 'art-auto-commit',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        type: 'agent_result',
+        role: 'agent',
+        body: 'Auto-commit 完成',
+        metadata: {},
+        createdAt: '2026-01-01T00:00:01.000Z',
+      },
+    });
+  });
+
+  it('当工作区有变更时，期望暂存并提交，同时记录 commit sha', async () => {
+    const calls: string[] = [];
+    const runner: TaskWorktreeCommandRunner = async (command, args) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      if (args[0] === 'status') return ok(' M src/app.ts');
+      if (args[0] === 'rev-parse') return ok('abc123');
+      return ok('');
+    };
+
+    const result = await runTaskAutoCommit({
+      snapshot,
+      worktreePath: '/tmp/worktree',
+      branchName: 'fix/demo-1',
+      defaultBranch: 'main',
+      commandRunner: runner,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.commitShas).toEqual(['abc123']);
+    expect(result.data.commitMessage).toBe('fix(task): 完成移动演示数据按钮');
+    expect(calls).toContain('git add -A');
+    expect(calls).toContain('git commit -m fix(task): 完成移动演示数据按钮');
+    expect(planningMocks.updateTaskDelivery).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      status: 'implemented',
+      worktreePath: '/tmp/worktree',
+      branchName: 'fix/demo-1',
+      commitShas: ['abc123'],
+    });
+  });
+
+  it('当 commit hook 失败时，期望返回摘要并记录完整日志 artifact', async () => {
+    const longError = `biome check failed\n${'x'.repeat(10_000)}`;
+    const runner: TaskWorktreeCommandRunner = async (_command, args) => {
+      if (args[0] === 'status') return ok(' M src/app.ts');
+      if (args[0] === 'commit') return err(longError);
+      return ok('');
+    };
+
+    const result = await runTaskAutoCommit({
+      snapshot,
+      worktreePath: '/tmp/worktree',
+      branchName: 'fix/demo-1',
+      defaultBranch: 'main',
+      commandRunner: runner,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.summary.length).toBeLessThanOrEqual(6000);
+    expect(result.failureArtifactId).toBe('art-auto-commit');
+    expect(planningMocks.updateTaskDelivery).not.toHaveBeenCalled();
+    expect(planningMocks.recordTaskAgentResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'auto-commit',
+        provider: 'system',
+        body: expect.stringContaining('完整输出'),
+      }),
+    );
+  });
+
+  it('当工作区干净但已有本地 commit 时，期望复用已有 commit', async () => {
+    const runner: TaskWorktreeCommandRunner = async (_command, args) => {
+      if (args[0] === 'status') return ok('');
+      if (args[0] === 'rev-list') return ok('def456');
+      return ok('');
+    };
+
+    const result = await runTaskAutoCommit({
+      snapshot,
+      worktreePath: '/tmp/worktree',
+      branchName: 'fix/demo-1',
+      defaultBranch: 'main',
+      commandRunner: runner,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.alreadyCommitted).toBe(true);
+    expect(result.data.commitShas).toEqual(['def456']);
+  });
+});

--- a/packages/along/src/domain/task-auto-commit.ts
+++ b/packages/along/src/domain/task-auto-commit.ts
@@ -1,0 +1,284 @@
+import type { Result } from '../core/result';
+import { success } from '../core/result';
+import type {
+  RunTaskAutoCommitInput,
+  TaskAutoCommitFailure,
+  TaskAutoCommitResult,
+} from './task-auto-commit-types';
+import {
+  artifactLog,
+  buildCommitMessage,
+  parseChangedFiles,
+  summarizeFailure,
+} from './task-auto-commit-utils';
+import {
+  recordTaskAgentResult,
+  TASK_STATUS,
+  updateTaskDelivery,
+} from './task-planning';
+import type { TaskWorktreeCommandRunner } from './task-worktree';
+
+async function runGit(
+  runner: TaskWorktreeCommandRunner,
+  cwd: string,
+  args: string[],
+): Promise<Result<string>> {
+  return runner('git', args, { cwd });
+}
+
+async function readExistingCommit(input: RunTaskAutoCommitInput) {
+  if (input.snapshot.task.commitShas.length > 0) {
+    return success(input.snapshot.task.commitShas);
+  }
+
+  const revListRes = await runGit(input.commandRunner, input.worktreePath, [
+    'rev-list',
+    '--max-count=1',
+    `origin/${input.defaultBranch}..HEAD`,
+  ]);
+  if (!revListRes.success) return revListRes;
+  const sha = revListRes.data.trim();
+  return success(sha ? [sha] : []);
+}
+
+function recordAutoCommitResult(
+  input: RunTaskAutoCommitInput,
+  body: string,
+): string | undefined {
+  const artifactRes = recordTaskAgentResult({
+    taskId: input.snapshot.task.taskId,
+    threadId: input.snapshot.thread.threadId,
+    agentId: 'auto-commit',
+    provider: 'system',
+    body,
+  });
+  return artifactRes.success ? artifactRes.data.artifactId : undefined;
+}
+
+function failAutoCommit(input: {
+  step: string;
+  command: string;
+  error: string;
+  changedFiles: string[];
+  autoCommitInput: RunTaskAutoCommitInput;
+}): TaskAutoCommitFailure {
+  const summary = summarizeFailure(input.error);
+  const failureArtifactId = recordAutoCommitResult(
+    input.autoCommitInput,
+    [
+      `Auto-commit 失败：${input.step}`,
+      '',
+      `命令：${input.command}`,
+      '',
+      '错误摘要：',
+      summary,
+      '',
+      '完整输出：',
+      artifactLog(input.error),
+    ].join('\n'),
+  );
+  return {
+    success: false,
+    error: `${input.step}: ${summary}`,
+    command: input.command,
+    summary,
+    changedFiles: input.changedFiles,
+    failureArtifactId,
+  };
+}
+
+function updateCommitMetadata(
+  input: RunTaskAutoCommitInput,
+  commitShas: string[],
+) {
+  return updateTaskDelivery({
+    taskId: input.snapshot.task.taskId,
+    status: TASK_STATUS.IMPLEMENTED,
+    worktreePath: input.worktreePath,
+    branchName: input.branchName,
+    commitShas,
+  });
+}
+
+async function readChangedFiles(
+  input: RunTaskAutoCommitInput,
+): Promise<TaskAutoCommitFailure | string[]> {
+  const statusRes = await runGit(input.commandRunner, input.worktreePath, [
+    'status',
+    '--porcelain',
+  ]);
+  if (!statusRes.success) {
+    return failAutoCommit({
+      step: '读取 git 状态失败',
+      command: 'git status --porcelain',
+      error: statusRes.error,
+      changedFiles: [],
+      autoCommitInput: input,
+    });
+  }
+
+  return parseChangedFiles(statusRes.data);
+}
+
+function successResult(input: {
+  commitShas: string[];
+  changedFiles: string[];
+  commitMessage: string;
+  alreadyCommitted: boolean;
+}): TaskAutoCommitResult {
+  return { success: true, data: input };
+}
+
+async function reuseExistingCommit(
+  input: RunTaskAutoCommitInput,
+  changedFiles: string[],
+  commitMessage: string,
+): Promise<TaskAutoCommitResult> {
+  const existingCommitRes = await readExistingCommit(input);
+  if (!existingCommitRes.success) {
+    return failAutoCommit({
+      step: '读取已有 commit 失败',
+      command: `git rev-list --max-count=1 origin/${input.defaultBranch}..HEAD`,
+      error: existingCommitRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+  if (existingCommitRes.data.length === 0) {
+    return failAutoCommit({
+      step: '没有可提交变更',
+      command: 'git status --porcelain',
+      error: 'Implementation agent 完成后未检测到工作区变更或本地 commit。',
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+
+  const updateRes = updateCommitMetadata(input, existingCommitRes.data);
+  if (!updateRes.success) {
+    return failAutoCommit({
+      step: '记录已有 commit 失败',
+      command: 'update task commit metadata',
+      error: updateRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+
+  return successResult({
+    commitShas: existingCommitRes.data,
+    changedFiles,
+    commitMessage,
+    alreadyCommitted: true,
+  });
+}
+
+async function stageAndCommitChanges(
+  input: RunTaskAutoCommitInput,
+  changedFiles: string[],
+  commitMessage: string,
+): Promise<TaskAutoCommitFailure | null> {
+  const addRes = await runGit(input.commandRunner, input.worktreePath, [
+    'add',
+    '-A',
+  ]);
+  if (!addRes.success) {
+    return failAutoCommit({
+      step: '暂存变更失败',
+      command: 'git add -A',
+      error: addRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+
+  const commitRes = await runGit(input.commandRunner, input.worktreePath, [
+    'commit',
+    '-m',
+    commitMessage,
+  ]);
+  if (commitRes.success) return null;
+  return failAutoCommit({
+    step: '提交失败',
+    command: `git commit -m "${commitMessage}"`,
+    error: commitRes.error,
+    changedFiles,
+    autoCommitInput: input,
+  });
+}
+
+async function readNewCommitSha(
+  input: RunTaskAutoCommitInput,
+  changedFiles: string[],
+): Promise<TaskAutoCommitFailure | string[]> {
+  const shaRes = await runGit(input.commandRunner, input.worktreePath, [
+    'rev-parse',
+    'HEAD',
+  ]);
+  if (!shaRes.success) {
+    return failAutoCommit({
+      step: '读取 commit sha 失败',
+      command: 'git rev-parse HEAD',
+      error: shaRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+  return [shaRes.data.trim()].filter(Boolean);
+}
+
+async function recordNewCommit(
+  input: RunTaskAutoCommitInput,
+  changedFiles: string[],
+  commitMessage: string,
+): Promise<TaskAutoCommitResult> {
+  const commitShas = await readNewCommitSha(input, changedFiles);
+  if ('success' in commitShas) return commitShas;
+
+  const updateRes = updateCommitMetadata(input, commitShas);
+  if (!updateRes.success) {
+    return failAutoCommit({
+      step: '记录 commit 信息失败',
+      command: 'update task commit metadata',
+      error: updateRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+  recordAutoCommitResult(
+    input,
+    [
+      'Auto-commit 完成：已在实施阶段提交本地变更。',
+      '',
+      `- Commit：${commitShas.join(', ')}`,
+      `- Message：${commitMessage}`,
+      `- Files：${changedFiles.join(', ')}`,
+    ].join('\n'),
+  );
+  return successResult({
+    commitShas,
+    changedFiles,
+    commitMessage,
+    alreadyCommitted: false,
+  });
+}
+
+export async function runTaskAutoCommit(
+  input: RunTaskAutoCommitInput,
+): Promise<TaskAutoCommitResult> {
+  const changedFiles = await readChangedFiles(input);
+  if ('success' in changedFiles) return changedFiles;
+
+  const commitMessage = buildCommitMessage(input.snapshot);
+  if (changedFiles.length === 0) {
+    return reuseExistingCommit(input, changedFiles, commitMessage);
+  }
+
+  const commitFailure = await stageAndCommitChanges(
+    input,
+    changedFiles,
+    commitMessage,
+  );
+  if (commitFailure) return commitFailure;
+  return recordNewCommit(input, changedFiles, commitMessage);
+}

--- a/packages/along/src/domain/task-delivery.test.ts
+++ b/packages/along/src/domain/task-delivery.test.ts
@@ -154,7 +154,14 @@ describe('task-delivery', () => {
     });
   });
 
-  it('当 Task 已实现且有变更时，期望提交推送并创建带 Task 标记的 PR', async () => {
+  it('当 Task 已实现且已有 commit 时，期望推送并创建带 Task 标记的 PR', async () => {
+    planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+      success: true,
+      data: {
+        ...snapshot,
+        task: { ...snapshot.task, commitShas: ['abc123'] },
+      },
+    });
     const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
     let prBody = '';
     const runner: TaskDeliveryCommandRunner = async (
@@ -164,7 +171,10 @@ describe('task-delivery', () => {
     ) => {
       calls.push({ command, args, cwd: options.cwd });
       if (command === 'git' && args[0] === 'status') {
-        return ok(' M packages/client/src/pages/home/list.tsx');
+        return ok('');
+      }
+      if (command === 'git' && args[0] === 'diff') {
+        return ok('packages/client/src/pages/home/list.tsx');
       }
       if (command === 'git' && args[0] === 'rev-parse') {
         if (args.includes('--verify')) return err('not found');
@@ -216,6 +226,9 @@ describe('task-delivery', () => {
     expect(calls.map((call) => `${call.command} ${call.args[0]}`)).toContain(
       'gh pr',
     );
+    expect(calls.map((call) => `git ${call.args[0]}`)).not.toContain(
+      'git commit',
+    );
     expect(
       calls.find((call) => call.command === 'git' && call.args[0] === 'status'),
     ).toEqual(
@@ -228,9 +241,10 @@ describe('task-delivery', () => {
     expect(prBody).not.toMatch(/(?:fixes|closes|resolves)\s+#\d+/i);
   });
 
-  it('当没有可提交变更时，期望回到已实现状态并返回失败', async () => {
+  it('当没有已提交 commit 时，期望回到已实现状态并返回失败', async () => {
     const runner: TaskDeliveryCommandRunner = async (command, args) => {
       if (command === 'git' && args[0] === 'status') return ok('');
+      if (command === 'git' && args[0] === 'rev-list') return ok('');
       return ok('');
     };
 
@@ -259,6 +273,7 @@ describe('task-delivery', () => {
           repoOwner: undefined,
           repoName: undefined,
           seq: undefined,
+          commitShas: ['abc123'],
         },
       },
     });
@@ -269,7 +284,10 @@ describe('task-delivery', () => {
         return ok('https://github.com/ranwawa/kinkeeper.git');
       }
       if (command === 'git' && args[0] === 'status') {
-        return ok(' M packages/client/src/pages/home/list.tsx');
+        return ok('');
+      }
+      if (command === 'git' && args[0] === 'diff') {
+        return ok('packages/client/src/pages/home/list.tsx');
       }
       if (command === 'git' && args[0] === 'rev-parse') {
         if (args.includes('--verify')) return err('not found');

--- a/packages/along/src/domain/task-delivery.ts
+++ b/packages/along/src/domain/task-delivery.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy delivery orchestration predates current function-size rule.
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy delivery module predates current file-size rule.
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -97,8 +99,8 @@ function buildPrBody(input: {
     '',
     '## 执行步骤',
     '1. 读取 Task 已批准方案',
-    '2. 在本地仓库完成代码实现',
-    `3. 提交并推送分支 \`${input.branchName}\``,
+    '2. 确认实施阶段已完成本地 commit',
+    `3. 推送分支 \`${input.branchName}\``,
     '4. 创建 Pull Request',
     '',
     '## 影响范围',
@@ -245,73 +247,43 @@ export async function runTaskDelivery(
     );
   }
 
-  const changedFiles = parseChangedFiles(statusRes.data);
-  if (changedFiles.length === 0 && snapshot.task.commitShas.length === 0) {
+  const uncommittedFiles = parseChangedFiles(statusRes.data);
+  if (uncommittedFiles.length > 0) {
     return failDeliveryRun(
       run,
       input.taskId,
       snapshot.thread.threadId,
-      '没有可提交变更',
+      `存在未提交变更，不能交付。请先完成实施阶段 auto-commit: ${uncommittedFiles.join(
+        ', ',
+      )}`,
     );
   }
 
   let commitShas = snapshot.task.commitShas;
-  if (changedFiles.length > 0) {
-    const branchRes = updateTaskDelivery({
-      taskId: input.taskId,
-      status: TASK_STATUS.DELIVERING,
-      branchName,
-    });
-    if (!branchRes.success) {
-      return failDeliveryRun(
-        run,
-        input.taskId,
-        snapshot.thread.threadId,
-        branchRes.error,
-      );
-    }
-
-    const addRes = await runGit(runner, worktreePath, ['add', '-A']);
-    if (!addRes.success) {
-      return failDeliveryRun(
-        run,
-        input.taskId,
-        snapshot.thread.threadId,
-        `暂存变更失败: ${addRes.error}`,
-      );
-    }
-
-    const commitMessage = `feat(task): 完成${normalizeTitle(
-      snapshot.task.title,
-      42,
-    )}，交付已批准方案`;
-    const commitRes = await runGit(runner, worktreePath, [
-      'commit',
-      '-m',
-      commitMessage,
+  if (commitShas.length === 0) {
+    const existingCommitRes = await runGit(runner, worktreePath, [
+      'rev-list',
+      '--max-count=1',
+      `origin/${defaultBranch}..HEAD`,
     ]);
-    if (!commitRes.success) {
+    if (!existingCommitRes.success) {
       return failDeliveryRun(
         run,
         input.taskId,
         snapshot.thread.threadId,
-        `提交失败: ${commitRes.error}`,
+        `读取已有 commit 失败: ${existingCommitRes.error}`,
       );
     }
-
-    const committedShaRes = await runGit(runner, worktreePath, [
-      'rev-parse',
-      'HEAD',
-    ]);
-    if (!committedShaRes.success) {
+    const existingCommit = existingCommitRes.data.trim();
+    if (!existingCommit) {
       return failDeliveryRun(
         run,
         input.taskId,
         snapshot.thread.threadId,
-        `读取 commit sha 失败: ${committedShaRes.error}`,
+        '没有已提交 commit，不能交付',
       );
     }
-    commitShas = [committedShaRes.data.trim()];
+    commitShas = [existingCommit];
     const commitMetaRes = updateTaskDelivery({
       taskId: input.taskId,
       status: TASK_STATUS.DELIVERING,
@@ -327,6 +299,25 @@ export async function runTaskDelivery(
       );
     }
   }
+
+  const changedFileRes = await runGit(runner, worktreePath, [
+    'diff',
+    '--name-only',
+    `origin/${defaultBranch}...HEAD`,
+  ]);
+  if (!changedFileRes.success) {
+    return failDeliveryRun(
+      run,
+      input.taskId,
+      snapshot.thread.threadId,
+      `读取 PR 文件列表失败: ${changedFileRes.error}`,
+    );
+  }
+  const changedFiles = changedFileRes.data
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+    .sort();
 
   const rebaseRes = await runGit(runner, worktreePath, [
     'rebase',
@@ -445,7 +436,7 @@ export async function runTaskDelivery(
       agentId: 'delivery',
       provider: 'system',
       body: [
-        'Delivery 完成：已提交、推送并创建 PR。',
+        'Delivery 完成：已推送并创建 PR。',
         '',
         `- 分支：${branchName}`,
         `- Commit：${finalCommitSha}`,

--- a/packages/along/src/domain/task-implementation-agent.test.ts
+++ b/packages/along/src/domain/task-implementation-agent.test.ts
@@ -6,6 +6,7 @@ const planningMocks = vi.hoisted(() => ({
 }));
 const runnerMock = vi.hoisted(() => vi.fn());
 const worktreeMock = vi.hoisted(() => vi.fn());
+const autoCommitMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./task-planning', () => ({
   PLAN_STATUS: {
@@ -25,7 +26,12 @@ vi.mock('./task-agent-runtime', () => ({
 }));
 
 vi.mock('./task-worktree', () => ({
+  defaultTaskWorktreeCommandRunner: vi.fn(),
   prepareTaskWorktree: worktreeMock,
+}));
+
+vi.mock('./task-auto-commit', () => ({
+  runTaskAutoCommit: autoCommitMock,
 }));
 
 import { runTaskImplementationAgent } from './task-implementation-agent';
@@ -130,9 +136,18 @@ describe('task-implementation-agent', () => {
         outputArtifactIds: ['art-result'],
       },
     });
+    autoCommitMock.mockResolvedValue({
+      success: true,
+      data: {
+        commitShas: ['abc123'],
+        changedFiles: ['src/app.ts'],
+        commitMessage: 'fix(task): 完成移动演示数据按钮',
+        alreadyCommitted: false,
+      },
+    });
   });
 
-  it('当 Task 有已批准方案时，期望启动实现 Agent 并更新状态', async () => {
+  it('当 Task 有已批准方案时，期望启动实现 Agent 并在完成后自动提交', async () => {
     const result = await runTaskImplementationAgent({
       taskId: 'task-1',
       cwd: '/tmp/kinkeeper',
@@ -145,11 +160,8 @@ describe('task-implementation-agent', () => {
       'task-1',
       'implementing',
     );
-    expect(planningMocks.updateTaskStatus).toHaveBeenNthCalledWith(
-      2,
-      'task-1',
-      'implemented',
-    );
+    expect(planningMocks.updateTaskStatus).toHaveBeenCalledTimes(1);
+    expect(result.data.commitShas).toEqual(['abc123']);
     expect(runnerMock).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: 'task-1',
@@ -160,6 +172,13 @@ describe('task-implementation-agent', () => {
           permissionMode: 'bypassPermissions',
           allowDangerouslySkipPermissions: true,
         }),
+      }),
+    );
+    expect(autoCommitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreePath: '/tmp/along-task-worktree',
+        branchName: 'along-task/task-1-demo',
+        defaultBranch: 'main',
       }),
     );
   });
@@ -181,6 +200,45 @@ describe('task-implementation-agent', () => {
       'task-1',
       'planning_approved',
     );
+  });
+
+  it('当 auto-commit 失败后，期望反馈错误给实现 Agent 修复并重试提交', async () => {
+    autoCommitMock
+      .mockResolvedValueOnce({
+        success: false,
+        error: '提交失败: biome check failed',
+        command: 'git commit -m "fix(task): 完成移动演示数据按钮"',
+        summary: 'biome check failed',
+        changedFiles: ['src/app.ts'],
+        failureArtifactId: 'art-commit-failure',
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          commitShas: ['def456'],
+          changedFiles: ['src/app.ts'],
+          commitMessage: 'fix(task): 完成移动演示数据按钮',
+          alreadyCommitted: false,
+        },
+      });
+
+    const result = await runTaskImplementationAgent({
+      taskId: 'task-1',
+      cwd: '/tmp/kinkeeper',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.commitShas).toEqual(['def456']);
+    expect(runnerMock).toHaveBeenCalledTimes(2);
+    expect(runnerMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        prompt: expect.stringContaining('auto-commit 子步骤'),
+        inputArtifactIds: expect.arrayContaining(['art-commit-failure']),
+      }),
+    );
+    expect(autoCommitMock).toHaveBeenCalledTimes(2);
   });
 
   it('当 Task worktree 准备失败时，期望拒绝启动实现', async () => {

--- a/packages/along/src/domain/task-implementation-agent.ts
+++ b/packages/along/src/domain/task-implementation-agent.ts
@@ -1,6 +1,12 @@
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
 import { runTaskAgentTurn } from './task-agent-runtime';
+import { runTaskAutoCommit } from './task-auto-commit';
+import type { TaskAutoCommitFailure } from './task-auto-commit-types';
+import {
+  buildAutoCommitFixPrompt,
+  buildImplementationPrompt,
+} from './task-implementation-prompts';
 import {
   PLAN_STATUS,
   readTaskPlanningSnapshot,
@@ -10,6 +16,8 @@ import {
   updateTaskStatus,
 } from './task-planning';
 import {
+  defaultTaskWorktreeCommandRunner,
+  type PrepareTaskWorktreeOutput,
   prepareTaskWorktree,
   type TaskWorktreeCommandRunner,
 } from './task-worktree';
@@ -29,12 +37,22 @@ export interface RunTaskImplementationAgentOutput {
   snapshot: TaskPlanningSnapshot;
   approvedPlan: TaskPlanRevisionRecord;
   assistantText: string;
+  commitShas: string[];
 }
 
-function truncateText(value: string, maxLength = 5000): string {
-  const text = value.trim();
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength)}\n...（内容已截断）`;
+type AutoCommitAttemptResult =
+  | Result<RunTaskImplementationAgentOutput>
+  | {
+      success: false;
+      error: string;
+      snapshot: TaskPlanningSnapshot;
+      failure: TaskAutoCommitFailure;
+    };
+
+interface PreparedImplementationRun {
+  snapshot: TaskPlanningSnapshot;
+  approvedPlan: TaskPlanRevisionRecord;
+  worktree: PrepareTaskWorktreeOutput;
 }
 
 function findApprovedPlan(
@@ -50,56 +68,180 @@ function findApprovedPlan(
   );
 }
 
-function buildImplementationPrompt(
-  snapshot: TaskPlanningSnapshot,
-  approvedPlan: TaskPlanRevisionRecord,
-  worktreePath: string,
-): string {
-  const context = {
-    task: {
-      taskId: snapshot.task.taskId,
-      title: snapshot.task.title,
-      body: truncateText(snapshot.task.body, 4000),
-      repoOwner: snapshot.task.repoOwner,
-      repoName: snapshot.task.repoName,
-      sourceCwd: snapshot.task.cwd,
-      worktreePath,
-    },
-    approvedPlan: {
-      planId: approvedPlan.planId,
-      version: approvedPlan.version,
-      body: truncateText(approvedPlan.body, 8000),
-    },
-    recentArtifacts: snapshot.artifacts.slice(-30).map((artifact) => ({
-      artifactId: artifact.artifactId,
-      type: artifact.type,
-      role: artifact.role,
-      body: truncateText(artifact.body, 2500),
-      metadata: artifact.metadata,
-    })),
-  };
-
-  return [
-    '你是 Along 的 Implementation Agent。你的任务是在当前 Task 专属 worktree 中严格按已批准方案完成代码实现。',
-    '',
-    '要求：',
-    '1. 不重新制定计划，不扩大需求范围。',
-    '2. 修改代码前先检查当前 worktree 状态和相关代码。',
-    '3. 只修改完成已批准方案所必需的文件。',
-    '4. 需要测试时，优先运行相关的局部测试或类型检查。',
-    '5. 不要创建 PR，不要提交或推送代码；本阶段只完成工作区代码改动和必要验证。',
-    '6. 最终回复必须简短说明改了什么、验证了什么、还有什么风险。',
-    '',
-    '任务上下文：',
-    JSON.stringify(context, null, 2),
-  ].join('\n');
+async function readRequiredSnapshot(
+  taskId: string,
+  message: string,
+): Promise<Result<TaskPlanningSnapshot>> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  if (!snapshotRes.data) return failure(message);
+  return success(snapshotRes.data);
 }
 
-export async function runTaskImplementationAgent(
-  input: RunTaskImplementationAgentInput,
-): Promise<Result<RunTaskImplementationAgentOutput>> {
-  const snapshotRes = readTaskPlanningSnapshot(input.taskId);
+function rollbackToPlanningApproved<T>(taskId: string, result: Result<T>) {
+  const rollbackRes = updateTaskStatus(taskId, TASK_STATUS.PLANNING_APPROVED);
+  return rollbackRes.success ? result : failure<T>(rollbackRes.error);
+}
+
+async function runImplementationTurn(input: {
+  taskInput: RunTaskImplementationAgentInput;
+  snapshot: TaskPlanningSnapshot;
+  approvedPlan: TaskPlanRevisionRecord;
+  worktree: PrepareTaskWorktreeOutput;
+  agentId: string;
+}) {
+  return runTaskAgentTurn({
+    taskId: input.taskInput.taskId,
+    threadId: input.snapshot.thread.threadId,
+    agentId: input.agentId,
+    prompt: buildImplementationPrompt(
+      input.snapshot,
+      input.approvedPlan,
+      input.worktree.worktreePath,
+    ),
+    cwd: input.worktree.worktreePath,
+    editor: input.taskInput.editor,
+    model: input.taskInput.model,
+    personalityVersion: input.taskInput.personalityVersion,
+    inputArtifactIds: [
+      input.approvedPlan.artifactId,
+      ...input.snapshot.artifacts.map((artifact) => artifact.artifactId),
+    ],
+    options: {
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      maxTurns: 80,
+    },
+  });
+}
+
+async function runAutoCommitFixTurn(input: {
+  taskInput: RunTaskImplementationAgentInput;
+  snapshot: TaskPlanningSnapshot;
+  approvedPlan: TaskPlanRevisionRecord;
+  worktree: PrepareTaskWorktreeOutput;
+  agentId: string;
+  failure: TaskAutoCommitFailure;
+  attempt: number;
+  maxAttempts: number;
+}) {
+  return runTaskAgentTurn({
+    taskId: input.taskInput.taskId,
+    threadId: input.snapshot.thread.threadId,
+    agentId: input.agentId,
+    prompt: buildAutoCommitFixPrompt({
+      snapshot: input.snapshot,
+      approvedPlan: input.approvedPlan,
+      worktreePath: input.worktree.worktreePath,
+      failure: input.failure,
+      attempt: input.attempt,
+      maxAttempts: input.maxAttempts,
+    }),
+    cwd: input.worktree.worktreePath,
+    editor: input.taskInput.editor,
+    model: input.taskInput.model,
+    personalityVersion: input.taskInput.personalityVersion,
+    inputArtifactIds: [
+      input.approvedPlan.artifactId,
+      ...input.snapshot.artifacts.map((artifact) => artifact.artifactId),
+      ...(input.failure.failureArtifactId
+        ? [input.failure.failureArtifactId]
+        : []),
+    ],
+    options: {
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      maxTurns: 40,
+    },
+  });
+}
+
+async function runAutoCommitLoop(input: {
+  taskInput: RunTaskImplementationAgentInput;
+  approvedPlan: TaskPlanRevisionRecord;
+  worktree: PrepareTaskWorktreeOutput;
+  agentId: string;
+  commandRunner: TaskWorktreeCommandRunner;
+  assistantText: string;
+}): Promise<Result<RunTaskImplementationAgentOutput>> {
+  let assistantText = input.assistantText;
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const attemptRes = await runAutoCommitAttempt(input, assistantText);
+    if (attemptRes.success) return attemptRes;
+    if (!('failure' in attemptRes)) return attemptRes;
+    if (attempt === maxAttempts) {
+      return rollbackToPlanningApproved(
+        input.taskInput.taskId,
+        failure(attemptRes.error),
+      );
+    }
+    const fixResult = await runAutoCommitFixTurn({
+      ...input,
+      snapshot: attemptRes.snapshot,
+      failure: attemptRes.failure,
+      attempt: attempt + 1,
+      maxAttempts,
+    });
+    if (!fixResult.success) {
+      return rollbackToPlanningApproved(input.taskInput.taskId, fixResult);
+    }
+    assistantText = fixResult.data.assistantText;
+  }
+  return failure('auto-commit 状态异常');
+}
+
+async function runAutoCommitAttempt(
+  input: {
+    taskInput: RunTaskImplementationAgentInput;
+    approvedPlan: TaskPlanRevisionRecord;
+    worktree: PrepareTaskWorktreeOutput;
+    commandRunner: TaskWorktreeCommandRunner;
+  },
+  assistantText: string,
+): Promise<AutoCommitAttemptResult> {
+  const snapshotRes = await readRequiredSnapshot(
+    input.taskInput.taskId,
+    `Task ${input.taskInput.taskId} 实现完成，但 auto-commit 前读取快照失败`,
+  );
   if (!snapshotRes.success) return snapshotRes;
+
+  const commitRes = await runTaskAutoCommit({
+    snapshot: snapshotRes.data,
+    worktreePath: input.worktree.worktreePath,
+    branchName: input.worktree.branchName,
+    defaultBranch: input.worktree.defaultBranch,
+    commandRunner: input.commandRunner,
+    assistantText,
+  });
+  if (!commitRes.success) {
+    return {
+      success: false,
+      error: `auto-commit 失败: ${commitRes.error}`,
+      snapshot: snapshotRes.data,
+      failure: commitRes,
+    };
+  }
+
+  const refreshed = await readRequiredSnapshot(
+    input.taskInput.taskId,
+    `Task ${input.taskInput.taskId} 已实现并提交，但读取快照失败`,
+  );
+  if (!refreshed.success) return refreshed;
+  return success({
+    snapshot: refreshed.data,
+    approvedPlan: input.approvedPlan,
+    assistantText,
+    commitShas: commitRes.data.commitShas,
+  });
+}
+
+async function prepareImplementationRun(
+  input: RunTaskImplementationAgentInput,
+  commandRunner: TaskWorktreeCommandRunner,
+): Promise<Result<PreparedImplementationRun>> {
+  const snapshotRes = readTaskPlanningSnapshot(input.taskId);
+  if (!snapshotRes.success) return failure(snapshotRes.error);
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${input.taskId}`);
 
@@ -115,59 +257,43 @@ export async function runTaskImplementationAgent(
   const worktreeRes = await prepareTaskWorktree({
     snapshot,
     repoPath: input.cwd,
-    commandRunner: input.commandRunner,
+    commandRunner,
     readDefaultBranch: input.readDefaultBranch,
   });
-  if (!worktreeRes.success) return worktreeRes;
+  if (!worktreeRes.success) return failure(worktreeRes.error);
 
   const startedRes = updateTaskStatus(input.taskId, TASK_STATUS.IMPLEMENTING);
-  if (!startedRes.success) return startedRes;
+  if (!startedRes.success) return failure(startedRes.error);
+
+  return success({ snapshot, approvedPlan, worktree: worktreeRes.data });
+}
+
+export async function runTaskImplementationAgent(
+  input: RunTaskImplementationAgentInput,
+): Promise<Result<RunTaskImplementationAgentOutput>> {
+  const commandRunner = input.commandRunner || defaultTaskWorktreeCommandRunner;
+  const prepared = await prepareImplementationRun(input, commandRunner);
+  if (!prepared.success) return prepared;
 
   const agentId = input.agentId || 'implementer';
-  const result = await runTaskAgentTurn({
-    taskId: input.taskId,
-    threadId: snapshot.thread.threadId,
+  const result = await runImplementationTurn({
+    taskInput: input,
+    snapshot: prepared.data.snapshot,
+    approvedPlan: prepared.data.approvedPlan,
+    worktree: prepared.data.worktree,
     agentId,
-    prompt: buildImplementationPrompt(
-      snapshot,
-      approvedPlan,
-      worktreeRes.data.worktreePath,
-    ),
-    cwd: worktreeRes.data.worktreePath,
-    editor: input.editor,
-    model: input.model,
-    personalityVersion: input.personalityVersion,
-    inputArtifactIds: [
-      approvedPlan.artifactId,
-      ...snapshot.artifacts.map((artifact) => artifact.artifactId),
-    ],
-    options: {
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      maxTurns: 80,
-    },
   });
 
   if (!result.success) {
-    const rollbackRes = updateTaskStatus(
-      input.taskId,
-      TASK_STATUS.PLANNING_APPROVED,
-    );
-    return rollbackRes.success ? result : rollbackRes;
+    return rollbackToPlanningApproved(input.taskId, result);
   }
 
-  const doneRes = updateTaskStatus(input.taskId, TASK_STATUS.IMPLEMENTED);
-  if (!doneRes.success) return doneRes;
-
-  const refreshedSnapshotRes = readTaskPlanningSnapshot(input.taskId);
-  if (!refreshedSnapshotRes.success) return refreshedSnapshotRes;
-  if (!refreshedSnapshotRes.data) {
-    return failure(`Task ${input.taskId} 已实现，但读取快照失败`);
-  }
-
-  return success({
-    snapshot: refreshedSnapshotRes.data,
-    approvedPlan,
+  return runAutoCommitLoop({
+    taskInput: input,
+    approvedPlan: prepared.data.approvedPlan,
+    worktree: prepared.data.worktree,
+    agentId,
+    commandRunner,
     assistantText: result.data.assistantText,
   });
 }

--- a/packages/along/src/domain/task-implementation-prompts.ts
+++ b/packages/along/src/domain/task-implementation-prompts.ts
@@ -1,0 +1,135 @@
+import type { TaskAutoCommitFailure } from './task-auto-commit-types';
+import type {
+  TaskPlanningSnapshot,
+  TaskPlanRevisionRecord,
+} from './task-planning';
+
+function truncateText(value: string, maxLength = 5000): string {
+  const text = value.trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}\n...（内容已截断）`;
+}
+
+function buildImplementationContext(
+  snapshot: TaskPlanningSnapshot,
+  approvedPlan: TaskPlanRevisionRecord,
+  worktreePath: string,
+): Record<string, unknown> {
+  return {
+    task: {
+      taskId: snapshot.task.taskId,
+      title: snapshot.task.title,
+      body: truncateText(snapshot.task.body, 4000),
+      repoOwner: snapshot.task.repoOwner,
+      repoName: snapshot.task.repoName,
+      sourceCwd: snapshot.task.cwd,
+      worktreePath,
+    },
+    approvedPlan: {
+      planId: approvedPlan.planId,
+      version: approvedPlan.version,
+      body: truncateText(approvedPlan.body, 8000),
+    },
+    recentArtifacts: snapshot.artifacts.slice(-30).map((artifact) => ({
+      artifactId: artifact.artifactId,
+      type: artifact.type,
+      role: artifact.role,
+      body: truncateText(artifact.body, 2500),
+      metadata: artifact.metadata,
+    })),
+  };
+}
+
+export function buildImplementationPrompt(
+  snapshot: TaskPlanningSnapshot,
+  approvedPlan: TaskPlanRevisionRecord,
+  worktreePath: string,
+): string {
+  return [
+    '你是 Along 的 Implementation Agent。你的任务是在当前 Task 专属 worktree 中严格按已批准方案完成代码实现。',
+    '',
+    '要求：',
+    '1. 不重新制定计划，不扩大需求范围。',
+    '2. 修改代码前先检查当前 worktree 状态和相关代码。',
+    '3. 只修改完成已批准方案所必需的文件。',
+    '4. 需要测试时，优先运行相关的局部测试或类型检查。',
+    '5. 不要创建 PR，不要提交或推送代码；本阶段只完成工作区代码改动和必要验证。',
+    '6. 最终回复必须简短说明改了什么、验证了什么、还有什么风险。',
+    '',
+    '任务上下文：',
+    JSON.stringify(
+      buildImplementationContext(snapshot, approvedPlan, worktreePath),
+      null,
+      2,
+    ),
+  ].join('\n');
+}
+
+export interface AutoCommitFixPromptInput {
+  snapshot: TaskPlanningSnapshot;
+  approvedPlan: TaskPlanRevisionRecord;
+  worktreePath: string;
+  failure: TaskAutoCommitFailure;
+  attempt: number;
+  maxAttempts: number;
+}
+
+function formatFailureArtifact(failure: TaskAutoCommitFailure): string {
+  return failure.failureArtifactId
+    ? `完整日志 artifact：${failure.failureArtifactId}`
+    : '完整日志 artifact：记录失败';
+}
+
+function formatChangedFiles(failure: TaskAutoCommitFailure): string {
+  return failure.changedFiles.length > 0
+    ? failure.changedFiles.map((file) => `- ${file}`).join('\n')
+    : '- 未能从 git status 解析到文件';
+}
+
+function buildFixPromptContext(
+  input: AutoCommitFixPromptInput,
+): Record<string, unknown> {
+  return {
+    task: {
+      taskId: input.snapshot.task.taskId,
+      title: input.snapshot.task.title,
+      body: truncateText(input.snapshot.task.body, 4000),
+    },
+    approvedPlan: {
+      planId: input.approvedPlan.planId,
+      version: input.approvedPlan.version,
+      body: truncateText(input.approvedPlan.body, 8000),
+    },
+  };
+}
+
+export function buildAutoCommitFixPrompt(
+  input: AutoCommitFixPromptInput,
+): string {
+  return [
+    '你是 Along 的 Implementation Agent。系统在实施阶段结束后的 auto-commit 子步骤中发现质量门禁或 git commit 失败。',
+    '',
+    '你的任务：基于当前 Task 专属 worktree 修复导致 commit 失败的问题，然后结束本轮修复。',
+    '',
+    '要求：',
+    '1. 不重新制定计划，不扩大需求范围。',
+    '2. 只修改修复 auto-commit 失败所必需的文件。',
+    '3. 优先根据错误信息修复 biome、类型、测试或 commit hook 问题。',
+    '4. 不要创建 PR，不要提交或推送代码；系统会在你完成后重新尝试 commit。',
+    '5. 最终回复简短说明修复了什么、验证了什么、还有什么风险。',
+    '',
+    `修复尝试：${input.attempt}/${input.maxAttempts}`,
+    `worktree：${input.worktreePath}`,
+    `失败命令：${input.failure.command}`,
+    formatFailureArtifact(input.failure),
+    '',
+    '错误摘要：',
+    input.failure.summary,
+    '',
+    '相关文件：',
+    formatChangedFiles(input.failure),
+    '',
+    '任务上下文：',
+    JSON.stringify(buildFixPromptContext(input), null, 2),
+  ].join('\n');
+}


### PR DESCRIPTION
along-task: #4

## 修改内容
- `ocs/task-thread-planning-session-implementation.md`
- `packages/along/src/domain/task-auto-commit-types.ts`
- `packages/along/src/domain/task-auto-commit-utils.ts`
- `packages/along/src/domain/task-auto-commit.test.ts`
- `packages/along/src/domain/task-auto-commit.ts`
- `packages/along/src/domain/task-delivery.test.ts`
- `packages/along/src/domain/task-delivery.ts`
- `packages/along/src/domain/task-implementation-agent.test.ts`
- `packages/along/src/domain/task-implementation-agent.ts`
- `packages/along/src/domain/task-implementation-prompts.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 在本地仓库完成代码实现
3. 提交并推送分支 `feat/task-4`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：调整任务执行流程，将 commit 从当前与 push、PR 绑定的后置流程中拆出，并前置到实施阶段结束后自动执行。这样 commit 触发的 biome 等质量检查可以尽早暴露问题，并允许 AI 在进入 push/PR 前继续修复。

实施范围：
1. 梳理现有实施阶段、commit、push、PR 的编排逻辑，确认当前 commit 与 push/PR 的耦合位置。
2. 将 commit 动作抽象为可独立调用的步骤，避免与 push、PR 创建强绑定。
3. 在实施阶段完成后新增自动 commit 流程：
   - 使用现有提交规范生成 commit message；
   - 执行 commit；
   - 捕获 commit hook 或 biome 检查失败信息；
   - 若失败，将错误反馈给 AI 修复流程，并允许修复后再次尝试 commit。
4. 调整后续 push/PR 阶段，使其基于已存在的本地 commit 继续执行，只负责 push 和 PR 创建/更新。
5. 补充或更新测试，覆盖：
   - 实施阶段结束会触发 commit；
   - commit 失败时不会继续 push/PR；
   - commit 成功后 push/PR 阶段不重复生成 commit；
   - 原有手动或已有 commit 场景不被破坏。
6. 更新必要的流程说明或内部文档，明确 commit 已成为实施阶段的一部分，push/PR 阶段只处理远端同步与合并请求。

验收标准：
1. 实施阶段完成后会自动尝试 commit。
2. biome 或其他 commit hook 检查失败时，系统能够阻断后续 push/PR，并将问题交回 AI 修复。
3. 修复完成后可以重新 commit，并在成功后继续进入 push/PR。
4. push/PR 逻辑不再隐式负责创建 commit。
5. 相关自动化测试通过，且不绕过现有 hook、CI 或质量门禁。

## 交付信息
- Commit: 2cd77521a7e2282983e9fdbeb74c36982fa8fffa