### PR TITLE
Task #9: 任务详情前端交互优化

### DIFF
--- a/packages/along-web/src/task-planning/AgentStagesPanel.tsx
+++ b/packages/along-web/src/task-planning/AgentStagesPanel.tsx
@@ -1,4 +1,8 @@
-import type { TaskAgentStageRecord } from '../types';
+import type {
+  TaskAgentManualResume,
+  TaskAgentRunRecord,
+  TaskAgentStageRecord,
+} from '../types';
 import {
   formatDuration,
   formatTime,
@@ -8,91 +12,116 @@ import {
 
 function AgentStageItem({ stage }: { stage: TaskAgentStageRecord }) {
   const run = stage.latestRun;
-  const manualResume = stage.manualResume;
   const showManualActions = stage.status === 'failed';
 
   return (
     <div className="rounded-lg border border-border-color bg-black/25 p-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-sm font-semibold text-text-secondary">
-            {stage.label}
-          </div>
-          <div className="text-xs text-text-muted mt-1">
-            {run
-              ? `${run.provider} / ${run.agentId} / ${formatDuration(
-                  run.startedAt,
-                  run.endedAt,
-                )}`
-              : stage.agentId}
-          </div>
-        </div>
-        <span
-          className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${getStageStatusClass(
-            stage.status,
-          )}`}
-        >
-          {getStageStatusLabel(stage.status)}
-        </span>
-      </div>
-
-      {run && (
-        <div className="mt-3 grid grid-cols-[72px_1fr] gap-x-3 gap-y-1 text-xs">
-          <span className="text-text-muted">开始</span>
-          <span>{formatTime(run.startedAt)}</span>
-          {run.endedAt && (
-            <>
-              <span className="text-text-muted">结束</span>
-              <span>{formatTime(run.endedAt)}</span>
-            </>
-          )}
-          <span className="text-text-muted">Run</span>
-          <span className="truncate" title={run.runId}>
-            {run.runId}
-          </span>
-          {(run.providerSessionIdAtEnd || run.providerSessionIdAtStart) && (
-            <>
-              <span className="text-text-muted">Session</span>
-              <span
-                className="truncate"
-                title={
-                  run.providerSessionIdAtEnd || run.providerSessionIdAtStart
-                }
-              >
-                {run.providerSessionIdAtEnd || run.providerSessionIdAtStart}
-              </span>
-            </>
-          )}
-        </div>
-      )}
-
-      {run?.error && (
-        <div className="mt-3 rounded-md border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-xs leading-5 text-rose-200 whitespace-pre-wrap break-words">
-          {run.error}
-        </div>
-      )}
-
+      <AgentStageHeader stage={stage} run={run} />
+      {run && <AgentStageRunDetails run={run} />}
+      {run?.error && <AgentStageError error={run.error} />}
       {showManualActions && (
-        <div className="mt-3 flex flex-col gap-2">
-          {manualResume?.command ? (
-            <pre className="rounded-md border border-border-color bg-black/40 px-3 py-2 text-xs leading-5 text-text-secondary overflow-x-auto whitespace-pre-wrap break-words">
-              {manualResume.command}
-            </pre>
-          ) : (
-            <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
-              {manualResume?.reason || '当前阶段没有可恢复命令'}
-            </div>
-          )}
-          {manualResume?.reason && manualResume.command && (
-            <div className="text-xs text-text-muted">{manualResume.reason}</div>
-          )}
-          <div className="flex flex-wrap gap-2">
-            <div className="text-xs text-text-muted">
-              接管和人工标记请使用当前节奏中的可执行操作。
-            </div>
-          </div>
+        <AgentStageManualActions manualResume={stage.manualResume} />
+      )}
+    </div>
+  );
+}
+
+function AgentStageHeader({
+  stage,
+  run,
+}: {
+  stage: TaskAgentStageRecord;
+  run?: TaskAgentRunRecord;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <div className="text-sm font-semibold text-text-secondary">
+          {stage.label}
+        </div>
+        <div className="text-xs text-text-muted mt-1">
+          {run
+            ? `${run.provider} / ${run.agentId} / ${formatDuration(
+                run.startedAt,
+                run.endedAt,
+              )}`
+            : stage.agentId}
+        </div>
+      </div>
+      <span
+        className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${getStageStatusClass(
+          stage.status,
+        )}`}
+      >
+        {getStageStatusLabel(stage.status)}
+      </span>
+    </div>
+  );
+}
+
+function AgentStageRunDetails({ run }: { run: TaskAgentRunRecord }) {
+  return (
+    <div className="mt-3 grid grid-cols-[72px_1fr] gap-x-3 gap-y-1 text-xs">
+      <span className="text-text-muted">开始</span>
+      <span>{formatTime(run.startedAt)}</span>
+      {run.endedAt && (
+        <>
+          <span className="text-text-muted">结束</span>
+          <span>{formatTime(run.endedAt)}</span>
+        </>
+      )}
+      <span className="text-text-muted">Run</span>
+      <span className="truncate" title={run.runId}>
+        {run.runId}
+      </span>
+      <AgentStageSession run={run} />
+    </div>
+  );
+}
+
+function AgentStageSession({ run }: { run: TaskAgentRunRecord }) {
+  const sessionId = run.providerSessionIdAtEnd || run.providerSessionIdAtStart;
+  if (!sessionId) return null;
+  return (
+    <>
+      <span className="text-text-muted">Session</span>
+      <span className="truncate" title={sessionId}>
+        {sessionId}
+      </span>
+    </>
+  );
+}
+
+function AgentStageError({ error }: { error: string }) {
+  return (
+    <div className="mt-3 rounded-md border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-xs leading-5 text-rose-200 whitespace-pre-wrap break-words">
+      {error}
+    </div>
+  );
+}
+
+function AgentStageManualActions({
+  manualResume,
+}: {
+  manualResume?: TaskAgentManualResume;
+}) {
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {manualResume?.command ? (
+        <pre className="rounded-md border border-border-color bg-black/40 px-3 py-2 text-xs leading-5 text-text-secondary overflow-x-auto whitespace-pre-wrap break-words">
+          {manualResume.command}
+        </pre>
+      ) : (
+        <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
+          {manualResume?.reason || '当前阶段没有可恢复命令'}
         </div>
       )}
+      {manualResume?.reason && manualResume.command && (
+        <div className="text-xs text-text-muted">{manualResume.reason}</div>
+      )}
+      <div className="text-xs text-text-muted">
+        接管和人工标记请在当前状态悬浮区域操作。
+      </div>
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
+  useState,
 } from 'react';
 import type {
   TaskArtifactRecord,
@@ -50,7 +51,7 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
     <aside className="min-w-0 flex flex-col gap-4">
       <div className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3">
         <div className="font-semibold text-sm text-text-secondary">
-          任务信息
+          任务元信息
         </div>
         <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 text-sm">
           <span className="text-text-muted">ID</span>
@@ -107,6 +108,46 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
         </div>
       </div>
     </aside>
+  );
+}
+
+function TaskBodyPanel({ selected }: { selected: TaskPlanningSnapshot }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const body = selected.task.body.trim();
+  const bodyText = body || '暂无任务详情。';
+  const collapsedText = body ? body.replace(/\s+/g, ' ') : bodyText;
+
+  return (
+    <section className="rounded-lg border border-border-color bg-black/25">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded((value) => !value)}
+        className="w-full min-w-0 px-4 py-3 text-left outline-none focus:ring-1 focus:ring-brand/60"
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="shrink-0 text-sm font-semibold text-text-secondary">
+            任务详情
+          </span>
+          {!isExpanded && (
+            <span
+              className="min-w-0 flex-1 truncate text-sm text-text-primary"
+              title={collapsedText}
+            >
+              {collapsedText}
+            </span>
+          )}
+          <span className="ml-auto shrink-0 text-xs text-text-muted">
+            {isExpanded ? '收起' : '展开'}
+          </span>
+        </div>
+        {isExpanded && (
+          <div className="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
+            {bodyText}
+          </div>
+        )}
+      </button>
+    </section>
   );
 }
 
