### PR TITLE
Task #8: along task 1. 输

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -150,12 +150,11 @@ function ExistingTaskComposer({
       }}
       className="flex flex-col gap-3"
     >
-      <div className="text-sm font-semibold text-text-secondary">继续输入</div>
       <textarea
         value={messageBody}
         onChange={(event) => onMessageChange(event.target.value)}
         placeholder="补充反馈、继续提问或说明交付后的修改要求"
-        rows={5}
+        rows={2}
         disabled={!canSubmitMessage}
         className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
       />
@@ -195,21 +194,12 @@ function NewTaskComposer({
 }) {
   return (
     <form onSubmit={onCreateTask} className="flex flex-col gap-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-sm font-semibold text-text-secondary">
-          任务内容
-        </div>
-        {selectedRepository && (
-          <span className="text-xs text-text-muted truncate">
-            {selectedRepository.fullName}
-          </span>
-        )}
-      </div>
+      <div className="text-sm font-semibold text-text-secondary">任务内容</div>
       <textarea
         value={draft.body}
         onChange={(event) => onDraftChange('body', event.target.value)}
         placeholder="输入任务目标或问题"
-        rows={6}
+        rows={2}
         className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
       />
       <div className="flex items-center justify-between gap-3">
@@ -352,33 +342,37 @@ function SelectedTaskDetail({
   onScroll: (element: HTMLDivElement) => void;
 }) {
   return (
-    <div className="flex-1 min-h-0 flex flex-col">
-      <div
-        ref={scrollRef}
-        onScroll={(event) => onScroll(event.currentTarget)}
-        className="flex-1 min-h-0 overflow-auto p-4 md:p-6 grid grid-cols-1 2xl:grid-cols-[minmax(0,1fr)_360px] gap-5"
-      >
-        <div className="min-w-0 flex flex-col gap-5">
-          <TaskFlowPanel
-            flow={selected.flow}
-            busyAction={detail.busyAction}
-            onAction={detail.onAction}
-          />
-          <CurrentPlanPanel selected={selected} />
-          <TaskProgressPanel snapshot={selected} />
-          <AgentStagesPanel stages={selected.agentStages || []} />
-          <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
+    <div className="flex-1 min-h-0 grid grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(180px,34vh)] 2xl:grid-cols-[minmax(0,1fr)_360px] 2xl:grid-rows-1">
+      <section className="min-h-0 min-w-0 flex flex-col">
+        <div
+          ref={scrollRef}
+          onScroll={(event) => onScroll(event.currentTarget)}
+          className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
+        >
+          <div className="min-w-0 flex flex-col gap-5">
+            <TaskFlowPanel
+              flow={selected.flow}
+              busyAction={detail.busyAction}
+              onAction={detail.onAction}
+            />
+            <CurrentPlanPanel selected={selected} />
+            <TaskProgressPanel snapshot={selected} />
+            <AgentStagesPanel stages={selected.agentStages || []} />
+            <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
+          </div>
         </div>
+        <div className="shrink-0 border-t border-border-color bg-bg-secondary p-3 md:p-4">
+          <ExistingTaskComposer
+            flow={selected.flow}
+            messageBody={detail.messageBody}
+            busyAction={detail.busyAction}
+            onMessageChange={detail.onMessageChange}
+            onSubmitMessage={detail.onSubmitMessage}
+          />
+        </div>
+      </section>
+      <div className="min-h-0 min-w-0 overflow-auto border-t border-border-color p-4 md:p-6 2xl:border-l 2xl:border-t-0">
         <TaskInfoPanel selected={selected} />
-      </div>
-      <div className="shrink-0 border-t border-border-color bg-bg-secondary p-4 md:p-5">
-        <ExistingTaskComposer
-          flow={selected.flow}
-          messageBody={detail.messageBody}
-          busyAction={detail.busyAction}
-          onMessageChange={detail.onMessageChange}
-          onSubmitMessage={detail.onSubmitMessage}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
along-task: #8

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.tsx`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/along-task-1-8`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：调整 Along task 页面/详情工作区的输入区与滚动布局，使沟通输入体验更紧凑，且任务信息列与沟通过程互不影响。

范围：
1. 将底部输入框默认高度调整为约 2 行文本高度，保留必要的输入、换行和提交能力。
2. 将输入区固定在中间沟通区域的底部，宽度仅跟随沟通区域，不跨入任务信息列。
3. 调整页面布局，使任务信息区域和沟通过程区域分别拥有独立的纵向滚动容器。
4. 移除输入框上方的“继续输入”文案和仓库标题展示。

边界：
1. 不改变任务、线程、消息、仓库等数据结构和接口语义。
2. 不改变提交输入内容的业务流程，仅调整展示和布局行为。
3. 不主动做旧布局兼容；如有特定历史页面或移动端兼容要求，需要另行确认。

风险：
1. 固定底部输入区可能遮挡沟通记录底部内容，需要为消息列表预留合理底部空间。
2. 独立滚动容器可能影响现有自动滚动到底部、聚焦输入框、移动端视口高度等交互，需要重点验证。
3. 移除仓库标题后，如果当前页面缺少其他仓库上下文入口，可能降低上下文可见性，需要确认页面其他位置仍能表达必要信息。

验证：
1. 打开 task 页面，确认输入框默认仅约 2 行高度，输入多行内容时表现符合现有交互预期。
2. 确认输入区固定在沟通区域底部，未覆盖或跨入任务信息列。
3. 分别滚动任务信息和沟通过程，确认两侧滚动互相独立。
4. 确认输入框上方不再显示“继续输入”和仓库标题。
5. 进行桌面和窄屏视口检查，确认内容不重叠、不被底部输入区异常遮挡。

交付标准：完成布局调整并通过项目现有相关检查；如无法运行完整验证，需要说明未验证项和剩余风险。

## 交付信息
- Commit: 176ef110467dff32ff4fadf1823685f5e9dc0dd8