### PR TITLE
Task #10: 调整右侧面板交互与布局

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -9,7 +9,6 @@ import {
 import type {
   TaskArtifactRecord,
   TaskFlowAction,
-  TaskFlowSnapshot,
   TaskPlanningSnapshot,
 } from '../types';
 import { AgentStagesPanel } from './AgentStagesPanel';
@@ -20,40 +19,39 @@ import {
   getTaskStatusLabel,
   getThreadStatusLabel,
 } from './format';
-import { TaskFlowPanel } from './TaskFlowPanel';
+import { FlowHistory, TaskFlowPanel } from './TaskFlowPanel';
 import { TaskProgressPanel } from './TaskProgressPanel';
 import { TaskRecordsPanel } from './TaskRecords';
 
-function CurrentPlanPanel({ selected }: { selected: TaskPlanningSnapshot }) {
-  return (
-    <section className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-text-secondary">当前方案</h3>
-        {selected.openRound && (
-          <span className="text-xs text-amber-300">等待重新规划</span>
-        )}
-      </div>
-      <div className="rounded-lg border border-border-color bg-black/35 p-4 min-h-[180px]">
-        {selected.currentPlan ? (
-          <div className="whitespace-pre-wrap break-words text-sm leading-6">
-            {selected.currentPlan.body}
-          </div>
-        ) : (
-          <div className="text-sm text-text-muted">等待 Planner 输出。</div>
-        )}
-      </div>
-    </section>
-  );
-}
-
 function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
+  const [isExpanded, setIsExpanded] = useState(true);
   return (
-    <aside className="min-w-0 flex flex-col gap-4">
-      <div className="rounded-lg border border-border-color bg-black/25 p-4 flex flex-col gap-3">
-        <div className="font-semibold text-sm text-text-secondary">
-          任务元信息
+    <aside className="min-w-0 rounded-lg border border-border-color bg-black/25">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded((value) => !value)}
+        className="w-full px-4 py-3 text-left outline-none focus:ring-1 focus:ring-brand/60"
+      >
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="min-w-0 flex items-center gap-2">
+            <span className="text-sm font-semibold text-text-secondary">
+              任务元信息
+            </span>
+            {!isExpanded && (
+              <span className="truncate text-xs text-text-muted">
+                {getTaskStatusLabel(selected.task.status)} ·{' '}
+                {formatTime(selected.task.updatedAt)}
+              </span>
+            )}
+          </div>
+          <span className="shrink-0 text-xs text-text-muted">
+            {isExpanded ? '收起' : '展开'}
+          </span>
         </div>
-        <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 text-sm">
+      </button>
+      {isExpanded && (
+        <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-4 pb-4 text-sm">
           <span className="text-text-muted">ID</span>
           <span className="truncate">{selected.task.taskId}</span>
           {selected.task.seq != null && (
@@ -106,52 +104,12 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
           <span className="text-text-muted">Updated</span>
           <span>{formatTime(selected.task.updatedAt)}</span>
         </div>
-      </div>
+      )}
     </aside>
   );
 }
 
-function TaskBodyPanel({ selected }: { selected: TaskPlanningSnapshot }) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const body = selected.task.body.trim();
-  const bodyText = body || '暂无任务详情。';
-  const collapsedText = body ? body.replace(/\s+/g, ' ') : bodyText;
-
-  return (
-    <section className="rounded-lg border border-border-color bg-black/25">
-      <button
-        type="button"
-        aria-expanded={isExpanded}
-        onClick={() => setIsExpanded((value) => !value)}
-        className="w-full min-w-0 px-4 py-3 text-left outline-none focus:ring-1 focus:ring-brand/60"
-      >
-        <div className="flex min-w-0 items-center gap-3">
-          <span className="shrink-0 text-sm font-semibold text-text-secondary">
-            任务详情
-          </span>
-          {!isExpanded && (
-            <span
-              className="min-w-0 flex-1 truncate text-sm text-text-primary"
-              title={collapsedText}
-            >
-              {collapsedText}
-            </span>
-          )}
-          <span className="ml-auto shrink-0 text-xs text-text-muted">
-            {isExpanded ? '收起' : '展开'}
-          </span>
-        </div>
-        {isExpanded && (
-          <div className="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-text-primary">
-            {bodyText}
-          </div>
-        )}
-      </button>
-    </section>
-  );
-}
-
-function getMessageActions(flow: TaskFlowSnapshot) {
+function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
   const submitFeedbackAction = flow.actions.find(
     (action) => action.id === 'submit_feedback',
   );
@@ -175,7 +133,7 @@ function ExistingTaskComposer({
   onMessageChange,
   onSubmitMessage,
 }: {
-  flow: TaskFlowSnapshot;
+  flow: TaskPlanningSnapshot['flow'];
   messageBody: string;
   busyAction: string | null;
   onMessageChange: (value: string) => void;
@@ -391,7 +349,6 @@ function SelectedTaskDetail({
           className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
         >
           <div className="min-w-0 flex flex-col gap-5">
-            <CurrentPlanPanel selected={selected} />
             <TaskProgressPanel snapshot={selected} />
             <AgentStagesPanel stages={selected.agentStages || []} />
             <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
@@ -407,17 +364,24 @@ function SelectedTaskDetail({
           />
         </div>
       </section>
-      <div className="min-h-0 min-w-0 overflow-auto border-t border-border-color p-4 md:p-6 2xl:border-l 2xl:border-t-0">
-        <div className="flex min-w-0 flex-col gap-4">
-          <TaskBodyPanel selected={selected} />
-          <TaskFlowPanel
-            flow={selected.flow}
-            busyAction={detail.busyAction}
-            onAction={detail.onAction}
-          />
-          <TaskInfoPanel selected={selected} />
+      <aside className="min-h-0 min-w-0 overflow-hidden border-t border-border-color 2xl:border-l 2xl:border-t-0">
+        <div className="flex h-full min-w-0 flex-col">
+          <div className="shrink-0 p-4 pb-3 md:p-5 md:pb-3">
+            <TaskInfoPanel selected={selected} />
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto px-4 pb-4 md:px-5 md:pb-5">
+            <TaskFlowPanel
+              flow={selected.flow}
+              currentPlan={selected.currentPlan}
+              busyAction={detail.busyAction}
+              onAction={detail.onAction}
+            />
+          </div>
+          <div className="max-h-[45%] shrink-0 overflow-auto border-t border-border-color bg-bg-secondary p-4 md:p-5">
+            <FlowHistory flow={selected.flow} />
+          </div>
         </div>
-      </div>
+      </aside>
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/TaskFlowPanel.test.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowPanel.test.tsx
@@ -1,0 +1,97 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { TaskFlowSnapshot, TaskPlanRevisionRecord } from '../types';
+import { TaskFlowPanel } from './TaskFlowPanel';
+
+function makeFlow(overrides: Partial<TaskFlowSnapshot> = {}): TaskFlowSnapshot {
+  return {
+    currentStageId: 'delivery',
+    conclusion: '结果已交付，等待验收或继续修改。',
+    severity: 'success',
+    blockers: [],
+    events: [],
+    stages: [
+      {
+        id: 'delivery',
+        label: '结果交付',
+        summary: '结果已交付',
+        state: 'current',
+        details: ['PR：https://example.com/pr/1'],
+      },
+      {
+        id: 'completed',
+        label: '已完成',
+        summary: '等待验收',
+        state: 'pending',
+        details: [],
+      },
+    ],
+    actions: [
+      {
+        id: 'accept_delivery',
+        label: '验收完成',
+        description: '确认交付结果并结束任务',
+        enabled: true,
+        stage: 'delivery',
+        variant: 'primary',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makePlan(): TaskPlanRevisionRecord {
+  return {
+    planId: 'plan-1',
+    taskId: 'task-1',
+    threadId: 'thread-1',
+    version: 1,
+    status: 'active',
+    artifactId: 'artifact-1',
+    body: '## 方案\n\n先实现右侧面板调整。',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('TaskFlowPanel', () => {
+  it('默认展开当前阶段并显示已交付验收按钮', () => {
+    const html = renderToStaticMarkup(
+      <TaskFlowPanel
+        flow={makeFlow()}
+        currentPlan={null}
+        busyAction={null}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('结果已交付');
+    expect(html).toContain('验收完成');
+  });
+
+  it('在计划确认阶段提供当前计划入口', () => {
+    const html = renderToStaticMarkup(
+      <TaskFlowPanel
+        flow={makeFlow({
+          currentStageId: 'plan_confirmation',
+          conclusion: '等待你确认计划。',
+          stages: [
+            {
+              id: 'plan_confirmation',
+              label: '计划确认',
+              summary: '等待用户确认',
+              state: 'current',
+              details: ['当前计划：v1'],
+            },
+          ],
+          actions: [],
+        })}
+        currentPlan={makePlan()}
+        busyAction={null}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('查看计划 v1');
+    expect(html).toContain('计划确认');
+  });
+});

--- a/packages/along-web/src/task-planning/TaskFlowPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowPanel.tsx
@@ -1,18 +1,27 @@
-import { useState } from 'react';
-import type { TaskFlowAction, TaskFlowSnapshot } from '../types';
-import { formatTime, getFlowSeverityClass } from './format';
+import { useEffect, useState } from 'react';
+import type {
+  TaskFlowAction,
+  TaskFlowSnapshot,
+  TaskPlanRevisionRecord,
+} from '../types';
+import { formatTime } from './format';
 import { FlowStages } from './TaskFlowStageCard';
 
 export function TaskFlowPanel({
   flow,
+  currentPlan,
   busyAction,
   onAction,
 }: {
   flow: TaskFlowSnapshot;
+  currentPlan: TaskPlanRevisionRecord | null;
   busyAction: string | null;
   onAction: (action: TaskFlowAction) => void;
 }) {
-  const [openStageId, setOpenStageId] = useState<string | null>(null);
+  const [openStageId, setOpenStageId] = useState<string | null>(
+    flow.currentStageId,
+  );
+  const [isPlanOpen, setIsPlanOpen] = useState(false);
   const commandActions = flow.actions.filter(
     (action) =>
       !['submit_feedback', 'request_revision', 'request_changes'].includes(
@@ -20,36 +29,40 @@ export function TaskFlowPanel({
       ),
   );
 
+  useEffect(() => {
+    setOpenStageId(flow.currentStageId);
+  }, [flow.currentStageId]);
+
   return (
-    <section className="rounded-lg border border-border-color bg-black/25 p-4 md:p-5 flex flex-col gap-4">
+    <section className="flex flex-col gap-4">
       <FlowSummary flow={flow} />
       <FlowStages
         stages={flow.stages}
-        currentStageId={flow.currentStageId}
         commandActions={commandActions}
         busyAction={busyAction}
+        currentPlan={currentPlan}
         onAction={onAction}
+        onShowPlan={() => setIsPlanOpen(true)}
         openStageId={openStageId}
         onOpenStageChange={setOpenStageId}
       />
-      <FlowHistory flow={flow} />
+      <CurrentPlanDialog
+        plan={currentPlan}
+        open={isPlanOpen}
+        onClose={() => setIsPlanOpen(false)}
+      />
     </section>
   );
 }
 
 function FlowSummary({ flow }: { flow: TaskFlowSnapshot }) {
   return (
-    <div className="flex flex-col gap-3">
-      <div
-        className={`rounded-lg border px-4 py-3 ${getFlowSeverityClass(
-          flow.severity,
-        )}`}
-      >
-        <div className="text-xs text-text-muted mb-1">当前节奏</div>
-        <div className="text-base font-semibold">{flow.conclusion}</div>
+    <div className="flex flex-col gap-2">
+      <div className="text-sm font-semibold text-text-primary">
+        {flow.conclusion}
       </div>
       {flow.blockers.length > 0 && (
-        <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-xs leading-5 text-amber-100">
+        <div className="text-xs leading-5 text-amber-100">
           {flow.blockers.map((blocker) => (
             <div key={blocker}>{blocker}</div>
           ))}
@@ -59,7 +72,42 @@ function FlowSummary({ flow }: { flow: TaskFlowSnapshot }) {
   );
 }
 
-function FlowHistory({ flow }: { flow: TaskFlowSnapshot }) {
+function CurrentPlanDialog({
+  plan,
+  open,
+  onClose,
+}: {
+  plan: TaskPlanRevisionRecord | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  if (!open || !plan) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="flex max-h-[80vh] w-full max-w-3xl flex-col rounded-lg border border-border-color bg-bg-secondary shadow-xl">
+        <div className="flex items-center justify-between gap-3 border-b border-border-color px-4 py-3">
+          <h3 className="text-sm font-semibold text-text-secondary">
+            当前计划 v{plan.version}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border-color px-2 py-1 text-xs font-semibold text-text-secondary hover:bg-white/5"
+          >
+            关闭
+          </button>
+        </div>
+        <div className="min-h-0 overflow-auto p-4">
+          <div className="whitespace-pre-wrap break-words text-sm leading-6">
+            {plan.body}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FlowHistory({ flow }: { flow: TaskFlowSnapshot }) {
   return (
     <details className="rounded-lg border border-border-color bg-black/20">
       <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-text-secondary">

--- a/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
@@ -1,48 +1,62 @@
-import type { TaskFlowAction, TaskFlowStage } from '../types';
-import {
-  getFlowActionClass,
-  getFlowStageDotClass,
-  getFlowStageStateClass,
-} from './format';
+import type {
+  TaskFlowAction,
+  TaskFlowStage,
+  TaskPlanRevisionRecord,
+} from '../types';
+import { getFlowActionClass, getFlowStageDotClass } from './format';
 
-function getStageActionScope(
+export function getStageActionScope(
   actions: TaskFlowAction[],
   stage: TaskFlowStage,
 ): TaskFlowAction[] {
   const stageActions = actions.filter((action) => action.stage === stage.id);
+  if (
+    stage.state === 'current' ||
+    stage.state === 'blocked' ||
+    stage.state === 'attention'
+  ) {
+    return stageActions;
+  }
   return stageActions.length > 0 ? stageActions : actions;
 }
 
 export function FlowStages({
   stages,
-  currentStageId,
   commandActions,
   busyAction,
+  currentPlan,
   onAction,
+  onShowPlan,
   openStageId,
   onOpenStageChange,
 }: {
   stages: TaskFlowStage[];
-  currentStageId: string;
   commandActions: TaskFlowAction[];
   busyAction: string | null;
+  currentPlan: TaskPlanRevisionRecord | null;
   onAction: (action: TaskFlowAction) => void;
+  onShowPlan: () => void;
   openStageId: string | null;
   onOpenStageChange: (stageId: string | null) => void;
 }) {
   return (
-    <div className="flex gap-3 overflow-x-auto pb-1">
+    <div className="flex flex-col gap-2">
       {stages.map((stage) => {
-        const isCurrent = stage.id === currentStageId;
+        const isCurrent =
+          stage.state === 'current' ||
+          stage.state === 'blocked' ||
+          stage.state === 'attention';
         return (
           <FlowStageItem
             key={stage.id}
             stage={stage}
             actions={commandActions}
             busyAction={busyAction}
+            currentPlan={currentPlan}
             isCurrent={isCurrent}
             isOpen={openStageId === stage.id}
             onAction={onAction}
+            onShowPlan={onShowPlan}
             onOpenChange={(isOpen) =>
               onOpenStageChange(isOpen ? stage.id : null)
             }
@@ -57,17 +71,21 @@ function FlowStageItem({
   stage,
   actions,
   busyAction,
+  currentPlan,
   isCurrent,
   isOpen,
   onAction,
+  onShowPlan,
   onOpenChange,
 }: {
   stage: TaskFlowStage;
   actions: TaskFlowAction[];
   busyAction: string | null;
+  currentPlan: TaskPlanRevisionRecord | null;
   isCurrent: boolean;
   isOpen: boolean;
   onAction: (action: TaskFlowAction) => void;
+  onShowPlan: () => void;
   onOpenChange: (isOpen: boolean) => void;
 }) {
   const scopedActions = getStageActionScope(actions, stage);
@@ -77,11 +95,7 @@ function FlowStageItem({
   );
 
   return (
-    <div
-      className={`group min-w-[180px] flex-1 rounded-lg border p-3 transition-colors ${getFlowStageStateClass(
-        stage.state,
-      )}`}
-    >
+    <div className="group border-l border-border-color pl-3">
       <FlowStageToggle
         stage={stage}
         isCurrent={isCurrent}
@@ -94,8 +108,10 @@ function FlowStageItem({
           enabledActions={enabledActions}
           disabledActions={disabledActions}
           busyAction={busyAction}
+          currentPlan={currentPlan}
           isOpen={isOpen}
           onAction={onAction}
+          onShowPlan={onShowPlan}
         />
       )}
     </div>
@@ -118,33 +134,46 @@ function FlowStageToggle({
       type="button"
       disabled={!isCurrent}
       onClick={() => onOpenChange(!isOpen)}
-      className="w-full text-left outline-none disabled:cursor-default"
+      className="w-full text-left outline-none disabled:cursor-default focus:ring-1 focus:ring-brand/60"
+      aria-expanded={isCurrent ? isOpen : undefined}
     >
-      <FlowStageSummary stage={stage} />
+      <FlowStageSummary stage={stage} isCurrent={isCurrent} />
     </button>
   );
 }
 
-function FlowStageSummary({ stage }: { stage: TaskFlowStage }) {
+function FlowStageSummary({
+  stage,
+  isCurrent,
+}: {
+  stage: TaskFlowStage;
+  isCurrent: boolean;
+}) {
   return (
-    <>
-      <div className="flex items-center gap-2">
+    <div className="flex min-w-0 items-start gap-2 py-1">
+      <div className="flex h-5 shrink-0 items-center">
         <span
           className={`h-2.5 w-2.5 rounded-full shrink-0 ${getFlowStageDotClass(
             stage.state,
           )}`}
         />
-        <span className="text-sm font-semibold">{stage.label}</span>
       </div>
-      <div className="mt-2 text-xs leading-5 text-text-secondary">
-        {stage.summary}
+      <div className="min-w-0 flex-1 text-sm leading-5">
+        <span
+          className={
+            isCurrent ? 'font-semibold text-text-primary' : 'text-text-muted'
+          }
+        >
+          {stage.label}
+        </span>
+        <span className="text-text-muted"> · {stage.summary}</span>
+        {stage.blocker && (
+          <div className="mt-1 text-xs leading-5 text-rose-200">
+            {stage.blocker}
+          </div>
+        )}
       </div>
-      {stage.blocker && (
-        <div className="mt-2 text-xs leading-5 text-rose-200">
-          {stage.blocker}
-        </div>
-      )}
-    </>
+    </div>
   );
 }
 
@@ -153,23 +182,32 @@ function FlowStageDetails({
   enabledActions,
   disabledActions,
   busyAction,
+  currentPlan,
   isOpen,
   onAction,
+  onShowPlan,
 }: {
   stage: TaskFlowStage;
   enabledActions: TaskFlowAction[];
   disabledActions: TaskFlowAction[];
   busyAction: string | null;
+  currentPlan: TaskPlanRevisionRecord | null;
   isOpen: boolean;
   onAction: (action: TaskFlowAction) => void;
+  onShowPlan: () => void;
 }) {
   return (
-    <div
-      className={`mt-3 rounded-md border border-white/10 bg-black/25 p-3 ${
-        isOpen ? 'block' : 'hidden group-hover:block group-focus-within:block'
-      }`}
-    >
+    <div className={`ml-4 pb-3 pt-1 ${isOpen ? 'block' : 'hidden'}`}>
       <FlowStageDetailText stage={stage} />
+      {stage.id === 'plan_confirmation' && currentPlan && (
+        <button
+          type="button"
+          onClick={onShowPlan}
+          className="mt-3 px-3 py-2 rounded-lg text-xs font-semibold border border-border-color text-text-secondary hover:bg-white/5 transition-colors"
+        >
+          查看计划 v{currentPlan.version}
+        </button>
+      )}
       <FlowStageActionList
         actions={enabledActions}
         busyAction={busyAction}
@@ -183,19 +221,14 @@ function FlowStageDetails({
 function FlowStageDetailText({ stage }: { stage: TaskFlowStage }) {
   return (
     <>
-      <div className="text-xs font-semibold text-text-secondary">
-        当前状态详情
-      </div>
       {stage.details.length > 0 ? (
-        <ul className="mt-2 flex flex-col gap-1 text-xs leading-5 text-text-secondary">
+        <ul className="flex flex-col gap-1 text-xs leading-5 text-text-secondary">
           {stage.details.map((detail) => (
             <li key={detail}>{detail}</li>
           ))}
         </ul>
       ) : (
-        <div className="mt-2 text-xs text-text-muted">
-          当前状态暂无更多详情。
-        </div>
+        <div className="text-xs text-text-muted">当前状态暂无更多详情。</div>
       )}
     </>
   );

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -825,6 +825,17 @@ describe('task-planning', () => {
 
     const delivered = updateTaskStatus(taskId, TASK_STATUS.DELIVERED);
     expect(delivered.success).toBe(true);
+    if (!delivered.success) throw new Error(delivered.error);
+    const deliveredSnapshot = readTaskPlanningSnapshot(taskId);
+    expect(deliveredSnapshot.success).toBe(true);
+    if (!deliveredSnapshot.success || !deliveredSnapshot.data)
+      throw new Error('missing delivered snapshot');
+    expect(deliveredSnapshot.data.flow.currentStageId).toBe('delivery');
+    expect(
+      deliveredSnapshot.data.flow.actions.find(
+        (action) => action.id === 'accept_delivery',
+      ),
+    ).toMatchObject({ enabled: true, stage: 'delivery' });
 
     const completed = completeDeliveredTask(taskId);
     expect(completed.success).toBe(true);

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -1135,7 +1135,7 @@ function buildTaskFlowActions(input: {
       description: '确认交付结果并结束任务',
       enabled: canAcceptDelivery,
       disabledReason: '只有已交付任务可以验收完成',
-      stage: 'completed',
+      stage: 'delivery',
       variant: 'primary',
     }),
     buildTaskFlowAction({


### PR DESCRIPTION
along-task: #10

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskFlowPanel.test.tsx`
- `packages/along-web/src/task-planning/TaskFlowPanel.tsx`
- `packages/along-web/src/task-planning/TaskFlowStageCard.tsx`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-10`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：调整 along web 右侧面板的信息架构与状态机交互，移除不需要的详情/节奏/当前方案展示，确保任务元信息、状态机操作与历史流转的层级清晰，并修复已交付等状态下操作按钮不可见的问题。

范围：
1. 移除右侧任务详情面板，不再在右侧重复展示任务详情内容。
2. 将任务元信息面板移动到右侧面板顶部，并支持展开/折叠；默认状态按现有产品习惯处理，需保证折叠后仍能识别该区域。
3. 移除当前节奏卡片。
4. 将历史流转从现有位置抽离为独立面板，与任务元信息面板同级，固定放在右侧面板底部区域。
5. 重构状态机视图展示方式：不再使用卡片形式，每个状态节点以一行文字从上到下排列；默认展开当前节点，并在当前节点下方展示该阶段可执行操作按钮。
6. 修复状态操作按钮不可见问题，重点验证“已交付”状态下应能看到并点击“验收”等后续操作；实施前必须先定位按钮不可见的根因，是布局遮挡、条件判断错误、状态映射缺失还是数据未传入，避免只做临时样式补丁。
7. 会话记录中移除“当前方案”模块，将计划确认相关能力迁移到状态机视图的计划确认阶段；点击后可通过弹框展示当前计划，或定位到左侧计划区块，具体交互优先复用现有弹框/锚点能力，保持体验一致。

边界：
- 本任务聚焦右侧面板交互与展示结构调整，不改变任务状态机业务规则本身。
- 不主动做旧版右侧面板展示兼容；如存在依赖原布局的测试、截图或埋点，需要同步更新。
- 不新增绕过状态权限或强行显示所有按钮的逻辑，按钮展示必须符合当前状态与权限语义。

风险：
- 状态机节点与操作按钮的条件渲染可能同时受任务状态、角色权限、会话阶段影响，需避免修复一个状态后破坏其他状态。
- “当前方案”迁移后，计划确认入口位置变化可能影响用户查找路径，需要保证入口在计划确认阶段足够明显。
- 右侧面板内容重新排序后，历史流转底部展示需注意滚动区域和小屏可用性，避免按钮再次被挤出或遮挡。

验证：
1. 覆盖至少以下任务状态的右侧面板检查：计划确认中、执行中、已交付、已完成/已验收。
2. 验证已交付状态下可见并可点击验收相关按钮。
3. 验证任务元信息可展开/折叠，历史流转独立展示且位于底部。
4. 验证会话记录不再展示当前方案模块，计划确认阶段可以打开计划弹框或定位到左侧计划区块。
5. 执行项目既有前端质量检查和相关测试；如无法执行，需说明原因和剩余风险。

交付标准：
- 右侧面板结构符合本计划描述，视觉层级清晰，无重复或废弃模块。
- 状态机当前节点默认展开，操作按钮在对应阶段稳定可见且不被布局遮挡。
- 计划确认入口迁移完成，会话记录区域职责收敛。
- 相关测试、类型检查和 lint 通过，或明确记录未验证项。

## 交付信息
- Commit: 2b10e8a5eac15103a2273553be1cd601a53e6731