@@ -342,7 +383,7 @@ function SelectedTaskDetail({
   onScroll: (element: HTMLDivElement) => void;
 }) {
   return (
-    <div className="flex-1 min-h-0 grid grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(180px,34vh)] 2xl:grid-cols-[minmax(0,1fr)_360px] 2xl:grid-rows-1">
+    <div className="flex-1 min-h-0 grid grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(260px,40vh)] 2xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-rows-1">
       <section className="min-h-0 min-w-0 flex flex-col">
         <div
           ref={scrollRef}
@@ -350,11 +391,6 @@ function SelectedTaskDetail({
           className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
         >
           <div className="min-w-0 flex flex-col gap-5">
-            <TaskFlowPanel
-              flow={selected.flow}
-              busyAction={detail.busyAction}
-              onAction={detail.onAction}
-            />
             <CurrentPlanPanel selected={selected} />
             <TaskProgressPanel snapshot={selected} />
             <AgentStagesPanel stages={selected.agentStages || []} />
@@ -372,7 +408,15 @@ function SelectedTaskDetail({
         </div>
       </section>
       <div className="min-h-0 min-w-0 overflow-auto border-t border-border-color p-4 md:p-6 2xl:border-l 2xl:border-t-0">
-        <TaskInfoPanel selected={selected} />
+        <div className="flex min-w-0 flex-col gap-4">
+          <TaskBodyPanel selected={selected} />
+          <TaskFlowPanel
+            flow={selected.flow}
+            busyAction={detail.busyAction}
+            onAction={detail.onAction}
+          />
+          <TaskInfoPanel selected={selected} />
+        </div>
       </div>
     </div>
   );

--- a/packages/along-web/src/task-planning/TaskFlowPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowPanel.tsx
@@ -1,62 +1,7 @@
-import type { TaskFlowAction, TaskFlowSnapshot, TaskFlowStage } from '../types';
-import {
-  formatTime,
-  getFlowActionClass,
-  getFlowSeverityClass,
-  getFlowStageDotClass,
-  getFlowStageStateClass,
-} from './format';
-
-function FlowStageItem({ stage }: { stage: TaskFlowStage }) {
-  return (
-    <div
-      className={`min-w-[160px] flex-1 rounded-lg border p-3 ${getFlowStageStateClass(
-        stage.state,
-      )}`}
-    >
-      <div className="flex items-center gap-2">
-        <span
-          className={`h-2.5 w-2.5 rounded-full shrink-0 ${getFlowStageDotClass(
-            stage.state,
-          )}`}
-        />
-        <span className="text-sm font-semibold">{stage.label}</span>
-      </div>
-      <div className="mt-2 text-xs leading-5 text-text-secondary">
-        {stage.summary}
-      </div>
-      {stage.blocker && (
-        <div className="mt-2 text-xs leading-5 text-rose-200">
-          {stage.blocker}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function FlowActionButton({
-  action,
-  busy,
-  onClick,
-}: {
-  action: TaskFlowAction;
-  busy: boolean;
-  onClick: (action: TaskFlowAction) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onClick(action)}
-      disabled={!action.enabled || busy}
-      title={!action.enabled ? action.disabledReason : action.description}
-      className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
-        action,
-      )}`}
-    >
-      {busy ? '处理中' : action.label}
-    </button>
-  );
-}
+import { useState } from 'react';
+import type { TaskFlowAction, TaskFlowSnapshot } from '../types';
+import { formatTime, getFlowSeverityClass } from './format';
+import { FlowStages } from './TaskFlowStageCard';
 
 export function TaskFlowPanel({
   flow,
@@ -67,6 +12,7 @@ export function TaskFlowPanel({
   busyAction: string | null;
   onAction: (action: TaskFlowAction) => void;
 }) {
+  const [openStageId, setOpenStageId] = useState<string | null>(null);
   const commandActions = flow.actions.filter(
     (action) =>
       !['submit_feedback', 'request_revision', 'request_changes'].includes(
@@ -77,12 +23,14 @@ export function TaskFlowPanel({
   return (
     <section className="rounded-lg border border-border-color bg-black/25 p-4 md:p-5 flex flex-col gap-4">
       <FlowSummary flow={flow} />
-      <FlowStages stages={flow.stages} />
-      <FlowActions
-        actions={flow.actions}
+      <FlowStages
+        stages={flow.stages}
+        currentStageId={flow.currentStageId}
         commandActions={commandActions}
         busyAction={busyAction}
         onAction={onAction}
+        openStageId={openStageId}
+        onOpenStageChange={setOpenStageId}
       />
       <FlowHistory flow={flow} />
     </section>
@@ -107,65 +55,6 @@ function FlowSummary({ flow }: { flow: TaskFlowSnapshot }) {
           ))}
         </div>
       )}
-    </div>
-  );
-}
-
-function FlowStages({ stages }: { stages: TaskFlowStage[] }) {
-  return (
-    <div className="flex gap-3 overflow-x-auto pb-1">
-      {stages.map((stage) => (
-        <FlowStageItem key={stage.id} stage={stage} />
-      ))}
-    </div>
-  );
-}
-
-function FlowActions({
-  actions,
-  commandActions,
-  busyAction,
-  onAction,
-}: {
-  actions: TaskFlowAction[];
-  commandActions: TaskFlowAction[];
-  busyAction: string | null;
-  onAction: (action: TaskFlowAction) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="text-sm font-semibold text-text-secondary">
-        可执行操作
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {commandActions.map((action) => (
-          <FlowActionButton
-            key={action.id}
-            action={action}
-            busy={Boolean(busyAction)}
-            onClick={onAction}
-          />
-        ))}
-      </div>
-      <FlowDisabledReasons actions={actions} />
-    </div>
-  );
-}
-
-function FlowDisabledReasons({ actions }: { actions: TaskFlowAction[] }) {
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-      {actions
-        .filter((action) => !action.enabled && action.disabledReason)
-        .map((action) => (
-          <div
-            key={action.id}
-            className="rounded-md border border-border-color bg-black/20 px-3 py-2 text-xs leading-5 text-text-muted"
-          >
-            <span className="text-text-secondary">{action.label}</span>：
-            {action.disabledReason}
-          </div>
-        ))}
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
@@ -1,0 +1,277 @@
+import type { TaskFlowAction, TaskFlowStage } from '../types';
+import {
+  getFlowActionClass,
+  getFlowStageDotClass,
+  getFlowStageStateClass,
+} from './format';
+
+function getStageActionScope(
+  actions: TaskFlowAction[],
+  stage: TaskFlowStage,
+): TaskFlowAction[] {
+  const stageActions = actions.filter((action) => action.stage === stage.id);
+  return stageActions.length > 0 ? stageActions : actions;
+}
+
+export function FlowStages({
+  stages,
+  currentStageId,
+  commandActions,
+  busyAction,
+  onAction,
+  openStageId,
+  onOpenStageChange,
+}: {
+  stages: TaskFlowStage[];
+  currentStageId: string;
+  commandActions: TaskFlowAction[];
+  busyAction: string | null;
+  onAction: (action: TaskFlowAction) => void;
+  openStageId: string | null;
+  onOpenStageChange: (stageId: string | null) => void;
+}) {
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-1">
+      {stages.map((stage) => {
+        const isCurrent = stage.id === currentStageId;
+        return (
+          <FlowStageItem
+            key={stage.id}
+            stage={stage}
+            actions={commandActions}
+            busyAction={busyAction}
+            isCurrent={isCurrent}
+            isOpen={openStageId === stage.id}
+            onAction={onAction}
+            onOpenChange={(isOpen) =>
+              onOpenStageChange(isOpen ? stage.id : null)
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function FlowStageItem({
+  stage,
+  actions,
+  busyAction,
+  isCurrent,
+  isOpen,
+  onAction,
+  onOpenChange,
+}: {
+  stage: TaskFlowStage;
+  actions: TaskFlowAction[];
+  busyAction: string | null;
+  isCurrent: boolean;
+  isOpen: boolean;
+  onAction: (action: TaskFlowAction) => void;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const scopedActions = getStageActionScope(actions, stage);
+  const enabledActions = scopedActions.filter((action) => action.enabled);
+  const disabledActions = scopedActions.filter(
+    (action) => !action.enabled && action.disabledReason,
+  );
+
+  return (
+    <div
+      className={`group min-w-[180px] flex-1 rounded-lg border p-3 transition-colors ${getFlowStageStateClass(
+        stage.state,
+      )}`}
+    >
+      <FlowStageToggle
+        stage={stage}
+        isCurrent={isCurrent}
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+      />
+      {isCurrent && (
+        <FlowStageDetails
+          stage={stage}
+          enabledActions={enabledActions}
+          disabledActions={disabledActions}
+          busyAction={busyAction}
+          isOpen={isOpen}
+          onAction={onAction}
+        />
+      )}
+    </div>
+  );
+}
+
+function FlowStageToggle({
+  stage,
+  isCurrent,
+  isOpen,
+  onOpenChange,
+}: {
+  stage: TaskFlowStage;
+  isCurrent: boolean;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={!isCurrent}
+      onClick={() => onOpenChange(!isOpen)}
+      className="w-full text-left outline-none disabled:cursor-default"
+    >
+      <FlowStageSummary stage={stage} />
+    </button>
+  );
+}
+
+function FlowStageSummary({ stage }: { stage: TaskFlowStage }) {
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span
+          className={`h-2.5 w-2.5 rounded-full shrink-0 ${getFlowStageDotClass(
+            stage.state,
+          )}`}
+        />
+        <span className="text-sm font-semibold">{stage.label}</span>
+      </div>
+      <div className="mt-2 text-xs leading-5 text-text-secondary">
+        {stage.summary}
+      </div>
+      {stage.blocker && (
+        <div className="mt-2 text-xs leading-5 text-rose-200">
+          {stage.blocker}
+        </div>
+      )}
+    </>
+  );
+}
+
+function FlowStageDetails({
+  stage,
+  enabledActions,
+  disabledActions,
+  busyAction,
+  isOpen,
+  onAction,
+}: {
+  stage: TaskFlowStage;
+  enabledActions: TaskFlowAction[];
+  disabledActions: TaskFlowAction[];
+  busyAction: string | null;
+  isOpen: boolean;
+  onAction: (action: TaskFlowAction) => void;
+}) {
+  return (
+    <div
+      className={`mt-3 rounded-md border border-white/10 bg-black/25 p-3 ${
+        isOpen ? 'block' : 'hidden group-hover:block group-focus-within:block'
+      }`}
+    >
+      <FlowStageDetailText stage={stage} />
+      <FlowStageActionList
+        actions={enabledActions}
+        busyAction={busyAction}
+        onAction={onAction}
+      />
+      <FlowDisabledReasonList actions={disabledActions} />
+    </div>
+  );
+}
+
+function FlowStageDetailText({ stage }: { stage: TaskFlowStage }) {
+  return (
+    <>
+      <div className="text-xs font-semibold text-text-secondary">
+        当前状态详情
+      </div>
+      {stage.details.length > 0 ? (
+        <ul className="mt-2 flex flex-col gap-1 text-xs leading-5 text-text-secondary">
+          {stage.details.map((detail) => (
+            <li key={detail}>{detail}</li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-2 text-xs text-text-muted">
+          当前状态暂无更多详情。
+        </div>
+      )}
+    </>
+  );
+}
+
+function FlowStageActionList({
+  actions,
+  busyAction,
+  onAction,
+}: {
+  actions: TaskFlowAction[];
+  busyAction: string | null;
+  onAction: (action: TaskFlowAction) => void;
+}) {
+  return (
+    <>
+      <div className="mt-3 text-xs font-semibold text-text-secondary">
+        可执行操作
+      </div>
+      {actions.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {actions.map((action) => (
+            <FlowActionButton
+              key={action.id}
+              action={action}
+              busy={Boolean(busyAction)}
+              onClick={onAction}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 text-xs text-text-muted">
+          当前状态暂无可执行操作。
+        </div>
+      )}
+    </>
+  );
+}
+
+function FlowDisabledReasonList({ actions }: { actions: TaskFlowAction[] }) {
+  if (actions.length === 0) return null;
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {actions.map((action) => (
+        <div
+          key={action.id}
+          className="rounded-md border border-border-color bg-black/20 px-3 py-2 text-xs leading-5 text-text-muted"
+        >
+          <span className="text-text-secondary">{action.label}</span>：
+          {action.disabledReason}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FlowActionButton({
+  action,
+  busy,
+  onClick,
+}: {
+  action: TaskFlowAction;
+  busy: boolean;
+  onClick: (action: TaskFlowAction) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(action)}
+      disabled={!action.enabled || busy}
+      title={!action.enabled ? action.disabledReason : action.description}
+      className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
+        action,
+      )}`}
+    >
+      {busy ? '处理中' : action.label}
+    </button>
+  );
+}

--- a/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
@@ -86,13 +86,12 @@ describe('TaskProgressPanel empty', () => {
 });
 
 describe('TaskProgressPanel progress event', () => {
-  it('渲染实时进展和当前状态', () => {
+  it('渲染实时进展列表', () => {
     const html = renderPanel(
       makeSnapshot({
         agentProgressEvents: [makeProgressEvent({ detail: '运行局部测试。' })],
       }),
     );
-    expect(html).toContain('当前状态');
     expect(html).toContain('正在执行命令');
     expect(html).toContain('运行局部测试');
   });

--- a/packages/along-web/src/task-planning/TaskProgressPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.tsx
@@ -147,14 +147,6 @@ export function TaskProgressPanel({
               {runningHint}
             </div>
           )}
-          {latestEvent && (
-            <div className="mb-3 rounded-md border border-cyan-500/25 bg-cyan-500/10 px-3 py-2">
-              <div className="text-xs text-text-muted">当前状态</div>
-              <div className="mt-1 text-sm font-semibold text-cyan-100">
-                {latestEvent.summary}
-              </div>
-            </div>
-          )}
           {hiddenCount > 0 && (
             <div className="mb-2 text-xs text-text-muted">
               已折叠较早 {hiddenCount} 条进展。


### PR DESCRIPTION
along-task: #9

## 修改内容
- `packages/along-web/src/task-planning/AgentStagesPanel.tsx`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskFlowPanel.tsx`
- `packages/along-web/src/task-planning/TaskFlowStageCard.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.test.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.tsx`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-9`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：调整任务信息侧的前端交互布局，让任务详情、状态机视图和当前状态操作在长交流场景下更易查看和操作，同时移除原顶部当前状态相关常驻逻辑。

范围：
1. 将任务详情区域放在任务信息侧最上方，默认折叠为一行摘要展示，支持点击展开完整内容，并可再次折叠。
2. 将状态机视图放在任务详情下方展示；不再把状态机或当前状态操作作为页面顶部常驻逻辑保留。
3. 为长交流场景在右侧提供状态机视图或快速查看区域，方便滚动较深时查看状态机，但需与主状态机数据保持一致。
4. 当前状态的可操作按钮不再常驻顶部展示，改为鼠标悬停在当前状态区域时展示可执行操作。
5. 当前状态的详细信息改为鼠标悬停当前状态区域时展示。

边界：
- 本任务只调整任务信息侧的前端交互与布局，不改变状态机业务流转规则、任务状态数据结构和后端接口语义。
- 顶部当前状态相关展示、按钮和详情逻辑需要移除，不做旧入口保留。
- 若现有移动端或触屏场景不支持 hover，需要实现等价的点击或聚焦触发方式，避免功能不可用。
- 如旧顶部布局入口被移除，需要在交付说明中明确影响。

风险：
- 状态机在主信息区和右侧同时出现时，需避免视觉重复过重或状态不同步。
- hover 展示操作按钮和详情时，需处理可点击区域、弹层消失时机、键盘可访问性和小屏遮挡问题。
- 移除顶部常驻逻辑后，需确认原有状态操作能力仍能从当前状态区域正常触达。
- 任务详情折叠为一行时，需保证摘要截断不会误导用户，并保留展开后的完整阅读能力。

验证：
1. 在任务详情内容较短、较长、多行和空内容场景下验证默认折叠、展开、再次折叠行为。
2. 验证任务信息侧布局顺序为任务详情在最上方、状态机视图在其下方，且原顶部当前状态相关常驻展示已移除。
3. 在长交流内容页面验证右侧状态机查看区域可正常使用，滚动过程中不遮挡关键内容，并与主状态机状态一致。
4. 验证鼠标悬停当前状态时，操作按钮与详细信息正确出现，移出后按设计隐藏。
5. 验证可执行状态、无可执行操作状态、加载中和异常状态下 UI 表现合理。
6. 执行项目现有前端检查、类型检查和相关测试；如无法执行，需说明原因和剩余风险。

交付标准：
- 用户进入任务信息侧后，最上方是默认单行折叠的任务详情，展开/折叠交互清晰稳定。
- 状态机视图位于任务详情下方，并可在长交流场景下从右侧快速查看。
- 顶部当前状态相关常驻逻辑已移除，当前状态操作和详情改为在当前状态区域 hover 时展示。
- 改动不破坏现有状态流转、任务详情读取和交流内容浏览流程。

## 交付信息
- Commit: 2298c0c8a5d4f0bd7063518db166aa9b4ba9f1ce