### PR TITLE
Task #7: along web面板样式调整

### DIFF
--- a/.along/git-hooks/pre-commit
+++ b/.along/git-hooks/pre-commit
@@ -1,2 +1,3 @@
 #!/bin/sh
 bunx biome check --staged --write --no-errors-on-unmatched
+git update-index --again

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -194,10 +194,7 @@ function NewTaskComposer({
   onCreateTask: (event: FormEvent) => void;
 }) {
   return (
-    <form
-      onSubmit={onCreateTask}
-      className="flex flex-col gap-3"
-    >
+    <form onSubmit={onCreateTask} className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
         <div className="text-sm font-semibold text-text-secondary">
           任务内容

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -22,7 +22,6 @@ import {
 import { TaskFlowPanel } from './TaskFlowPanel';
 import { TaskProgressPanel } from './TaskProgressPanel';
 import { TaskRecordsPanel } from './TaskRecords';
-import { TaskStatusBadge } from './TaskStatusBadge';
 
 function CurrentPlanPanel({ selected }: { selected: TaskPlanningSnapshot }) {
   return (
@@ -149,7 +148,7 @@ function ExistingTaskComposer({
         event.preventDefault();
         onSubmitMessage();
       }}
-      className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3"
+      className="flex flex-col gap-3"
     >
       <div className="text-sm font-semibold text-text-secondary">继续输入</div>
       <textarea
@@ -197,11 +196,11 @@ function NewTaskComposer({
   return (
     <form
       onSubmit={onCreateTask}
-      className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3"
+      className="flex flex-col gap-3"
     >
       <div className="flex items-center justify-between gap-3">
         <div className="text-sm font-semibold text-text-secondary">
-          继续输入
+          任务内容
         </div>
         {selectedRepository && (
           <span className="text-xs text-text-muted truncate">
@@ -325,27 +324,22 @@ function NewTaskDetail({
   onScroll: (element: HTMLDivElement) => void;
 }) {
   return (
-    <>
-      <div className="shrink-0 p-4 md:p-6 border-b border-border-color flex flex-col gap-2">
-        <div className="text-xs text-text-muted">新任务会话</div>
-        <h2 className="text-lg md:text-xl font-semibold">新任务</h2>
-      </div>
+    <div className="flex-1 min-h-0 flex flex-col">
       <div
         ref={scrollRef}
         onScroll={(event) => onScroll(event.currentTarget)}
-        className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
-      >
-        <TaskRecordsPanel artifacts={[]}>
-          <NewTaskComposer
-            draft={detail.draft}
-            selectedRepository={detail.selectedRepository}
-            busyAction={detail.busyAction}
-            onDraftChange={detail.onDraftChange}
-            onCreateTask={detail.onCreateTask}
-          />
-        </TaskRecordsPanel>
+        className="flex-1 min-h-0 overflow-auto"
+      />
+      <div className="shrink-0 border-t border-border-color bg-bg-secondary p-4 md:p-5">
+        <NewTaskComposer
+          draft={detail.draft}
+          selectedRepository={detail.selectedRepository}
+          busyAction={detail.busyAction}
+          onDraftChange={detail.onDraftChange}
+          onCreateTask={detail.onCreateTask}
+        />
       </div>
-    </>
+    </div>
   );
 }
 
@@ -361,37 +355,7 @@ function SelectedTaskDetail({
   onScroll: (element: HTMLDivElement) => void;
 }) {
   return (
-    <>
-      <div className="shrink-0 p-4 md:p-6 border-b border-border-color flex flex-col gap-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 mb-2">
-              <TaskStatusBadge snapshot={selected} />
-              {selected.task.type && (
-                <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-500/15 text-violet-300 border border-violet-500/30">
-                  {selected.task.type}
-                </span>
-              )}
-              <span className="text-xs text-text-muted">
-                v{selected.currentPlan?.version || 0}
-              </span>
-            </div>
-            <h2 className="text-lg md:text-xl font-semibold truncate">
-              {selected.task.seq != null && (
-                <span className="text-text-muted mr-1">
-                  #{selected.task.seq}
-                </span>
-              )}
-              {selected.task.title}
-            </h2>
-          </div>
-          <div className="shrink-0 text-right text-xs text-text-muted">
-            <div>{formatTime(selected.task.updatedAt)}</div>
-            <div>{getTaskStatusLabel(selected.task.status)}</div>
-          </div>
-        </div>
-      </div>
-
+    <div className="flex-1 min-h-0 flex flex-col">
       <div
         ref={scrollRef}
         onScroll={(event) => onScroll(event.currentTarget)}
@@ -406,18 +370,19 @@ function SelectedTaskDetail({
           <CurrentPlanPanel selected={selected} />
           <TaskProgressPanel snapshot={selected} />
           <AgentStagesPanel stages={selected.agentStages || []} />
-          <TaskRecordsPanel artifacts={detail.sortedArtifacts}>
-            <ExistingTaskComposer
-              flow={selected.flow}
-              messageBody={detail.messageBody}
-              busyAction={detail.busyAction}
-              onMessageChange={detail.onMessageChange}
-              onSubmitMessage={detail.onSubmitMessage}
-            />
-          </TaskRecordsPanel>
+          <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
         </div>
         <TaskInfoPanel selected={selected} />
       </div>
-    </>
+      <div className="shrink-0 border-t border-border-color bg-bg-secondary p-4 md:p-5">
+        <ExistingTaskComposer
+          flow={selected.flow}
+          messageBody={detail.messageBody}
+          busyAction={detail.busyAction}
+          onMessageChange={detail.onMessageChange}
+          onSubmitMessage={detail.onSubmitMessage}
+        />
+      </div>
+    </div>
   );
 }

--- a/packages/along/src/domain/task-auto-commit-settle.ts
+++ b/packages/along/src/domain/task-auto-commit-settle.ts
@@ -1,0 +1,91 @@
+import type { Result } from '../core/result';
+import type { TaskAutoCommitFailure } from './task-auto-commit-types';
+import { parseChangedFiles } from './task-auto-commit-utils';
+
+interface FailAutoCommitInput {
+  step: string;
+  command: string;
+  error: string;
+  changedFiles: string[];
+}
+
+interface SettlePostCommitChangesInput {
+  changedFiles: string[];
+  runGit: (args: string[]) => Promise<Result<string>>;
+  fail: (input: FailAutoCommitInput) => TaskAutoCommitFailure;
+}
+
+function mergeChangedFiles(...groups: string[][]): string[] {
+  return [...new Set(groups.flat())].sort();
+}
+
+async function readChangedFiles(
+  input: SettlePostCommitChangesInput,
+): Promise<TaskAutoCommitFailure | string[]> {
+  const statusRes = await input.runGit(['status', '--porcelain']);
+  if (!statusRes.success) {
+    return input.fail({
+      step: '读取提交后 git 状态失败',
+      command: 'git status --porcelain',
+      error: statusRes.error,
+      changedFiles: input.changedFiles,
+    });
+  }
+  return parseChangedFiles(statusRes.data);
+}
+
+function failDirtyAfterAmend(
+  input: SettlePostCommitChangesInput,
+  allChangedFiles: string[],
+  finalFiles: string[],
+) {
+  return input.fail({
+    step: '提交后仍有未提交变更',
+    command: 'git status --porcelain',
+    error: `commit hook 或格式化工具在 amend 后仍留下未提交变更: ${finalFiles.join(
+      ', ',
+    )}`,
+    changedFiles: mergeChangedFiles(allChangedFiles, finalFiles),
+  });
+}
+
+export async function settlePostCommitChanges(
+  input: SettlePostCommitChangesInput,
+): Promise<TaskAutoCommitFailure | string[]> {
+  const postCommitFiles = await readChangedFiles(input);
+  if ('success' in postCommitFiles) return postCommitFiles;
+  if (postCommitFiles.length === 0) return input.changedFiles;
+
+  const allChangedFiles = mergeChangedFiles(
+    input.changedFiles,
+    postCommitFiles,
+  );
+  const addRes = await input.runGit(['add', '-A']);
+  if (!addRes.success) {
+    return input.fail({
+      step: '暂存提交后变更失败',
+      command: 'git add -A',
+      error: addRes.error,
+      changedFiles: allChangedFiles,
+    });
+  }
+
+  const amendRes = await input.runGit(['commit', '--amend', '--no-edit']);
+  if (!amendRes.success) {
+    return input.fail({
+      step: '补提交提交后变更失败',
+      command: 'git commit --amend --no-edit',
+      error: amendRes.error,
+      changedFiles: allChangedFiles,
+    });
+  }
+
+  const finalFiles = await readChangedFiles({
+    ...input,
+    changedFiles: allChangedFiles,
+  });
+  if ('success' in finalFiles) return finalFiles;
+  return finalFiles.length === 0
+    ? allChangedFiles
+    : failDirtyAfterAmend(input, allChangedFiles, finalFiles);
+}

--- a/packages/along/src/domain/task-auto-commit.test.ts
+++ b/packages/along/src/domain/task-auto-commit.test.ts
@@ -81,9 +81,13 @@ describe('task-auto-commit', () => {
 
   it('当工作区有变更时，期望暂存并提交，同时记录 commit sha', async () => {
     const calls: string[] = [];
+    let statusCount = 0;
     const runner: TaskWorktreeCommandRunner = async (command, args) => {
       calls.push(`${command} ${args.join(' ')}`);
-      if (args[0] === 'status') return ok(' M src/app.ts');
+      if (args[0] === 'status') {
+        statusCount += 1;
+        return statusCount === 1 ? ok(' M src/app.ts') : ok('');
+      }
       if (args[0] === 'rev-parse') return ok('abc123');
       return ok('');
     };
@@ -109,6 +113,34 @@ describe('task-auto-commit', () => {
       branchName: 'fix/demo-1',
       commitShas: ['abc123'],
     });
+  });
+
+  it('当 commit hook 写回格式化变更时，期望自动 amend 并保持工作区干净', async () => {
+    const calls: string[] = [];
+    let statusCount = 0;
+    const runner: TaskWorktreeCommandRunner = async (command, args) => {
+      calls.push(`${command} ${args.join(' ')}`);
+      if (args[0] === 'status') {
+        statusCount += 1;
+        return statusCount <= 2 ? ok(' M src/app.ts') : ok('');
+      }
+      if (args[0] === 'rev-parse') return ok('amended123');
+      return ok('');
+    };
+
+    const result = await runTaskAutoCommit({
+      snapshot,
+      worktreePath: '/tmp/worktree',
+      branchName: 'fix/demo-1',
+      defaultBranch: 'main',
+      commandRunner: runner,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.commitShas).toEqual(['amended123']);
+    expect(result.data.changedFiles).toEqual(['src/app.ts']);
+    expect(calls).toContain('git commit --amend --no-edit');
   });
 
   it('当 commit hook 失败时，期望返回摘要并记录完整日志 artifact', async () => {

--- a/packages/along/src/domain/task-auto-commit.ts
+++ b/packages/along/src/domain/task-auto-commit.ts
@@ -1,5 +1,6 @@
 import type { Result } from '../core/result';
 import { success } from '../core/result';
+import { settlePostCommitChanges } from './task-auto-commit-settle';
 import type {
   RunTaskAutoCommitInput,
   TaskAutoCommitFailure,
@@ -177,7 +178,7 @@ async function stageAndCommitChanges(
   input: RunTaskAutoCommitInput,
   changedFiles: string[],
   commitMessage: string,
-): Promise<TaskAutoCommitFailure | null> {
+): Promise<TaskAutoCommitFailure | string[]> {
   const addRes = await runGit(input.commandRunner, input.worktreePath, [
     'add',
     '-A',
@@ -197,13 +198,24 @@ async function stageAndCommitChanges(
     '-m',
     commitMessage,
   ]);
-  if (commitRes.success) return null;
-  return failAutoCommit({
-    step: '提交失败',
-    command: `git commit -m "${commitMessage}"`,
-    error: commitRes.error,
+  if (!commitRes.success) {
+    return failAutoCommit({
+      step: '提交失败',
+      command: `git commit -m "${commitMessage}"`,
+      error: commitRes.error,
+      changedFiles,
+      autoCommitInput: input,
+    });
+  }
+
+  return settlePostCommitChanges({
     changedFiles,
-    autoCommitInput: input,
+    runGit: (args) => runGit(input.commandRunner, input.worktreePath, args),
+    fail: (failureInput) =>
+      failAutoCommit({
+        ...failureInput,
+        autoCommitInput: input,
+      }),
   });
 }
 
@@ -274,11 +286,11 @@ export async function runTaskAutoCommit(
     return reuseExistingCommit(input, changedFiles, commitMessage);
   }
 
-  const commitFailure = await stageAndCommitChanges(
+  const committedFiles = await stageAndCommitChanges(
     input,
     changedFiles,
     commitMessage,
   );
-  if (commitFailure) return commitFailure;
-  return recordNewCommit(input, changedFiles, commitMessage);
+  if ('success' in committedFiles) return committedFiles;
+  return recordNewCommit(input, committedFiles, commitMessage);
 }

--- a/packages/along/src/domain/task-worktree.test.ts
+++ b/packages/along/src/domain/task-worktree.test.ts
@@ -18,6 +18,7 @@ vi.mock('./worktree-init', () => ({
 }));
 
 import {
+  defaultTaskWorktreeCommandRunner,
   prepareTaskWorktree,
   type TaskWorktreeCommandRunner,
 } from './task-worktree';
@@ -73,6 +74,18 @@ describe('task-worktree', () => {
       success: true,
       data: undefined,
     });
+  });
+
+  it('执行命令时保留 stdout 前导空格，避免破坏 git porcelain 输出', async () => {
+    const result = await defaultTaskWorktreeCommandRunner(
+      process.execPath,
+      ['-e', "process.stdout.write(' M src/app.ts\\n')"],
+      { cwd: process.cwd() },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data).toBe(' M src/app.ts');
   });
 
   it('为 Task 创建独立 worktree，并把 branch/worktree 写回 Task', async () => {

--- a/packages/along/src/domain/task-worktree.ts
+++ b/packages/along/src/domain/task-worktree.ts
@@ -59,7 +59,9 @@ export async function defaultTaskWorktreeCommandRunner(
   });
   if (result.error) return failure(result.error.message);
   if (result.status !== 0) return failure(getErrorOutput(result));
-  return success(typeof result.stdout === 'string' ? result.stdout.trim() : '');
+  return success(
+    typeof result.stdout === 'string' ? result.stdout.trimEnd() : '',
+  );
 }
 
 function slugifyTitle(title: string): string {
@@ -184,93 +186,150 @@ async function isGitWorktree(
   return result.success && result.data.trim() === 'true';
 }
 
-export async function prepareTaskWorktree(
-  input: PrepareTaskWorktreeInput,
-): Promise<Result<PrepareTaskWorktreeOutput>> {
-  const { snapshot } = input;
-  const runner = input.commandRunner || defaultTaskWorktreeCommandRunner;
-  const readDefaultBranch = input.readDefaultBranch || getDefaultBranch;
+interface TaskWorktreeContext {
+  runner: TaskWorktreeCommandRunner;
+  snapshot: TaskPlanningSnapshot;
+  repoPath: string;
+  worktreePath: string;
+  branchName: string;
+  defaultBranch: string;
+}
 
+function getTaskDataDir(
+  snapshot: TaskPlanningSnapshot,
+  repoOwner: string,
+  repoName: string,
+) {
+  return snapshot.task.seq != null
+    ? config.getTaskDirBySeq(repoOwner, repoName, snapshot.task.seq)
+    : config.getTaskDir(repoOwner, repoName, snapshot.task.taskId);
+}
+
+async function resolveBranchName(
+  input: PrepareTaskWorktreeInput,
+  runner: TaskWorktreeCommandRunner,
+) {
+  return (
+    input.snapshot.task.branchName ||
+    generateTaskBranchName(
+      runner,
+      input.repoPath,
+      input.snapshot.task.taskId,
+      input.snapshot.task.title,
+      input.snapshot.task.seq,
+      input.snapshot.task.type,
+    )
+  );
+}
+
+async function resolveTaskWorktreeContext(
+  input: PrepareTaskWorktreeInput,
+): Promise<Result<TaskWorktreeContext>> {
+  const runner = input.commandRunner || defaultTaskWorktreeCommandRunner;
   const repositoryRes = await ensureTaskRepository(
-    snapshot,
+    input.snapshot,
     input.repoPath,
     runner,
   );
   if (!repositoryRes.success) {
     return failure(`${repositoryRes.error}，不能创建独立 worktree`);
   }
-  const { repoOwner, repoName } = repositoryRes.data;
 
+  const readDefaultBranch = input.readDefaultBranch || getDefaultBranch;
   const defaultBranchRes = await readDefaultBranch(input.repoPath);
   if (!defaultBranchRes.success) return defaultBranchRes;
-  const defaultBranch = defaultBranchRes.data;
 
-  const taskDir =
-    snapshot.task.seq != null
-      ? config.getTaskDirBySeq(repoOwner, repoName, snapshot.task.seq)
-      : config.getTaskDir(repoOwner, repoName, snapshot.task.taskId);
-  const worktreePath =
-    snapshot.task.worktreePath || path.join(taskDir, 'worktree');
-  const branchName =
-    snapshot.task.branchName ||
-    (await generateTaskBranchName(
-      runner,
-      input.repoPath,
-      snapshot.task.taskId,
-      snapshot.task.title,
-      snapshot.task.seq,
-      snapshot.task.type,
-    ));
+  const { repoOwner, repoName } = repositoryRes.data;
+  const taskDir = getTaskDataDir(input.snapshot, repoOwner, repoName);
+  return success({
+    runner,
+    snapshot: input.snapshot,
+    repoPath: input.repoPath,
+    worktreePath:
+      input.snapshot.task.worktreePath || path.join(taskDir, 'worktree'),
+    branchName: await resolveBranchName(input, runner),
+    defaultBranch: defaultBranchRes.data,
+  });
+}
 
-  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
-
-  const fetchRes = await runGit(runner, input.repoPath, [
+async function syncDefaultBranch(context: TaskWorktreeContext) {
+  fs.mkdirSync(path.dirname(context.worktreePath), { recursive: true });
+  const fetchRes = await runGit(context.runner, context.repoPath, [
     'fetch',
     'origin',
-    defaultBranch,
+    context.defaultBranch,
   ]);
   if (!fetchRes.success) {
     return failure(`同步远端默认分支失败: ${fetchRes.error}`);
   }
+  await runGit(context.runner, context.repoPath, ['worktree', 'prune']);
+  return success(null);
+}
 
-  await runGit(runner, input.repoPath, ['worktree', 'prune']);
+async function createTaskWorktree(context: TaskWorktreeContext) {
+  const addArgs = context.snapshot.task.branchName
+    ? ['worktree', 'add', context.worktreePath, context.branchName]
+    : [
+        'worktree',
+        'add',
+        '-B',
+        context.branchName,
+        context.worktreePath,
+        `origin/${context.defaultBranch}`,
+      ];
+  const addRes = await runGit(context.runner, context.repoPath, addArgs);
+  return addRes.success
+    ? success(null)
+    : failure(`创建 Task worktree 失败: ${addRes.error}`);
+}
 
-  if (await isGitWorktree(runner, worktreePath)) {
-    const switchRes = await runGit(runner, worktreePath, [
+async function ensureTaskWorktreeReady(context: TaskWorktreeContext) {
+  if (await isGitWorktree(context.runner, context.worktreePath)) {
+    const switchRes = await runGit(context.runner, context.worktreePath, [
       'switch',
-      branchName,
+      context.branchName,
     ]);
-    if (!switchRes.success) {
-      return failure(`切换 Task worktree 分支失败: ${switchRes.error}`);
-    }
-  } else if (fs.existsSync(worktreePath)) {
-    return failure(
-      `Task worktree 路径已存在但不是 Git worktree: ${worktreePath}`,
-    );
-  } else {
-    const addArgs = snapshot.task.branchName
-      ? ['worktree', 'add', worktreePath, branchName]
-      : [
-          'worktree',
-          'add',
-          '-B',
-          branchName,
-          worktreePath,
-          `origin/${defaultBranch}`,
-        ];
-    const addRes = await runGit(runner, input.repoPath, addArgs);
-    if (!addRes.success) {
-      return failure(`创建 Task worktree 失败: ${addRes.error}`);
-    }
+    return switchRes.success
+      ? success(null)
+      : failure(`切换 Task worktree 分支失败: ${switchRes.error}`);
   }
 
-  const updateRes = updateTaskDelivery({
-    taskId: snapshot.task.taskId,
-    status: snapshot.task.status,
-    branchName,
-    worktreePath,
+  if (fs.existsSync(context.worktreePath)) {
+    return failure(
+      `Task worktree 路径已存在但不是 Git worktree: ${context.worktreePath}`,
+    );
+  }
+  return createTaskWorktree(context);
+}
+
+function recordTaskWorktree(context: TaskWorktreeContext) {
+  return updateTaskDelivery({
+    taskId: context.snapshot.task.taskId,
+    status: context.snapshot.task.status,
+    branchName: context.branchName,
+    worktreePath: context.worktreePath,
   });
+}
+
+export async function prepareTaskWorktree(
+  input: PrepareTaskWorktreeInput,
+): Promise<Result<PrepareTaskWorktreeOutput>> {
+  const contextRes = await resolveTaskWorktreeContext(input);
+  if (!contextRes.success) return contextRes;
+  const context = contextRes.data;
+
+  const syncRes = await syncDefaultBranch(context);
+  if (!syncRes.success) return syncRes;
+
+  const worktreeRes = await ensureTaskWorktreeReady(context);
+  if (!worktreeRes.success) return worktreeRes;
+
+  const updateRes = recordTaskWorktree(context);
   if (!updateRes.success) return updateRes;
 
-  return success({ worktreePath, branchName, defaultBranch });
+  return success({
+    worktreePath: context.worktreePath,
+    branchName: context.branchName,
+    defaultBranch: context.defaultBranch,
+  });
 }


### PR DESCRIPTION
along-task: #7

## 修改内容
- `.along/git-hooks/pre-commit`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along/src/domain/task-auto-commit-settle.ts`
- `packages/along/src/domain/task-auto-commit.test.ts`
- `packages/along/src/domain/task-auto-commit.ts`
- `packages/along/src/domain/task-worktree.test.ts`
- `packages/along/src/domain/task-worktree.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `style/along-web-7`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：调整 Along Web 面板的任务编辑/查看区域样式，使界面减少重复标题占位，并保证输入区在长内容场景下始终可操作。

范围：
1. 任务详情面板移除顶部 header，仅保留正文内容和必要操作入口；如 header 内存在返回、关闭、状态切换等关键交互，需要迁移到不增加顶部标题栏的合理位置。
2. 新增任务面板移除顶部“新任务”header，保持创建表单本身的可识别性和操作完整性。
3. 任务讨论/输入框固定在面板底部，不随内容滚动区域滚动；内容列表或详情正文应独立滚动，避免输入框被滚出视口。

边界：
- 本任务仅处理 Web 面板布局与样式交互，不改变任务创建、详情加载、提交、状态流转等业务逻辑。
- 不主动保留旧 header 的视觉兼容；若存在依赖 header 的快捷操作，需要以新的布局承载，避免功能丢失。
- 不引入临时遮挡、绝对定位覆盖内容等只修表象的方案，应保证不同内容长度下布局结构稳定。

风险：
- 移除 header 可能影响原有操作入口、无障碍标签或测试选择器，需要确认相关入口仍可访问。
- 输入框固定底部可能与移动端安全区、窄屏高度、虚拟键盘或滚动容器边界产生冲突，需要重点检查。
- 若当前面板存在多种模式（详情、新建、编辑、讨论），需要避免只修其中一个入口导致体验不一致。

验证：
1. 在任务详情面板确认顶部 header 不再显示，详情内容与必要操作入口正常。
2. 在新增任务面板确认顶部“新任务”header 不再显示，表单创建流程正常。
3. 构造长任务详情或长讨论内容，确认滚动时输入框始终固定在底部，内容不被输入框永久遮挡。
4. 覆盖桌面与窄屏视口，检查布局无重叠、无异常空白、滚动区域符合预期。
5. 运行项目既有前端质量检查或相关测试；如无法运行，需要记录原因和剩余风险。

交付标准：
- 三项样式诉求全部落地。
- 原有任务查看、新建和输入提交流程不回归。
- 布局在长内容和窄屏场景下稳定可用。

## 交付信息
- Commit: 0c1f9f74fc1b02be33d7c142b8bcf3e99b128f6d