### PR TITLE
Task #12: 实时展示Agent会话日志

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -239,7 +239,7 @@ type TaskDetailProps = {
   onAction: (action: TaskFlowAction) => void;
 };
 
-function useLatestScroll(detailKey: string, artifactCount: number) {
+function useLatestScroll(detailKey: string, activityCount: number) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const shouldFollowLatestRef = useRef(true);
   const onScroll = (element: HTMLDivElement) => {
@@ -254,9 +254,9 @@ function useLatestScroll(detailKey: string, artifactCount: number) {
   }, [detailKey]);
 
   useEffect(() => {
-    void artifactCount;
+    void activityCount;
     if (shouldFollowLatestRef.current) scrollToLatest(scrollRef.current);
-  }, [artifactCount]);
+  }, [activityCount]);
 
   return { scrollRef, onScroll };
 }
@@ -264,10 +264,11 @@ function useLatestScroll(detailKey: string, artifactCount: number) {
 export function TaskDetail(props: TaskDetailProps) {
   const detailKey =
     props.selected?.task.taskId || (props.isNewTaskOpen ? 'new' : 'empty');
-  const { scrollRef, onScroll } = useLatestScroll(
-    detailKey,
-    props.sortedArtifacts.length,
-  );
+  const activityCount =
+    props.sortedArtifacts.length +
+    (props.selected?.agentProgressEvents.length || 0) +
+    (props.selected?.agentSessionEvents.length || 0);
+  const { scrollRef, onScroll } = useLatestScroll(detailKey, activityCount);
 
   if (!props.selected) {
     if (props.isNewTaskOpen) {

--- a/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
@@ -41,6 +41,7 @@ function makeSnapshot(
     plans: [],
     agentRuns: [],
     agentProgressEvents: [],
+    agentSessionEvents: [],
     agentStages: [],
     flow: {
       currentStageId: 'implementation',
@@ -111,6 +112,42 @@ describe('TaskProgressPanel progress event', () => {
     );
     expect(html).toContain('失败');
     expect(html).toContain('命令退出码 1');
+  });
+});
+
+describe('TaskProgressPanel session tail', () => {
+  it('渲染 Agent session 会话流', () => {
+    const html = renderPanel(
+      makeSnapshot({
+        agentRuns: [makeRunningRun()],
+        agentSessionEvents: [
+          {
+            eventId: 'sess-1',
+            runId: 'run-1',
+            taskId: 'task-1',
+            threadId: 'thread-1',
+            agentId: 'implementer',
+            provider: 'codex',
+            source: 'agent',
+            kind: 'output',
+            content: '正在修改 TaskProgressPanel。',
+            metadata: {},
+            createdAt: '2026-01-01T00:04:50.000Z',
+          },
+        ],
+      }),
+    );
+    expect(html).toContain('Agent 会话 Tail');
+    expect(html).toContain('正在修改 TaskProgressPanel');
+  });
+
+  it('运行中但无会话输出时渲染可观测提示', () => {
+    const html = renderPanel(
+      makeSnapshot({
+        agentRuns: [makeRunningRun()],
+      }),
+    );
+    expect(html).toContain('正在等待第一条会话输出');
   });
 });
 

--- a/packages/along-web/src/task-planning/TaskProgressPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.tsx
@@ -1,6 +1,8 @@
 import type {
   TaskAgentProgressEventRecord,
   TaskAgentRunRecord,
+  TaskAgentSessionEventRecord,
+  TaskAgentSessionEventSource,
   TaskPlanningSnapshot,
 } from '../types';
 import {
@@ -10,9 +12,16 @@ import {
 } from './format';
 
 const RECENT_PROGRESS_LIMIT = 8;
+const RECENT_SESSION_LIMIT = 40;
 const STALE_PROGRESS_MS = 2 * 60 * 1000;
 
 function sortProgressEvents(events: TaskAgentProgressEventRecord[]) {
+  return [...events].sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  );
+}
+
+function sortSessionEvents(events: TaskAgentSessionEventRecord[]) {
   return [...events].sort((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );
@@ -72,6 +81,51 @@ function buildRunningHint(input: {
   )}，最近一次进展在 ${formatRelativeTime(lastTime, input.nowMs)}。`;
 }
 
+function buildSessionQuietHint(input: {
+  runningRun: TaskAgentRunRecord | null;
+  latestEvent?: TaskAgentSessionEventRecord;
+  nowMs: number;
+}): string | null {
+  if (!input.runningRun) return null;
+  if (!input.latestEvent) {
+    return 'Agent 仍在执行，但当前暂无可展示会话信息。';
+  }
+  const seconds = getRelativeSeconds(input.latestEvent.createdAt, input.nowMs);
+  if (seconds === null || seconds < 120) return null;
+  return `最近一条会话在 ${formatRelativeTime(
+    input.latestEvent.createdAt,
+    input.nowMs,
+  )}，Agent 仍处于运行状态。`;
+}
+
+function getSessionSourceLabel(source: TaskAgentSessionEventSource): string {
+  switch (source) {
+    case 'agent':
+      return 'Agent';
+    case 'tool':
+      return 'Tool';
+    case 'stdout':
+      return 'stdout';
+    case 'stderr':
+      return 'stderr';
+    default:
+      return 'System';
+  }
+}
+
+function getSessionEventClass(event: TaskAgentSessionEventRecord): string {
+  if (event.kind === 'error' || event.source === 'stderr') {
+    return 'border-red-500/25 bg-red-500/10 text-red-100';
+  }
+  if (event.source === 'agent') {
+    return 'border-emerald-500/25 bg-emerald-500/10 text-emerald-50';
+  }
+  if (event.source === 'tool' || event.source === 'stdout') {
+    return 'border-sky-500/25 bg-sky-500/10 text-sky-50';
+  }
+  return 'border-border-color bg-black/25 text-text-secondary';
+}
+
 function ProgressEventItem({
   event,
   isLatest,
@@ -112,6 +166,142 @@ function ProgressEventItem({
   );
 }
 
+function SessionEventItem({
+  event,
+  nowMs,
+}: {
+  event: TaskAgentSessionEventRecord;
+  nowMs: number;
+}) {
+  return (
+    <li className="grid grid-cols-[72px_1fr] gap-3">
+      <div className="text-xs text-text-muted pt-0.5">
+        {formatRelativeTime(event.createdAt, nowMs)}
+      </div>
+      <div
+        className={`rounded-lg border px-3 py-2 ${getSessionEventClass(event)}`}
+      >
+        <div className="mb-1 flex items-center justify-between gap-3 text-[10px] font-semibold uppercase tracking-normal">
+          <span>
+            {getSessionSourceLabel(event.source)} / {event.provider}
+          </span>
+          <span>{event.kind}</span>
+        </div>
+        <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5">
+          {event.content}
+        </pre>
+      </div>
+    </li>
+  );
+}
+
+function SessionTail({
+  events,
+  runningRun,
+  nowMs,
+}: {
+  events: TaskAgentSessionEventRecord[];
+  runningRun: TaskAgentRunRecord | null;
+  nowMs: number;
+}) {
+  const latestEvent = events[events.length - 1];
+  const quietHint = buildSessionQuietHint({ runningRun, latestEvent, nowMs });
+  const visibleEvents = events.slice(-RECENT_SESSION_LIMIT);
+  const hiddenCount = Math.max(0, events.length - visibleEvents.length);
+
+  return (
+    <div className="rounded-lg border border-border-color bg-black/20 p-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold text-text-secondary">
+            Agent 会话 Tail
+          </div>
+          <div className="mt-1 text-xs text-text-muted">
+            {latestEvent
+              ? `最近更新 ${formatRelativeTime(latestEvent.createdAt, nowMs)}`
+              : '暂无可展示会话信息'}
+          </div>
+        </div>
+        <span className="text-xs text-text-muted">{events.length} 条</span>
+      </div>
+      {quietHint && (
+        <div className="mb-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
+          {quietHint}
+        </div>
+      )}
+      {hiddenCount > 0 && (
+        <div className="mb-2 text-xs text-text-muted">
+          已折叠较早 {hiddenCount} 条会话。
+        </div>
+      )}
+      {visibleEvents.length === 0 ? (
+        <div className="rounded-md border border-border-color bg-black/25 px-3 py-3 text-sm text-text-muted">
+          {runningRun
+            ? 'Agent 已开始运行，正在等待第一条会话输出。'
+            : '暂无可展示会话信息。'}
+        </div>
+      ) : (
+        <ol className="flex max-h-[520px] flex-col gap-2 overflow-auto pr-1">
+          {visibleEvents.map((event) => (
+            <SessionEventItem key={event.eventId} event={event} nowMs={nowMs} />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function ProgressEventsPanel({
+  events,
+  runningRun,
+  nowMs,
+}: {
+  events: TaskAgentProgressEventRecord[];
+  runningRun: TaskAgentRunRecord | null;
+  nowMs: number;
+}) {
+  const latestEvent = events[events.length - 1];
+  const runningHint = buildRunningHint({ runningRun, latestEvent, nowMs });
+  const visibleEvents = events.slice(-RECENT_PROGRESS_LIMIT);
+  const hiddenCount = Math.max(0, events.length - visibleEvents.length);
+
+  if (events.length === 0) {
+    return (
+      <div className="rounded-lg border border-border-color bg-black/25 px-4 py-3 text-sm text-text-muted">
+        {runningHint ||
+          (runningRun
+            ? 'Agent 已开始运行，正在等待第一条进展。'
+            : '暂无 Agent 运行进展。')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border-color bg-black/20 p-3">
+      {runningHint && (
+        <div className="mb-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
+          {runningHint}
+        </div>
+      )}
+      {hiddenCount > 0 && (
+        <div className="mb-2 text-xs text-text-muted">
+          已折叠较早 {hiddenCount} 条进展。
+        </div>
+      )}
+      <ol className="flex flex-col gap-2">
+        {visibleEvents.map((event, index) => (
+          <ProgressEventItem
+            key={event.progressId}
+            event={event}
+            isLatest={index === visibleEvents.length - 1}
+            nowMs={nowMs}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
 export function TaskProgressPanel({
   snapshot,
   nowMs = Date.now(),
@@ -120,11 +310,8 @@ export function TaskProgressPanel({
   nowMs?: number;
 }) {
   const events = sortProgressEvents(snapshot.agentProgressEvents || []);
+  const sessionEvents = sortSessionEvents(snapshot.agentSessionEvents || []);
   const runningRun = getLatestRunningRun(snapshot.agentRuns || []);
-  const latestEvent = events[events.length - 1];
-  const runningHint = buildRunningHint({ runningRun, latestEvent, nowMs });
-  const visibleEvents = events.slice(-RECENT_PROGRESS_LIMIT);
-  const hiddenCount = Math.max(0, events.length - visibleEvents.length);
 
   return (
     <section className="flex flex-col gap-3">
@@ -133,37 +320,16 @@ export function TaskProgressPanel({
         <span className="text-xs text-text-muted">{events.length} 条</span>
       </div>
 
-      {events.length === 0 ? (
-        <div className="rounded-lg border border-border-color bg-black/25 px-4 py-3 text-sm text-text-muted">
-          {runningHint ||
-            (runningRun
-              ? 'Agent 已开始运行，正在等待第一条进展。'
-              : '暂无 Agent 运行进展。')}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-border-color bg-black/20 p-3">
-          {runningHint && (
-            <div className="mb-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
-              {runningHint}
-            </div>
-          )}
-          {hiddenCount > 0 && (
-            <div className="mb-2 text-xs text-text-muted">
-              已折叠较早 {hiddenCount} 条进展。
-            </div>
-          )}
-          <ol className="flex flex-col gap-2">
-            {visibleEvents.map((event, index) => (
-              <ProgressEventItem
-                key={event.progressId}
-                event={event}
-                isLatest={index === visibleEvents.length - 1}
-                nowMs={nowMs}
-              />
-            ))}
-          </ol>
-        </div>
-      )}
+      <ProgressEventsPanel
+        events={events}
+        runningRun={runningRun}
+        nowMs={nowMs}
+      />
+      <SessionTail
+        events={sessionEvents}
+        runningRun={runningRun}
+        nowMs={nowMs}
+      />
     </section>
   );
 }

--- a/packages/along-web/src/task-planning/flowActionRouter.test.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.test.ts
@@ -50,6 +50,7 @@ function makeSnapshot(stage: TaskAgentStage): TaskPlanningSnapshot {
     plans: [],
     agentRuns: [],
     agentProgressEvents: [],
+    agentSessionEvents: [],
     agentStages: [
       {
         stage,

--- a/packages/along-web/src/types-task.ts
+++ b/packages/along-web/src/types-task.ts
@@ -135,6 +135,33 @@ export interface TaskAgentProgressEventRecord {
   createdAt: string;
 }
 
+export type TaskAgentSessionEventSource =
+  | 'system'
+  | 'agent'
+  | 'tool'
+  | 'stdout'
+  | 'stderr';
+
+export type TaskAgentSessionEventKind =
+  | 'progress'
+  | 'message'
+  | 'output'
+  | 'error';
+
+export interface TaskAgentSessionEventRecord {
+  eventId: string;
+  runId: string;
+  taskId: string;
+  threadId: string;
+  agentId: string;
+  provider: string;
+  source: TaskAgentSessionEventSource;
+  kind: TaskAgentSessionEventKind;
+  content: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
 export interface TaskAgentManualResume {
   available: boolean;
   cwd?: string;
@@ -241,6 +268,7 @@ export interface TaskPlanningSnapshot {
   plans: TaskPlanRevisionRecord[];
   agentRuns: TaskAgentRunRecord[];
   agentProgressEvents: TaskAgentProgressEventRecord[];
+  agentSessionEvents: TaskAgentSessionEventRecord[];
   agentStages: TaskAgentStageRecord[];
   flow: TaskFlowSnapshot;
 }

--- a/packages/along/src/core/db-schema.ts
+++ b/packages/along/src/core/db-schema.ts
@@ -115,6 +115,16 @@ const TABLES = [
     FOREIGN KEY(task_id) REFERENCES task_items(task_id) ON DELETE CASCADE,
     FOREIGN KEY(thread_id) REFERENCES task_threads(thread_id) ON DELETE CASCADE
   );`,
+  `CREATE TABLE IF NOT EXISTS task_agent_session_events (
+    event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL, task_id TEXT NOT NULL, thread_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL, provider TEXT NOT NULL, source TEXT NOT NULL,
+    kind TEXT NOT NULL, content TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(run_id) REFERENCES task_agent_runs(run_id) ON DELETE CASCADE,
+    FOREIGN KEY(task_id) REFERENCES task_items(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(thread_id) REFERENCES task_threads(thread_id) ON DELETE CASCADE
+  );`,
 ];
 
 const INDEXES = [
@@ -133,6 +143,7 @@ const INDEXES = [
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_task_feedback_rounds_open_thread ON task_feedback_rounds(thread_id) WHERE status IN ('open','processing','stale_partial')",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_task_agent_runs_active ON task_agent_runs(thread_id, agent_id, provider) WHERE status = 'running'",
   'CREATE INDEX IF NOT EXISTS idx_task_agent_progress_thread ON task_agent_progress_events(thread_id, created_at)',
+  'CREATE INDEX IF NOT EXISTS idx_task_agent_session_thread ON task_agent_session_events(thread_id, created_at)',
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_task_items_repo_seq ON task_items(repo_owner, repo_name, seq)',
 ];
 

--- a/packages/along/src/domain/task-agent-progress.ts
+++ b/packages/along/src/domain/task-agent-progress.ts
@@ -1,7 +1,10 @@
 import {
   recordTaskAgentProgress,
+  recordTaskAgentSessionEvent,
   TASK_AGENT_PROGRESS_PHASE,
   type TaskAgentProgressPhase,
+  type TaskAgentSessionEventKind,
+  type TaskAgentSessionEventSource,
 } from './task-planning';
 
 export interface TaskAgentProgressContext {
@@ -23,6 +26,29 @@ export function writeTaskAgentProgress(
     phase,
     summary,
     detail,
+  });
+  recordTaskAgentSessionEvent({
+    ...context,
+    source: 'system',
+    kind: phase === TASK_AGENT_PROGRESS_PHASE.FAILED ? 'error' : 'progress',
+    content: detail ? `${summary}\n${detail}` : summary,
+    metadata: { phase },
+  });
+}
+
+export function writeTaskAgentSessionEvent(
+  context: TaskAgentProgressContext,
+  source: TaskAgentSessionEventSource,
+  kind: TaskAgentSessionEventKind,
+  content: string,
+  metadata?: Record<string, unknown>,
+): void {
+  recordTaskAgentSessionEvent({
+    ...context,
+    source,
+    kind,
+    content,
+    metadata,
   });
 }
 

--- a/packages/along/src/domain/task-claude-messages.ts
+++ b/packages/along/src/domain/task-claude-messages.ts
@@ -10,6 +10,13 @@ export interface ClaudeProgressSummary {
   detail?: string;
 }
 
+export interface ClaudeSessionEventSummary {
+  source: 'system' | 'agent' | 'tool';
+  kind: 'message' | 'output' | 'error';
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
 function isRecord(value: unknown): value is UnknownRecord {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -72,6 +79,91 @@ export function getResultStructuredOutput(message: SDKMessage): unknown {
   const record: unknown = message;
   if (!isRecord(record) || record.type !== 'result') return undefined;
   return record.structured_output;
+}
+
+export function summarizeClaudeSessionEvent(
+  message: SDKMessage,
+): ClaudeSessionEventSummary | null {
+  const record: unknown = message;
+  if (!isRecord(record)) return null;
+  const type = typeof record.type === 'string' ? record.type : 'unknown';
+  if (type === 'system') return summarizeClaudeSystemEvent(record);
+  if (type === 'assistant') return summarizeClaudeAssistantEvent(record);
+  if (type === 'tool_use_summary') {
+    return {
+      source: 'tool',
+      kind: 'message',
+      content: stringifyBriefRecord(record),
+      metadata: { type },
+    };
+  }
+  if (type === 'rate_limit_event') {
+    return {
+      source: 'system',
+      kind: 'message',
+      content: 'Agent 遇到服务限流，正在等待恢复。',
+      metadata: { type },
+    };
+  }
+  if (type === 'result') return summarizeClaudeResultEvent(record);
+  return null;
+}
+
+function summarizeClaudeSystemEvent(
+  record: UnknownRecord,
+): ClaudeSessionEventSummary {
+  const sessionId =
+    typeof record.session_id === 'string' ? record.session_id : undefined;
+  return {
+    source: 'system',
+    kind: 'message',
+    content: sessionId
+      ? `Agent session 已连接：${sessionId}`
+      : 'Agent session 已连接。',
+    metadata: { type: 'system', sessionId },
+  };
+}
+
+function summarizeClaudeAssistantEvent(
+  record: UnknownRecord,
+): ClaudeSessionEventSummary | null {
+  if (!isRecord(record.message)) return null;
+  const text = collectTextBlocks(record.message.content).join('\n\n').trim();
+  if (!text) return null;
+  return {
+    source: 'agent',
+    kind: 'output',
+    content: text,
+    metadata: { type: 'assistant' },
+  };
+}
+
+function summarizeClaudeResultEvent(
+  record: UnknownRecord,
+): ClaudeSessionEventSummary {
+  const error = getResultError(record as SDKMessage);
+  if (error) {
+    return {
+      source: 'system',
+      kind: 'error',
+      content: error,
+      metadata: { type: 'result', subtype: record.subtype },
+    };
+  }
+  return {
+    source: 'system',
+    kind: 'message',
+    content:
+      typeof record.result === 'string' && record.result.trim()
+        ? record.result
+        : 'Agent 已返回最终结果。',
+    metadata: { type: 'result', subtype: record.subtype },
+  };
+}
+
+function stringifyBriefRecord(record: UnknownRecord): string {
+  const text = JSON.stringify(record, null, 2);
+  return text.length > 2000 ? `${text.slice(0, 2000)}\n...[已截断]` : text;
 }
 
 export function summarizeClaudeProgress(

--- a/packages/along/src/domain/task-claude-runner.test.ts
+++ b/packages/along/src/domain/task-claude-runner.test.ts
@@ -7,6 +7,7 @@ const planningMocks = vi.hoisted(() => ({
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
+  recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
   updateTaskAgentProviderSession: vi.fn(),
 }));
@@ -25,6 +26,7 @@ vi.mock('./task-planning', () => ({
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
+  recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
   TASK_AGENT_PROGRESS_PHASE: {
     STARTING: 'starting',
@@ -138,6 +140,22 @@ describe('task-claude-runner', () => {
         provider: 'claude',
         phase: 'starting',
         summary: 'Agent 已启动，正在准备任务上下文。',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    planningMocks.recordTaskAgentSessionEvent.mockReturnValue({
+      success: true,
+      data: {
+        eventId: 'sess-1',
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        provider: 'claude',
+        source: 'system',
+        kind: 'progress',
+        content: 'Agent 已启动，正在准备任务上下文。',
+        metadata: {},
         createdAt: '2026-01-01T00:00:00.000Z',
       },
     });

--- a/packages/along/src/domain/task-claude-runner.ts
+++ b/packages/along/src/domain/task-claude-runner.ts
@@ -8,6 +8,7 @@ import { failure, success } from '../core/result';
 import {
   type TaskAgentProgressContext,
   writeTaskAgentProgress,
+  writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
   finishTaskAgentSuccess,
@@ -24,6 +25,7 @@ import {
   getResultText,
   getSessionId,
   summarizeClaudeProgress,
+  summarizeClaudeSessionEvent,
 } from './task-claude-messages';
 import {
   type TaskAgentRunRecord,
@@ -144,6 +146,7 @@ function processClaudeMessage(
 ): Result<void> {
   const sessionId = getSessionId(message);
   if (sessionId) state.latestSessionId = sessionId;
+  writeClaudeSessionEvent(context, message);
   writeClaudeProgress(context, message);
   state.assistantTextParts.push(...getAssistantMessageText(message));
   const resultText = getResultText(message);
@@ -162,6 +165,21 @@ function processClaudeMessage(
   }
   const failedRes = markTaskAgentFailed(context, error, state.latestSessionId);
   return failedRes.success ? failure(error) : failure(failedRes.error);
+}
+
+function writeClaudeSessionEvent(
+  context: TaskAgentProgressContext,
+  message: SDKMessage,
+) {
+  const event = summarizeClaudeSessionEvent(message);
+  if (!event) return;
+  writeTaskAgentSessionEvent(
+    context,
+    event.source,
+    event.kind,
+    event.content,
+    event.metadata,
+  );
 }
 
 function completeClaudeTurn(

--- a/packages/along/src/domain/task-codex-runner.test.ts
+++ b/packages/along/src/domain/task-codex-runner.test.ts
@@ -7,6 +7,7 @@ const planningMocks = vi.hoisted(() => ({
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
+  recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
   updateTaskAgentProviderSession: vi.fn(),
 }));
@@ -21,6 +22,7 @@ vi.mock('./task-planning', () => ({
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
+  recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
   TASK_AGENT_PROGRESS_PHASE: {
     STARTING: 'starting',
@@ -103,6 +105,22 @@ describe('task-codex-runner', () => {
         provider: 'codex',
         phase: 'starting',
         summary: 'Agent 已启动，正在创建 Codex thread。',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    planningMocks.recordTaskAgentSessionEvent.mockReturnValue({
+      success: true,
+      data: {
+        eventId: 'sess-1',
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        provider: 'codex',
+        source: 'system',
+        kind: 'progress',
+        content: 'Agent 已启动，正在创建 Codex thread。',
+        metadata: {},
         createdAt: '2026-01-01T00:00:00.000Z',
       },
     });

--- a/packages/along/src/domain/task-codex-runner.ts
+++ b/packages/along/src/domain/task-codex-runner.ts
@@ -4,6 +4,7 @@ import { failure, success } from '../core/result';
 import {
   type TaskAgentProgressContext,
   writeTaskAgentProgress,
+  writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
   finishTaskAgentSuccess,
@@ -94,6 +95,7 @@ async function runStartedCodexTurn(
     thread = openCodexThread(input, progressContext, binding.providerSessionId);
     const turn = await runCodexPrompt(thread, prompt, outputSchema);
     latestThreadId = thread.id || binding.providerSessionId;
+    writeCodexTurnSessionEvents(progressContext, turn);
     return completeCodexTurn(
       input,
       progressContext,
@@ -106,6 +108,26 @@ async function runStartedCodexTurn(
     return failCodexTurn(progressContext, error, thread?.id || latestThreadId);
   } finally {
     stopHeartbeat();
+  }
+}
+
+function writeCodexTurnSessionEvents(
+  context: TaskAgentProgressContext,
+  turn: TaskCodexTurn,
+) {
+  if (turn.finalResponse.trim()) {
+    writeTaskAgentSessionEvent(context, 'agent', 'output', turn.finalResponse, {
+      type: 'final_response',
+    });
+  }
+  if (turn.items.length > 0) {
+    writeTaskAgentSessionEvent(
+      context,
+      'tool',
+      'message',
+      `Codex 返回 ${turn.items.length} 条会话 item。`,
+      { type: 'items', count: turn.items.length },
+    );
   }
 }
 

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -14,6 +14,7 @@ const mockDbState = vi.hoisted(() => {
     bindings: Row[];
     runs: Row[];
     progress: Row[];
+    sessionEvents: Row[];
   };
 
   const state: State = {
@@ -25,6 +26,7 @@ const mockDbState = vi.hoisted(() => {
     bindings: [],
     runs: [],
     progress: [],
+    sessionEvents: [],
   };
 
   function reset() {
@@ -36,6 +38,7 @@ const mockDbState = vi.hoisted(() => {
     state.bindings = [];
     state.runs = [];
     state.progress = [];
+    state.sessionEvents = [];
   }
 
   function normalizeSql(sql: string): string {
@@ -182,6 +185,17 @@ const mockDbState = vi.hoisted(() => {
           )
         ) {
           return state.progress
+            .filter((row) => row.thread_id === args[0])
+            .sort((a, b) =>
+              String(a.created_at).localeCompare(String(b.created_at)),
+            );
+        }
+        if (
+          normalized.includes(
+            'FROM task_agent_session_events WHERE thread_id = ?',
+          )
+        ) {
+          return state.sessionEvents
             .filter((row) => row.thread_id === args[0])
             .sort((a, b) =>
               String(a.created_at).localeCompare(String(b.created_at)),
@@ -652,6 +666,36 @@ const mockDbState = vi.hoisted(() => {
           return { changes: 1 };
         }
 
+        if (normalized.startsWith('INSERT INTO task_agent_session_events')) {
+          const [
+            eventId,
+            runId,
+            taskId,
+            threadId,
+            agentId,
+            provider,
+            source,
+            kind,
+            content,
+            metadata,
+            createdAt,
+          ] = args;
+          state.sessionEvents.push({
+            event_id: eventId,
+            run_id: runId,
+            task_id: taskId,
+            thread_id: threadId,
+            agent_id: agentId,
+            provider,
+            source,
+            kind,
+            content,
+            metadata,
+            created_at: createdAt,
+          });
+          return { changes: 1 };
+        }
+
         return { changes: 0 };
       },
     };
@@ -686,6 +730,7 @@ import {
   readTaskPlanningSnapshot,
   recordTaskAgentProgress,
   recordTaskAgentResult,
+  recordTaskAgentSessionEvent,
   recoverInterruptedTaskAgentRuns,
   submitTaskMessage,
   TASK_AGENT_PROGRESS_PHASE,
@@ -1080,6 +1125,49 @@ describe('task-planning', () => {
         phase: 'tool',
         summary: '正在执行工具或命令。',
         detail: '只保存用户可理解摘要。',
+      }),
+    ]);
+  });
+
+  it('当记录 Agent Session 事件时，期望快照包含脱敏后的会话流', () => {
+    const { taskId } = createTaskWithPlan();
+    const snapshot = readTaskPlanningSnapshot(taskId);
+    expect(snapshot.success).toBe(true);
+    if (!snapshot.success || !snapshot.data)
+      throw new Error('missing snapshot');
+
+    const run = createTaskAgentRun({
+      taskId,
+      threadId: snapshot.data.thread.threadId,
+      agentId: 'planner',
+      provider: 'claude',
+    });
+    expect(run.success).toBe(true);
+    if (!run.success) throw new Error(run.error);
+
+    const event = recordTaskAgentSessionEvent({
+      runId: run.data.runId,
+      taskId,
+      threadId: snapshot.data.thread.threadId,
+      agentId: 'planner',
+      provider: 'claude',
+      source: 'agent',
+      kind: 'output',
+      content: '执行中 TOKEN=secret-value',
+    });
+    expect(event.success).toBe(true);
+    if (!event.success) throw new Error(event.error);
+
+    const refreshed = readTaskPlanningSnapshot(taskId);
+    expect(refreshed.success).toBe(true);
+    if (!refreshed.success || !refreshed.data)
+      throw new Error('missing refreshed snapshot');
+    expect(refreshed.data.agentSessionEvents).toEqual([
+      expect.objectContaining({
+        runId: run.data.runId,
+        source: 'agent',
+        kind: 'output',
+        content: '执行中 TOKEN=[REDACTED]',
       }),
     ]);
   });

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -231,6 +231,33 @@ export interface TaskAgentProgressEventRecord {
   createdAt: string;
 }
 
+export type TaskAgentSessionEventSource =
+  | 'system'
+  | 'agent'
+  | 'tool'
+  | 'stdout'
+  | 'stderr';
+
+export type TaskAgentSessionEventKind =
+  | 'progress'
+  | 'message'
+  | 'output'
+  | 'error';
+
+export interface TaskAgentSessionEventRecord {
+  eventId: string;
+  runId: string;
+  taskId: string;
+  threadId: string;
+  agentId: string;
+  provider: string;
+  source: TaskAgentSessionEventSource;
+  kind: TaskAgentSessionEventKind;
+  content: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
 export interface TaskAgentStageRecord {
   stage: TaskAgentStage;
   agentId: string;
@@ -329,8 +356,13 @@ export interface TaskPlanningSnapshot {
   plans: TaskPlanRevisionRecord[];
   agentRuns: TaskAgentRunRecord[];
   agentProgressEvents: TaskAgentProgressEventRecord[];
+  agentSessionEvents: TaskAgentSessionEventRecord[];
   agentStages: TaskAgentStageRecord[];
   flow: TaskFlowSnapshot;
+}
+
+export interface ReadTaskPlanningSnapshotOptions {
+  includeSessionEvents?: boolean;
 }
 
 export interface CreatePlanningTaskInput {
@@ -401,6 +433,18 @@ export interface RecordTaskAgentProgressInput {
   phase: TaskAgentProgressPhase;
   summary: string;
   detail?: string;
+}
+
+export interface RecordTaskAgentSessionEventInput {
+  runId: string;
+  taskId: string;
+  threadId: string;
+  agentId: string;
+  provider: string;
+  source: TaskAgentSessionEventSource;
+  kind: TaskAgentSessionEventKind;
+  content: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RecoverInterruptedTaskAgentRunsOutput {
@@ -551,6 +595,20 @@ interface TaskAgentProgressEventRow {
   created_at: string;
 }
 
+interface TaskAgentSessionEventRow {
+  event_id: string;
+  run_id: string;
+  task_id: string;
+  thread_id: string;
+  agent_id: string;
+  provider: string;
+  source: TaskAgentSessionEventSource;
+  kind: TaskAgentSessionEventKind;
+  content: string;
+  metadata: string;
+  created_at: string;
+}
+
 interface TaskIdRow {
   task_id: string;
 }
@@ -587,6 +645,36 @@ function parseMetadata(
   } catch {
     return {};
   }
+}
+
+const SESSION_EVENT_CONTENT_LIMIT = 8000;
+const SECRET_VALUE = '[REDACTED]';
+
+function redactSensitiveContent(value: string): string {
+  return value
+    .replace(
+      /\b(?:ghp|gho|ghu|ghs|ghr|github_pat|glpat|xox[baprs])_[A-Za-z0-9_=-]{16,}\b/g,
+      SECRET_VALUE,
+    )
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, SECRET_VALUE)
+    .replace(
+      /\b((?:api[_-]?key|token|secret|password|authorization|bearer)\s*[:=]\s*["']?)([^\s"',;]+)/gi,
+      `$1${SECRET_VALUE}`,
+    )
+    .replace(
+      /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*\s*=\s*)([^\s]+)/g,
+      `$1${SECRET_VALUE}`,
+    );
+}
+
+function normalizeSessionEventContent(value: string): string {
+  const redacted = redactSensitiveContent(value.trim());
+  if (redacted.length <= SESSION_EVENT_CONTENT_LIMIT) return redacted;
+  const omitted = redacted.length - SESSION_EVENT_CONTENT_LIMIT;
+  return `${redacted.slice(
+    0,
+    SESSION_EVENT_CONTENT_LIMIT,
+  )}\n...[已截断 ${omitted} 字符]`;
 }
 
 function mapThread(row: TaskThreadRow): TaskThreadRecord {
@@ -712,6 +800,24 @@ function mapProgressEvent(
     phase: row.phase,
     summary: row.summary,
     detail: row.detail || undefined,
+    createdAt: row.created_at,
+  };
+}
+
+function mapSessionEvent(
+  row: TaskAgentSessionEventRow,
+): TaskAgentSessionEventRecord {
+  return {
+    eventId: row.event_id,
+    runId: row.run_id,
+    taskId: row.task_id,
+    threadId: row.thread_id,
+    agentId: row.agent_id,
+    provider: row.provider,
+    source: row.source,
+    kind: row.kind,
+    content: row.content,
+    metadata: parseMetadata(row.metadata),
     createdAt: row.created_at,
   };
 }
@@ -1735,6 +1841,7 @@ export function updatePlanningTaskTitle(
 
 export function readTaskPlanningSnapshot(
   taskId: string,
+  options: ReadTaskPlanningSnapshotOptions = {},
 ): Result<TaskPlanningSnapshot | null> {
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
@@ -1798,6 +1905,21 @@ export function readTaskPlanningSnapshot(
         'SELECT * FROM task_agent_progress_events WHERE thread_id = ? ORDER BY created_at ASC',
       )
       .all(threadRow.thread_id) as TaskAgentProgressEventRow[];
+    const sessionEventRows =
+      options.includeSessionEvents === false
+        ? []
+        : (db
+            .prepare(
+              `
+                SELECT * FROM (
+                  SELECT * FROM task_agent_session_events
+                  WHERE thread_id = ?
+                  ORDER BY created_at DESC
+                  LIMIT 200
+                ) ORDER BY created_at ASC
+              `,
+            )
+            .all(threadRow.thread_id) as TaskAgentSessionEventRow[]);
     const task = mapTask(taskRow);
     const thread = mapThread(threadRow);
     const currentPlan = currentPlanRow ? mapPlan(currentPlanRow) : null;
@@ -1807,6 +1929,7 @@ export function readTaskPlanningSnapshot(
     const agentBindings = bindingRows.map(mapBinding);
     const agentRuns = runRows.map(mapRun);
     const agentProgressEvents = progressRows.map(mapProgressEvent);
+    const agentSessionEvents = sessionEventRows.map(mapSessionEvent);
     const agentStages = buildTaskAgentStages(agentRuns, agentBindings, task);
 
     return success({
@@ -1818,6 +1941,7 @@ export function readTaskPlanningSnapshot(
       plans,
       agentRuns,
       agentProgressEvents,
+      agentSessionEvents,
       agentStages,
       flow: buildTaskFlowSnapshot({
         task,
@@ -1865,7 +1989,9 @@ export function listTaskPlanningSnapshots(
     const snapshots: TaskPlanningSnapshot[] = [];
 
     for (const row of rows) {
-      const snapshotRes = readTaskPlanningSnapshot(row.task_id);
+      const snapshotRes = readTaskPlanningSnapshot(row.task_id, {
+        includeSessionEvents: false,
+      });
       if (!snapshotRes.success) return snapshotRes;
       if (snapshotRes.data) snapshots.push(snapshotRes.data);
     }
@@ -2795,6 +2921,59 @@ export function recordTaskAgentProgress(
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return failure(`记录 Agent Progress 失败: ${message}`);
+  }
+}
+
+export function recordTaskAgentSessionEvent(
+  input: RecordTaskAgentSessionEventInput,
+): Result<TaskAgentSessionEventRecord> {
+  const content = normalizeSessionEventContent(input.content);
+  if (!content) return failure('Agent Session 内容不能为空');
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+  const eventId = generateId('sess');
+  const createdAt = iso_timestamp();
+
+  try {
+    dbRes.data
+      .prepare(
+        `
+          INSERT INTO task_agent_session_events (
+            event_id, run_id, task_id, thread_id, agent_id, provider,
+            source, kind, content, metadata, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run(
+        eventId,
+        input.runId,
+        input.taskId,
+        input.threadId,
+        input.agentId,
+        input.provider,
+        input.source,
+        input.kind,
+        content,
+        JSON.stringify(input.metadata || {}),
+        createdAt,
+      );
+
+    return success({
+      eventId,
+      runId: input.runId,
+      taskId: input.taskId,
+      threadId: input.threadId,
+      agentId: input.agentId,
+      provider: input.provider,
+      source: input.source,
+      kind: input.kind,
+      content,
+      metadata: input.metadata || {},
+      createdAt,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`记录 Agent Session 事件失败: ${message}`);
   }
 }
 

--- a/packages/along/src/domain/task-spawn-runner.test.ts
+++ b/packages/along/src/domain/task-spawn-runner.test.ts
@@ -6,6 +6,7 @@ const planningMocks = vi.hoisted(() => ({
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
+  recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
 }));
 
@@ -19,6 +20,7 @@ vi.mock('./task-planning', () => ({
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
+  recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
   TASK_AGENT_PROGRESS_PHASE: {
     STARTING: 'starting',
@@ -100,6 +102,22 @@ describe('task-spawn-runner', () => {
         provider: 'pi',
         phase: 'starting',
         summary: 'Agent 已启动，正在执行 PI。',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    planningMocks.recordTaskAgentSessionEvent.mockReturnValue({
+      success: true,
+      data: {
+        eventId: 'sess-1',
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'implementer',
+        provider: 'pi',
+        source: 'system',
+        kind: 'progress',
+        content: 'Agent 已启动，正在执行 PI。',
+        metadata: {},
         createdAt: '2026-01-01T00:00:00.000Z',
       },
     });

--- a/packages/along/src/domain/task-spawn-runner.ts
+++ b/packages/along/src/domain/task-spawn-runner.ts
@@ -5,6 +5,7 @@ import { failure, success } from '../core/result';
 import {
   type TaskAgentProgressContext,
   writeTaskAgentProgress,
+  writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
   finishTaskAgentSuccess,
@@ -25,6 +26,8 @@ export interface TaskAgentSpawnCommand {
   args: string[];
   cwd: string;
   stdin?: string;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
 }
 
 export interface TaskAgentSpawnResult {
@@ -102,9 +105,11 @@ export async function defaultTaskAgentSpawnRunner(
     proc.stderr?.setEncoding('utf-8');
     proc.stdout?.on('data', (chunk) => {
       stdout += chunk;
+      command.onStdout?.(chunk);
     });
     proc.stderr?.on('data', (chunk) => {
       stderr += chunk;
+      command.onStderr?.(chunk);
     });
     proc.on('error', (error) => {
       resolve(failure(getErrorMessage(error)));
@@ -155,12 +160,14 @@ export async function runTaskSpawnTurn(
   );
   const runner = input.spawnRunner || defaultTaskAgentSpawnRunner;
   try {
+    const streamState = { seen: false };
     return executeSpawnTurn(
       input,
       commandRes.data,
       editorRes.data,
       startedRes.data,
       runner,
+      streamState,
     );
   } finally {
     stopHeartbeat();
@@ -187,13 +194,16 @@ async function executeSpawnTurn(
   editor: EditorConfig,
   started: StartedTaskAgentRun,
   runner: TaskAgentSpawnRunner,
+  streamState: { seen: boolean },
 ): Promise<Result<RunTaskClaudeTurnOutput>> {
   writeTaskAgentProgress(
     started.progressContext,
     TASK_AGENT_PROGRESS_PHASE.TOOL,
     '正在等待外部 Agent 命令返回。',
   );
-  const executionRes = await runner(command);
+  const executionRes = await runner(
+    withSessionStreamCallbacks(command, started.progressContext, streamState),
+  );
   if (!executionRes.success) {
     return failSpawnTurn(
       started.progressContext,
@@ -201,7 +211,37 @@ async function executeSpawnTurn(
       executionRes.error,
     );
   }
-  return finishSpawnExecution(input, editor, started, executionRes.data);
+  return finishSpawnExecution(
+    input,
+    editor,
+    started,
+    executionRes.data,
+    streamState.seen,
+  );
+}
+
+function withSessionStreamCallbacks(
+  command: TaskAgentSpawnCommand,
+  context: TaskAgentProgressContext,
+  streamState: { seen: boolean },
+): TaskAgentSpawnCommand {
+  return {
+    ...command,
+    onStdout: (chunk) => {
+      streamState.seen = true;
+      command.onStdout?.(chunk);
+      writeTaskAgentSessionEvent(context, 'stdout', 'output', chunk, {
+        stream: 'stdout',
+      });
+    },
+    onStderr: (chunk) => {
+      streamState.seen = true;
+      command.onStderr?.(chunk);
+      writeTaskAgentSessionEvent(context, 'stderr', 'error', chunk, {
+        stream: 'stderr',
+      });
+    },
+  };
 }
 
 function finishSpawnExecution(
@@ -209,7 +249,9 @@ function finishSpawnExecution(
   editor: EditorConfig,
   started: StartedTaskAgentRun,
   execution: TaskAgentSpawnResult,
+  hadStreamEvents: boolean,
 ): Result<RunTaskClaudeTurnOutput> {
+  if (!hadStreamEvents) writeSpawnFinalSessionEvent(started, execution);
   if (execution.exitCode !== 0) {
     return failSpawnTurn(
       started.progressContext,
@@ -238,6 +280,32 @@ function finishSpawnExecution(
     assistantText,
     outputArtifactIds: outputRes.data,
   });
+}
+
+function writeSpawnFinalSessionEvent(
+  started: StartedTaskAgentRun,
+  execution: TaskAgentSpawnResult,
+) {
+  const stdout = execution.stdout.trim();
+  const stderr = execution.stderr.trim();
+  if (stdout) {
+    writeTaskAgentSessionEvent(
+      started.progressContext,
+      'stdout',
+      'output',
+      stdout,
+      { stream: 'stdout', final: true },
+    );
+  }
+  if (stderr) {
+    writeTaskAgentSessionEvent(
+      started.progressContext,
+      'stderr',
+      execution.exitCode === 0 ? 'output' : 'error',
+      stderr,
+      { stream: 'stderr', final: true },
+    );
+  }
 }
 
 function failSpawnTurn(


### PR DESCRIPTION
along-task: #12

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.test.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.tsx`
- `packages/along-web/src/task-planning/flowActionRouter.test.ts`
- `packages/along-web/src/types-task.ts`
- `packages/along/src/core/db-schema.ts`
- `packages/along/src/domain/task-agent-progress.ts`
- `packages/along/src/domain/task-claude-messages.ts`
- `packages/along/src/domain/task-claude-runner.test.ts`
- `packages/along/src/domain/task-claude-runner.ts`
- `packages/along/src/domain/task-codex-runner.test.ts`
- `packages/along/src/domain/task-codex-runner.ts`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/domain/task-spawn-runner.test.ts`
- `packages/along/src/domain/task-spawn-runner.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/agent-12`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
目标：为 Agent 执行中的任务提供接近实时的 session 会话信息展示，让用户能像 tail 日志一样判断 Agent 是否仍在推进、卡在哪一步、最近输出了什么，降低长时间任务只显示“运行中”但不可观测的问题。

范围：
1. 梳理当前任务进度展示链路，确认现有轮询只展示状态/耗时的边界，以及 Agent session 会话信息当前的产生、存储、传输和权限模型。
2. 设计并实现任务详情页或执行进度区域的实时会话流展示能力，至少展示时间、角色/来源、内容摘要或原始输出，并支持持续追加最新消息。
3. 保留现有任务状态、耗时和超时提示，但将“仍在执行但无可见输出”的场景补充为可观测的 session 流，避免用户只能依赖超时时间判断是否挂起。
4. 对长时间无新 session 输出的任务增加明确提示，例如最近一次会话更新时间、已静默时长、是否仍处于执行状态。
5. 明确敏感信息处理规则：不得向无权限用户暴露不属于该任务的 session 内容；如 session 可能包含密钥、token、环境变量等，需要沿用或补充脱敏策略。

边界：
1. 本计划不要求改变 Agent 的实际执行调度、超时策略或任务取消语义。
2. 本计划不默认提供历史全量日志检索、日志下载、跨任务聚合搜索，除非实现时发现这是现有架构的最小必要能力。
3. 本计划不主动做旧版本兼容设计；如现有历史任务缺少 session 数据，只需在界面上明确显示“暂无可展示会话信息”。

风险与关注点：
1. 实时展示方式需结合现有架构选择，避免高频轮询导致数据库或 API 压力明显上升。
2. Agent 输出可能很长，需要限制单次加载量、追加策略和前端渲染规模，避免页面卡顿。
3. session 信息的权限与脱敏是核心风险，必须优先确认数据边界后再开放展示。
4. 如果当前系统没有持久化细粒度 session 事件，需先补齐事件记录链路，否则只能展示有限的状态信息。

验证：
1. 构造一个持续运行超过 30 分钟的任务，确认页面能持续看到最新 session 信息或最近静默时长。
2. 构造 Agent 仍在执行但一段时间无输出的任务，确认用户能区分“仍在执行但暂无新消息”和“任务已结束/失败”。
3. 验证无权限用户不能访问其他任务的 session 内容。
4. 验证大输出量任务下页面不会明显卡顿，接口负载在可接受范围内。
5. 覆盖任务运行中、成功、失败、超时、无 session 数据等状态。

交付标准：
1. 用户在任务详情或进度视图中可以看到 Agent session 会话信息的实时追加展示。
2. 长时间运行任务能显示最近一条会话信息时间和静默时长。
3. 权限、脱敏和大输出处理有明确实现与测试覆盖。
4. 现有任务状态展示不回退，原有轮询/刷新能力仍可正常工作。

## 交付信息
- Commit: bcd9d23c14e195c950d463faef0343f37e3bb0d0