### PR TITLE
Task #14: 新增任务模式选择支持全自动

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -25,6 +25,8 @@ import { TaskRecordsPanel } from './TaskRecords';
 
 function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
   const [isExpanded, setIsExpanded] = useState(true);
+  const executionMode =
+    selected.task.executionMode === 'autonomous' ? '全自动' : '人工确认';
   return (
     <aside className="min-w-0 rounded-lg border border-border-color bg-black/25">
       <button
@@ -72,6 +74,8 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
           <span>{getThreadStatusLabel(selected.thread.status)}</span>
           <span className="text-text-muted">Source</span>
           <span>{selected.task.source}</span>
+          <span className="text-text-muted">Mode</span>
+          <span>{executionMode}</span>
           <span className="text-text-muted">Status</span>
           <span>{getTaskStatusLabel(selected.task.status)}</span>
           {selected.task.branchName && (
@@ -201,6 +205,19 @@ function NewTaskComposer({
         rows={2}
         className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
       />
+      <label className="flex flex-col gap-1 text-xs text-text-muted">
+        执行模式
+        <select
+          value={draft.executionMode}
+          onChange={(event) =>
+            onDraftChange('executionMode', event.target.value)
+          }
+          className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm text-text-primary outline-none focus:ring-1 focus:ring-brand/60"
+        >
+          <option value="manual">人工确认</option>
+          <option value="autonomous">全自动</option>
+        </select>
+      </label>
       <div className="flex items-center justify-between gap-3">
         <span className="min-w-0 text-xs text-text-muted">
           {selectedRepository ? '将创建到当前仓库。' : '请先选择仓库。'}

--- a/packages/along-web/src/task-planning/api.ts
+++ b/packages/along-web/src/task-planning/api.ts
@@ -1,4 +1,4 @@
-import type { TaskPlanningSnapshot } from '../types';
+import type { TaskExecutionMode, TaskPlanningSnapshot } from '../types';
 
 export interface CreateTaskResponse {
   taskId: string;
@@ -58,6 +58,7 @@ export interface RepositoryListResponse {
 export interface DraftTaskInput {
   body: string;
   repository: string;
+  executionMode: TaskExecutionMode;
 }
 
 interface TaskApiError {
@@ -67,6 +68,7 @@ interface TaskApiError {
 export const emptyDraft: DraftTaskInput = {
   body: '',
   repository: '',
+  executionMode: 'manual',
 };
 
 export function mergeSnapshotIntoList(

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -49,6 +49,9 @@ async function runBusy(
 
 function buildCreatePayload(input: UseTaskPlanningActionsInput, body: string) {
   const payload: Record<string, string | boolean> = { body, autoRun: true };
+  if (input.draft.executionMode === 'autonomous') {
+    payload.executionMode = 'autonomous';
+  }
   if (input.selectedRepository) {
     payload.owner = input.selectedRepository.owner;
     payload.repo = input.selectedRepository.repo;

--- a/packages/along-web/src/types-task.ts
+++ b/packages/along-web/src/types-task.ts
@@ -7,6 +7,8 @@ export type TaskStatus =
   | 'delivered'
   | 'completed';
 
+export type TaskExecutionMode = 'manual' | 'autonomous';
+
 export type TaskThreadStatus =
   | 'drafting'
   | 'awaiting_approval'
@@ -37,6 +39,7 @@ export interface TaskItemRecord {
   prNumber?: number;
   seq?: number;
   type?: string;
+  executionMode: TaskExecutionMode;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/along/src/commands/webhook-server.ts
+++ b/packages/along/src/commands/webhook-server.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy webhook server predates current function-size rule.
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy webhook server predates current file-size rule.
 /**
  * webhook-server.ts - 本地 webhook 接收服务器
  *
@@ -69,6 +71,10 @@ import {
   type ScheduledTaskPlanningRun,
   type ScheduledTaskTitleSummaryRun,
 } from '../integration/task-api';
+import {
+  continueAutonomousTaskAfterImplementation,
+  continueAutonomousTaskAfterPlanning,
+} from '../integration/task-autonomous-continuation';
 import {
   cleanupIssueSession,
   resolveCi,
@@ -460,6 +466,21 @@ function enqueueTaskPlanningRun(input: ScheduledTaskPlanningRun) {
       logger.info(
         `[Task ${input.taskId}] planning 完成: ${result.data.action}`,
       );
+      const continuation = continueAutonomousTaskAfterPlanning({
+        taskId: input.taskId,
+        cwd: input.cwd,
+        plannerAction: result.data.action,
+        scheduleImplementation: enqueueTaskImplementationRun,
+      });
+      if (!continuation.success) {
+        logger.error(
+          `[Task ${input.taskId}] autonomous planning 推进失败: ${continuation.error}`,
+        );
+      } else if (continuation.data !== 'skipped') {
+        logger.info(
+          `[Task ${input.taskId}] autonomous planning 推进: ${continuation.data}`,
+        );
+      }
     });
   });
 }
@@ -485,6 +506,21 @@ function enqueueTaskImplementationRun(input: ScheduledTaskImplementationRun) {
         return;
       }
       logger.info(`[Task ${input.taskId}] implementation 完成`);
+      const continuation = continueAutonomousTaskAfterImplementation({
+        taskId: input.taskId,
+        cwd: input.cwd,
+        scheduleImplementation: enqueueTaskImplementationRun,
+        scheduleDelivery: enqueueTaskDeliveryRun,
+      });
+      if (!continuation.success) {
+        logger.error(
+          `[Task ${input.taskId}] autonomous implementation 推进失败: ${continuation.error}`,
+        );
+      } else if (continuation.data !== 'skipped') {
+        logger.info(
+          `[Task ${input.taskId}] autonomous implementation 推进: ${continuation.data}`,
+        );
+      }
     });
   });
 }

--- a/packages/along/src/core/db-schema.ts
+++ b/packages/along/src/core/db-schema.ts
@@ -53,6 +53,7 @@ const TABLES = [
     status TEXT NOT NULL, active_thread_id TEXT, repo_owner TEXT, repo_name TEXT,
     cwd TEXT, worktree_path TEXT, branch_name TEXT, commit_shas TEXT DEFAULT '[]',
     pr_url TEXT, pr_number INTEGER, seq INTEGER, type TEXT,
+    execution_mode TEXT NOT NULL DEFAULT 'manual',
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL
   );`,
   `CREATE TABLE IF NOT EXISTS task_threads (
@@ -168,6 +169,7 @@ const COLUMN_MIGRATIONS = [
   'ALTER TABLE task_items ADD COLUMN pr_number INTEGER',
   'ALTER TABLE task_items ADD COLUMN seq INTEGER',
   'ALTER TABLE task_items ADD COLUMN type TEXT',
+  "ALTER TABLE task_items ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'manual'",
 ];
 
 function execRequired(db: Database, statements: string[]) {

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -226,6 +226,7 @@ const mockDbState = vi.hoisted(() => {
             repoName,
             cwd,
             seq,
+            executionMode,
             createdAt,
             updatedAt,
           ] = args;
@@ -246,6 +247,7 @@ const mockDbState = vi.hoisted(() => {
             pr_number: null,
             seq,
             type: null,
+            execution_mode: executionMode,
             created_at: createdAt,
             updated_at: updatedAt,
           });
@@ -787,6 +789,35 @@ describe('task-planning', () => {
       snapshot.data.flow.actions.find((action) => action.id === 'approve_plan')
         ?.enabled,
     ).toBe(true);
+  });
+
+  it('当创建 Task 未指定执行模式时，期望默认为 manual', () => {
+    const created = createPlanningTask({
+      title: '默认模式任务',
+      body: '不指定 executionMode。',
+      source: 'test',
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) throw new Error(created.error);
+
+    expect(created.data.task.executionMode).toBe('manual');
+  });
+
+  it('当创建 Task 指定全自动模式时，期望快照返回 autonomous', () => {
+    const created = createPlanningTask({
+      title: '全自动任务',
+      body: '指定 executionMode。',
+      source: 'test',
+      executionMode: 'autonomous',
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) throw new Error(created.error);
+
+    const snapshot = readTaskPlanningSnapshot(created.data.task.taskId);
+    expect(snapshot.success).toBe(true);
+    if (!snapshot.success || !snapshot.data)
+      throw new Error('missing snapshot');
+    expect(snapshot.data.task.executionMode).toBe('autonomous');
   });
 
   it('当首版计划前需要澄清时，期望记录 Planning Update 并保持可继续讨论', () => {

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -24,6 +24,14 @@ export const TASK_STATUS = {
 
 export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
 
+export const TASK_EXECUTION_MODE = {
+  MANUAL: 'manual',
+  AUTONOMOUS: 'autonomous',
+} as const;
+
+export type TaskExecutionMode =
+  (typeof TASK_EXECUTION_MODE)[keyof typeof TASK_EXECUTION_MODE];
+
 export const THREAD_PURPOSE = {
   PLANNING: 'planning',
 } as const;
@@ -145,6 +153,7 @@ export interface TaskItemRecord {
   prNumber?: number;
   seq?: number;
   type?: string;
+  executionMode: TaskExecutionMode;
   createdAt: string;
   updatedAt: string;
 }
@@ -380,6 +389,7 @@ export interface CreatePlanningTaskInput {
   repoOwner?: string;
   repoName?: string;
   cwd?: string;
+  executionMode?: TaskExecutionMode;
 }
 
 export interface UpdatePlanningTaskTitleInput {
@@ -535,6 +545,7 @@ interface TaskItemRow {
   pr_number: number | null;
   seq: number | null;
   type: string | null;
+  execution_mode?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -642,6 +653,14 @@ function parseStringArray(value: string | null | undefined): string[] {
   }
 }
 
+function normalizeTaskExecutionMode(
+  value: string | null | undefined,
+): TaskExecutionMode {
+  return value === TASK_EXECUTION_MODE.AUTONOMOUS
+    ? TASK_EXECUTION_MODE.AUTONOMOUS
+    : TASK_EXECUTION_MODE.MANUAL;
+}
+
 function parseMetadata(
   value: string | null | undefined,
 ): Record<string, unknown> {
@@ -745,6 +764,7 @@ function mapTask(row: TaskItemRow): TaskItemRecord {
     prNumber: row.pr_number || undefined,
     seq: row.seq || undefined,
     type: row.type || undefined,
+    executionMode: normalizeTaskExecutionMode(row.execution_mode),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -1850,8 +1870,8 @@ export function createPlanningTask(
         `
           INSERT INTO task_items (
             task_id, title, body, source, status, active_thread_id,
-            repo_owner, repo_name, cwd, seq, created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            repo_owner, repo_name, cwd, seq, execution_mode, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
       ).run(
         taskId,
@@ -1864,6 +1884,7 @@ export function createPlanningTask(
         input.repoName || null,
         input.cwd || null,
         seq,
+        input.executionMode || TASK_EXECUTION_MODE.MANUAL,
         now,
         now,
       );

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -29,6 +29,7 @@ import {
   readPositiveInt,
   readStringField,
   readTaskAgentStageField,
+  readTaskExecutionModeField,
   resolveTaskCwd,
   scheduleDeliveryIfNeeded,
   scheduleImplementationIfNeeded,
@@ -112,6 +113,8 @@ function createTaskFromPayload(
 ): Result<TaskPlanningSnapshot> {
   const cwdRes = resolveTaskCwd(payload, context);
   if (!cwdRes.success) return cwdRes;
+  const executionModeRes = readTaskExecutionModeField(payload, 'executionMode');
+  if (!executionModeRes.success) return executionModeRes;
   const repository = getTaskRepositoryFields(payload, context, cwdRes.data);
   return createPlanningTask({
     title: deriveTitle(taskBody),
@@ -120,6 +123,7 @@ function createTaskFromPayload(
     repoOwner: repository.repoOwner,
     repoName: repository.repoName,
     cwd: cwdRes.data,
+    executionMode: executionModeRes.data,
   });
 }
 

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -22,6 +22,10 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../domain/task-planning', () => ({
+  TASK_EXECUTION_MODE: {
+    MANUAL: 'manual',
+    AUTONOMOUS: 'autonomous',
+  },
   TASK_AGENT_STAGE: {
     PLANNING: 'planning',
     IMPLEMENTATION: 'implementation',

--- a/packages/along/src/integration/task-api-utils.ts
+++ b/packages/along/src/integration/task-api-utils.ts
@@ -4,7 +4,9 @@ import {
   readTaskAgentBinding,
   readTaskPlanningSnapshot,
   TASK_AGENT_STAGE,
+  TASK_EXECUTION_MODE,
   type TaskAgentStage,
+  type TaskExecutionMode,
   type TaskPlanningSnapshot,
 } from '../domain/task-planning';
 import type {
@@ -65,6 +67,24 @@ export function readBooleanField(
 ): boolean | undefined {
   const value = payload[key];
   return typeof value === 'boolean' ? value : undefined;
+}
+
+export function readTaskExecutionModeField(
+  payload: UnknownRecord,
+  key: string,
+): Result<TaskExecutionMode | undefined> {
+  const rawValue = payload[key];
+  const value = typeof rawValue === 'string' ? rawValue.trim() : rawValue;
+  if (value === undefined || value === null || value === '') {
+    return success(undefined);
+  }
+  if (
+    value === TASK_EXECUTION_MODE.MANUAL ||
+    value === TASK_EXECUTION_MODE.AUTONOMOUS
+  ) {
+    return success(value);
+  }
+  return failure('executionMode 必须是 manual 或 autonomous');
 }
 
 export function readTaskAgentStageField(

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -22,6 +22,8 @@ export const snapshot = {
     source: 'web',
     status: 'planning',
     activeThreadId: 'thread-1',
+    commitShas: [],
+    executionMode: 'manual',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   },
@@ -157,7 +159,7 @@ export function jsonRequest(
 export function expectScheduledRunner(
   scheduled: unknown[],
   cwd: string,
-  reason: 'task_created' | 'user_message' | 'manual',
+  reason: 'task_created' | 'user_message' | 'manual' | 'autonomous',
 ) {
   expect(scheduled).toEqual([
     {

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -21,6 +21,10 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../domain/task-planning', () => ({
+  TASK_EXECUTION_MODE: {
+    MANUAL: 'manual',
+    AUTONOMOUS: 'autonomous',
+  },
   TASK_AGENT_STAGE: {
     PLANNING: 'planning',
     IMPLEMENTATION: 'implementation',
@@ -86,6 +90,46 @@ it('当创建 Task 时，期望返回 202 并调度 planner', async () => {
       body: '通过 Web API 创建 planning task。',
     },
   ]);
+});
+
+it('当创建 Task 指定全自动模式时，期望 executionMode 传给创建层', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks', {
+      body: '创建全自动 planning task。',
+      executionMode: 'autonomous',
+    }),
+    new URL('http://localhost/api/tasks'),
+    {
+      defaultCwd: '/tmp/default',
+      scheduleTitleSummary: () => {},
+    },
+  );
+
+  expect(response.status).toBe(201);
+  expect(planningMocks.createPlanningTask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      executionMode: 'autonomous',
+    }),
+  );
+});
+
+it('当创建 Task 指定非法执行模式时，期望返回 400', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks', {
+      body: '创建非法模式 planning task。',
+      executionMode: 'fast',
+    }),
+    new URL('http://localhost/api/tasks'),
+    {
+      defaultCwd: '/tmp/default',
+      scheduleTitleSummary: () => {},
+    },
+  );
+  const payload = (await response.json()) as { error: string };
+
+  expect(response.status).toBe(400);
+  expect(payload.error).toBe('executionMode 必须是 manual 或 autonomous');
+  expect(planningMocks.createPlanningTask).not.toHaveBeenCalled();
 });
 
 it('当创建 Task 未带 owner/repo 时，期望从默认 cwd 反查仓库并落库', async () => {
@@ -220,6 +264,7 @@ function expectCreatedTaskFields(cwd: string) {
     repoOwner: 'ranwawa',
     repoName: 'along',
     cwd,
+    executionMode: undefined,
   });
 }
 
@@ -236,5 +281,6 @@ function expectDefaultCreatedTaskFields() {
     repoOwner: 'ranwawa',
     repoName: 'along',
     cwd: '/tmp/along/packages/along',
+    executionMode: undefined,
   });
 }

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -16,7 +16,7 @@ import { errorResponse } from './task-api-utils';
 export interface ScheduledTaskPlanningRun {
   taskId: string;
   cwd: string;
-  reason: 'task_created' | 'user_message' | 'manual';
+  reason: 'task_created' | 'user_message' | 'manual' | 'autonomous';
   agentId?: string;
   editor?: string;
   model?: string;
@@ -26,7 +26,7 @@ export interface ScheduledTaskPlanningRun {
 export interface ScheduledTaskImplementationRun {
   taskId: string;
   cwd: string;
-  reason: 'manual';
+  reason: 'manual' | 'autonomous';
   agentId?: string;
   editor?: string;
   model?: string;
@@ -36,7 +36,7 @@ export interface ScheduledTaskImplementationRun {
 export interface ScheduledTaskDeliveryRun {
   taskId: string;
   cwd: string;
-  reason: 'manual';
+  reason: 'manual' | 'autonomous';
 }
 
 export interface ScheduledTaskTitleSummaryRun {

--- a/packages/along/src/integration/task-autonomous-continuation.test.ts
+++ b/packages/along/src/integration/task-autonomous-continuation.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import {
+  continueAutonomousTaskAfterImplementation,
+  continueAutonomousTaskAfterPlanning,
+} from './task-autonomous-continuation';
+
+const planningMocks = vi.hoisted(() => ({
+  approveTaskImplementationSteps: vi.fn(),
+  approveCurrentTaskPlan: vi.fn(),
+  readTaskPlanningSnapshot: vi.fn(),
+}));
+
+vi.mock('../domain/task-planning', () => ({
+  PLAN_STATUS: {
+    ACTIVE: 'active',
+    APPROVED: 'approved',
+  },
+  TASK_EXECUTION_MODE: {
+    MANUAL: 'manual',
+    AUTONOMOUS: 'autonomous',
+  },
+  TASK_STATUS: {
+    PLANNING_APPROVED: 'planning_approved',
+    IMPLEMENTED: 'implemented',
+  },
+  approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
+  approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  planningMocks.approveCurrentTaskPlan.mockReturnValue({
+    success: true,
+    data: plan,
+  });
+  planningMocks.approveTaskImplementationSteps.mockReturnValue({
+    success: true,
+    data: stepsApproval,
+  });
+});
+
+it('autonomous planner 产出正式 plan 后自动批准并调度 implementation', () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: makeSnapshot(),
+  });
+
+  const result = continueAutonomousTaskAfterPlanning({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    plannerAction: 'plan_revision',
+    scheduleImplementation: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({ success: true, data: 'approved_plan' });
+  expect(planningMocks.approveCurrentTaskPlan).toHaveBeenCalledWith('task-1');
+  expect(scheduled).toEqual([
+    { taskId: 'task-1', cwd: '/tmp/project', reason: 'autonomous' },
+  ]);
+});
+
+it('planner 产出 planning_update 时不自动批准', () => {
+  const scheduled: unknown[] = [];
+
+  const result = continueAutonomousTaskAfterPlanning({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    plannerAction: 'planning_update',
+    scheduleImplementation: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({ success: true, data: 'skipped' });
+  expect(planningMocks.readTaskPlanningSnapshot).not.toHaveBeenCalled();
+  expect(scheduled).toEqual([]);
+});
+
+it('存在 openRound 时不自动批准 plan', () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: makeSnapshot({ openRound: { roundId: 'round-1' } }),
+  });
+
+  const result = continueAutonomousTaskAfterPlanning({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    plannerAction: 'plan_revision',
+    scheduleImplementation: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({ success: true, data: 'skipped' });
+  expect(planningMocks.approveCurrentTaskPlan).not.toHaveBeenCalled();
+  expect(scheduled).toEqual([]);
+});
+
+it('implementation 仅产出步骤时自动确认并二次调度', () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: makeSnapshot({
+      task: { status: 'planning_approved' },
+      thread: { approvedPlanId: 'plan-1' },
+      currentPlan: { status: 'approved' },
+      plans: [plan],
+      artifacts: [steps],
+    }),
+  });
+
+  const result = continueAutonomousTaskAfterImplementation({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    scheduleImplementation: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({
+    success: true,
+    data: 'approved_implementation_steps',
+  });
+  expect(planningMocks.approveTaskImplementationSteps).toHaveBeenCalledWith(
+    'task-1',
+  );
+  expect(scheduled).toEqual([
+    { taskId: 'task-1', cwd: '/tmp/project', reason: 'autonomous' },
+  ]);
+});
+
+it('implementation 完成且有 commit 后自动调度 delivery', () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: makeSnapshot({
+      task: { status: 'implemented', commitShas: ['abc123'] },
+    }),
+  });
+
+  const result = continueAutonomousTaskAfterImplementation({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    scheduleDelivery: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({ success: true, data: 'scheduled_delivery' });
+  expect(scheduled).toEqual([
+    { taskId: 'task-1', cwd: '/tmp/project', reason: 'autonomous' },
+  ]);
+});
+
+it('已有 prUrl 时不重复调度 delivery', () => {
+  const scheduled: unknown[] = [];
+  planningMocks.readTaskPlanningSnapshot.mockReturnValue({
+    success: true,
+    data: makeSnapshot({
+      task: {
+        status: 'implemented',
+        commitShas: ['abc123'],
+        prUrl: 'https://github.com/ranwawa/along/pull/1',
+      },
+    }),
+  });
+
+  const result = continueAutonomousTaskAfterImplementation({
+    taskId: 'task-1',
+    cwd: '/tmp/project',
+    scheduleDelivery: (input) => scheduled.push(input),
+  });
+
+  expect(result).toEqual({ success: true, data: 'skipped' });
+  expect(scheduled).toEqual([]);
+});
+
+const plan = {
+  planId: 'plan-1',
+  taskId: 'task-1',
+  threadId: 'thread-1',
+  version: 1,
+  status: 'approved',
+  artifactId: 'art-plan',
+  body: 'Plan',
+  createdAt: '2026-01-01T00:00:01.000Z',
+};
+
+const steps = {
+  artifactId: 'art-steps',
+  taskId: 'task-1',
+  threadId: 'thread-1',
+  type: 'agent_result',
+  role: 'agent',
+  body: '实施步骤',
+  metadata: {
+    kind: 'implementation_steps',
+    planId: 'plan-1',
+  },
+  createdAt: '2026-01-01T00:00:02.000Z',
+};
+
+const stepsApproval = {
+  artifactId: 'art-steps-approval',
+  taskId: 'task-1',
+  threadId: 'thread-1',
+  type: 'approval',
+  role: 'user',
+  body: 'Approved Implementation Steps for Plan v1',
+  metadata: {
+    kind: 'implementation_steps_approval',
+    planId: 'plan-1',
+    stepsArtifactId: 'art-steps',
+  },
+  createdAt: '2026-01-01T00:00:03.000Z',
+};
+
+function makeSnapshot(
+  overrides: {
+    task?: Record<string, unknown>;
+    thread?: Record<string, unknown>;
+    currentPlan?: Record<string, unknown> | null;
+    openRound?: Record<string, unknown> | null;
+    plans?: unknown[];
+    artifacts?: unknown[];
+  } = {},
+) {
+  return {
+    task: {
+      taskId: 'task-1',
+      title: 'Task',
+      body: 'Body',
+      source: 'web',
+      status: 'planning',
+      activeThreadId: 'thread-1',
+      commitShas: [],
+      executionMode: 'autonomous',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides.task,
+    },
+    thread: {
+      threadId: 'thread-1',
+      taskId: 'task-1',
+      purpose: 'planning',
+      status: 'awaiting_approval',
+      currentPlanId: 'plan-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides.thread,
+    },
+    currentPlan:
+      overrides.currentPlan === null
+        ? null
+        : {
+            ...plan,
+            status: 'active',
+            ...overrides.currentPlan,
+          },
+    openRound: overrides.openRound ?? null,
+    artifacts: overrides.artifacts || [],
+    plans: overrides.plans || [{ ...plan, status: 'active' }],
+    agentRuns: [],
+    agentProgressEvents: [],
+    agentSessionEvents: [],
+    agentStages: [],
+    flow: {
+      currentStageId: 'plan_confirmation',
+      conclusion: '',
+      severity: 'normal',
+      stages: [],
+      actions: [],
+      blockers: [],
+      events: [],
+    },
+  };
+}

--- a/packages/along/src/integration/task-autonomous-continuation.ts
+++ b/packages/along/src/integration/task-autonomous-continuation.ts
@@ -1,0 +1,147 @@
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
+import {
+  areImplementationStepsApproved,
+  findImplementationStepsArtifact,
+} from '../domain/task-implementation-steps';
+import {
+  approveCurrentTaskPlan,
+  approveTaskImplementationSteps,
+  PLAN_STATUS,
+  readTaskPlanningSnapshot,
+  TASK_EXECUTION_MODE,
+  TASK_STATUS,
+  type TaskPlanningSnapshot,
+} from '../domain/task-planning';
+import type {
+  ScheduledTaskDeliveryRun,
+  ScheduledTaskImplementationRun,
+} from './task-api';
+
+export type AutonomousContinuationAction =
+  | 'skipped'
+  | 'approved_plan'
+  | 'approved_implementation_steps'
+  | 'scheduled_delivery';
+
+export interface TaskAutonomousContinuationSchedulers {
+  scheduleImplementation?: (input: ScheduledTaskImplementationRun) => void;
+  scheduleDelivery?: (input: ScheduledTaskDeliveryRun) => void;
+}
+
+export interface TaskAutonomousContinuationInput
+  extends TaskAutonomousContinuationSchedulers {
+  taskId: string;
+  cwd: string;
+}
+
+function readRequiredSnapshot(taskId: string): Result<TaskPlanningSnapshot> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  if (!snapshotRes.data) return failure(`Task 不存在: ${taskId}`);
+  return success(snapshotRes.data);
+}
+
+function isAutonomous(snapshot: TaskPlanningSnapshot): boolean {
+  return snapshot.task.executionMode === TASK_EXECUTION_MODE.AUTONOMOUS;
+}
+
+function hasApprovedThread(snapshot: TaskPlanningSnapshot): boolean {
+  return Boolean(snapshot.thread.approvedPlanId);
+}
+
+export function continueAutonomousTaskAfterPlanning(
+  input: TaskAutonomousContinuationInput & { plannerAction: string },
+): Result<AutonomousContinuationAction> {
+  if (input.plannerAction !== 'plan_revision') return success('skipped');
+
+  const snapshotRes = readRequiredSnapshot(input.taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  const snapshot = snapshotRes.data;
+  if (!isAutonomous(snapshot)) return success('skipped');
+  if (
+    !snapshot.currentPlan ||
+    snapshot.currentPlan.status !== PLAN_STATUS.ACTIVE ||
+    snapshot.openRound ||
+    hasApprovedThread(snapshot)
+  ) {
+    return success('skipped');
+  }
+  if (!input.scheduleImplementation) {
+    return failure('Implementation 调度器未启用，无法自动推进');
+  }
+
+  const approveRes = approveCurrentTaskPlan(input.taskId);
+  if (!approveRes.success) return approveRes;
+  input.scheduleImplementation({
+    taskId: input.taskId,
+    cwd: input.cwd,
+    reason: 'autonomous',
+  });
+  return success('approved_plan');
+}
+
+export function continueAutonomousTaskAfterImplementation(
+  input: TaskAutonomousContinuationInput,
+): Result<AutonomousContinuationAction> {
+  const snapshotRes = readRequiredSnapshot(input.taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  const snapshot = snapshotRes.data;
+  if (!isAutonomous(snapshot)) return success('skipped');
+
+  if (snapshot.task.status === TASK_STATUS.PLANNING_APPROVED) {
+    return continueAfterImplementationSteps(input, snapshot);
+  }
+  if (snapshot.task.status === TASK_STATUS.IMPLEMENTED) {
+    return continueAfterImplemented(input, snapshot);
+  }
+  return success('skipped');
+}
+
+function continueAfterImplementationSteps(
+  input: TaskAutonomousContinuationInput,
+  snapshot: TaskPlanningSnapshot,
+): Result<AutonomousContinuationAction> {
+  const approvedPlan = snapshot.plans.find(
+    (plan) =>
+      plan.planId === snapshot.thread.approvedPlanId &&
+      plan.status === PLAN_STATUS.APPROVED,
+  );
+  if (!approvedPlan) return success('skipped');
+  if (!findImplementationStepsArtifact(snapshot, approvedPlan)) {
+    return success('skipped');
+  }
+  if (areImplementationStepsApproved(snapshot, approvedPlan)) {
+    return success('skipped');
+  }
+  if (!input.scheduleImplementation) {
+    return failure('Implementation 调度器未启用，无法自动推进');
+  }
+
+  const approveRes = approveTaskImplementationSteps(input.taskId);
+  if (!approveRes.success) return approveRes;
+  input.scheduleImplementation({
+    taskId: input.taskId,
+    cwd: input.cwd,
+    reason: 'autonomous',
+  });
+  return success('approved_implementation_steps');
+}
+
+function continueAfterImplemented(
+  input: TaskAutonomousContinuationInput,
+  snapshot: TaskPlanningSnapshot,
+): Result<AutonomousContinuationAction> {
+  if (snapshot.task.prUrl || snapshot.task.commitShas.length === 0) {
+    return success('skipped');
+  }
+  if (!input.scheduleDelivery) {
+    return failure('Delivery 调度器未启用，无法自动推进');
+  }
+  input.scheduleDelivery({
+    taskId: input.taskId,
+    cwd: input.cwd,
+    reason: 'autonomous',
+  });
+  return success('scheduled_delivery');
+}


### PR DESCRIPTION
along-task: #14

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/api.ts`
- `packages/along-web/src/task-planning/useTaskPlanningActions.ts`
- `packages/along-web/src/types-task.ts`
- `packages/along/src/commands/webhook-server.ts`
- `packages/along/src/core/db-schema.ts`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api-scheduling.test.ts`
- `packages/along/src/integration/task-api-utils.ts`
- `packages/along/src/integration/task-api.test-utils.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-api.ts`
- `packages/along/src/integration/task-autonomous-continuation.test.ts`
- `packages/along/src/integration/task-autonomous-continuation.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-14`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立，当前 web task 的计划确认、实施步骤确认、开始实现、提交 PR 都依赖人工点击；对低风险简单任务交互成本过高。该能力值得做，但必须以显式“执行模式”选择为边界，避免默认跳过人工确认造成错误实现或误发 PR。完全自主模式的目标是自动推进到 PR 创建完成，仍保留失败停机、错误可见和人工接管能力，不自动验收完成任务。

Summary
在新增 Task 时增加执行模式：manual（人工确认，维持现有行为）与 autonomous（完全自主执行）。autonomous 模式下，Planner 产出正式 plan 后由系统自动批准；Implementation 产出实施步骤后由系统自动确认并继续编码；实现完成后自动进入 Delivery 创建 PR。任一阶段失败、缺少正式计划、计划被 Planner 判定为信息不足、实现未生成 commit、delivery 创建 PR 失败或调度器不可用时，流程停止在当前阶段并沿用现有失败记录与人工接管入口。

```mermaid
flowchart TD
  A[Web 新建 Task] --> B{executionMode}
  B -->|manual| C[现有流程：Planner 后等待人工批准]
  B -->|autonomous| D[保存 Task executionMode=autonomous]
  D --> E[调度 Planner]
  E --> F{Planner 输出}
  F -->|planning_update/失败| G[停止并展示阻塞原因]
  F -->|plan_revision| H[系统自动批准 Plan]
  H --> I[调度 Implementation]
  I --> J{Implementation 结果}
  J -->|仅产出实施步骤| K[系统自动确认实施步骤]
  K --> I
  J -->|实现完成并有 commit| L[调度 Delivery]
  J -->|失败| G
  L --> M{Delivery 结果}
  M -->|PR 已创建| N[Task 状态 delivered，等待人工验收]
  M -->|失败| G
```

Implementation Changes
1. 数据模型：为 task_items 增加 execution_mode 字段，取值 manual/autonomous，默认 manual；在 TaskItemRecord、CreatePlanningTaskInput、snapshot 映射、schema migration 中补齐该字段。不要复用现有 type 字段，type 继续表示 conventional commit 类型。
2. Task API：POST /api/tasks 接收 executionMode；只允许 manual/autonomous，非法值返回 400。创建任务时持久化该模式，并在返回 snapshot 中暴露。现有未传字段请求按 manual 处理。
3. Web 新建任务：在 NewTaskComposer 增加模式选择控件，默认 manual；选择 autonomous 时创建 payload 带 executionMode=autonomous。任务元信息展示当前 executionMode，便于审计和排查。
4. 自动推进编排：在 webhook-server 的 Task agent 队列层新增统一的 autonomous continuation 逻辑，而不是让前端连续调用多个接口。Planner 成功后读取最新 snapshot；若 task.executionMode=autonomous 且存在 active plan、无 openRound、线程未批准，则调用 approveCurrentTaskPlan 并调度 implementation。Implementation 成功后读取最新 snapshot；若仍为 planning_approved 且存在未确认实施步骤，则调用 approveTaskImplementationSteps 并再次调度 implementation；若状态为 implemented，则调度 delivery。Delivery 成功创建 PR 后停止，保持 delivered 状态等待人工验收。
5. 失败处理：自动推进只在前一阶段明确成功且状态满足契约时进入下一阶段；任何 Result failure、缺少调度器、状态不匹配、Planner 输出 planning_update、open feedback round、Implementation 未完成或 Delivery 失败都不重试、不绕过，记录现有 agent run/error，并让 UI 继续显示失败阶段的继续执行、复制接管命令和人工已处理能力。
6. 并发与幂等：沿用 withTaskPlanningLock 串行化同一 task 的 planning/implementation/delivery，避免自动链路与用户手动点击并发。自动推进前必须重新读取 snapshot 并检查目标阶段是否已运行或已完成，防止轮询/重复调度导致重复 implementation 或重复 PR。
7. UI 行为：manual 模式的按钮、文案和状态流不变；autonomous 模式下仍可展示各阶段进度，但不需要用户点击批准计划、确认实施步骤、开始实现或提交并创建 PR。失败后仍显示人工接管动作，不自动隐藏。

Contracts / Interfaces
- executionMode: 'manual' | 'autonomous'。
- POST /api/tasks payload 增加可选字段 executionMode。
- TaskPlanningSnapshot.task 增加 executionMode，旧数据读取为 manual。
- autonomous 只跳过确认动作，不跳过 Planner、Implementation、Auto Commit、Delivery 的既有质量与状态检查。
- autonomous 的终点是 delivered/PR 已创建，不自动调用 accept_delivery/complete。

Test Plan
1. domain/db 测试：创建 Task 时默认 executionMode=manual；传 autonomous 后 snapshot 正确返回；旧表 migration 后旧任务按 manual 读取。
2. API 测试：POST /api/tasks 接受 manual/autonomous，拒绝非法 executionMode；createPlanningTask 收到正确字段；现有请求不传字段仍兼容。
3. 调度测试：autonomous 下 Planner 输出 plan_revision 后自动批准并调度 implementation；Planner 输出 planning_update 或 openRound 时不批准、不实现。
4. 实施链路测试：autonomous 下首次 implementation 仅产出步骤时自动确认并二次调度；实现完成后自动调度 delivery；implementation failure 时不进入 delivery。
5. Delivery 测试：implemented 状态自动提交 PR；delivery failure 时状态回到 implemented 并保留失败记录；已存在 prUrl 时不重复创建 PR。
6. Web 测试：新增任务表单可选择执行模式，payload 正确；任务详情展示执行模式；manual 模式现有交互快照测试不回退。
7. 质量验证：运行 bun --filter @ranwawa/along test，并运行 along-web 的相关测试或 build，最后运行 quality:changed。

Assumptions
- “完全自主执行”表示用户显式选择后自动推进到 PR 创建完成，不包含自动验收/关闭任务。
- 该能力只覆盖 web task 新建入口；CLI/GitHub Issue 既有流程不默认开启 autonomous。
- 不新增向下兼容开关，旧任务和未传 executionMode 的请求统一视为 manual。

## 交付信息
- Commit: c4485b6013bebcee85b0c7fb15db6b44ba3e190f