### PR TITLE
Task #15: 任务列表展示优化

### DIFF
--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -1,0 +1,130 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { TaskPlanningSnapshot } from '../types';
+import { TaskListPanel } from './TaskSidebar';
+
+function makeTask(
+  overrides: Partial<TaskPlanningSnapshot['task']> = {},
+): TaskPlanningSnapshot['task'] {
+  return {
+    taskId: 'task-1',
+    title: '优化左侧任务列表展示',
+    body: '这段任务正文不应该出现在左侧列表。',
+    source: 'test',
+    status: 'implementing',
+    commitShas: [],
+    seq: 12,
+    executionMode: 'manual',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: 'custom-updated-at',
+    ...overrides,
+  };
+}
+
+function makeThread(): TaskPlanningSnapshot['thread'] {
+  return {
+    threadId: 'thread-1',
+    taskId: 'task-1',
+    purpose: 'planning',
+    status: 'approved',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<TaskPlanningSnapshot> = {},
+): TaskPlanningSnapshot {
+  return {
+    task: makeTask(),
+    thread: makeThread(),
+    currentPlan: null,
+    openRound: null,
+    artifacts: [],
+    plans: [],
+    agentRuns: [],
+    agentProgressEvents: [],
+    agentSessionEvents: [],
+    agentStages: [
+      {
+        stage: 'implementation',
+        agentId: 'implementer',
+        label: '实现',
+        status: 'failed',
+        latestRun: {
+          runId: 'run-1',
+          taskId: 'task-1',
+          threadId: 'thread-1',
+          agentId: 'implementer',
+          provider: 'codex',
+          status: 'failed',
+          inputArtifactIds: [],
+          outputArtifactIds: [],
+          error: '命令退出码 1',
+          startedAt: '2026-01-01T00:01:00.000Z',
+          endedAt: '2026-01-01T00:02:00.000Z',
+        },
+      },
+    ],
+    flow: {
+      currentStageId: 'implementation',
+      conclusion: '实现阶段失败。',
+      severity: 'blocked',
+      stages: [],
+      actions: [],
+      blockers: [],
+      events: [],
+    },
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  overrides: Partial<Parameters<typeof TaskListPanel>[0]> = {},
+): string {
+  return renderToStaticMarkup(
+    <TaskListPanel
+      tasks={[makeSnapshot()]}
+      loading={false}
+      selectedTaskId={undefined}
+      isNewTaskOpen={false}
+      onNewTask={() => undefined}
+      onSelect={() => undefined}
+      {...overrides}
+    />,
+  );
+}
+
+describe('TaskListPanel', () => {
+  it('任务项只展示序号、标题和状态', () => {
+    const html = renderPanel();
+
+    expect(html).toContain('#12');
+    expect(html).toContain('优化左侧任务列表展示');
+    expect(html).toContain('实现中');
+    expect(html).not.toContain('custom-updated-at');
+    expect(html).not.toContain('这段任务正文不应该出现在左侧列表');
+    expect(html).not.toContain('命令退出码 1');
+    expect(html).not.toContain('实现失败');
+  });
+
+  it('序号缺失时不补造占位内容', () => {
+    const html = renderPanel({
+      tasks: [makeSnapshot({ task: makeTask({ seq: undefined }) })],
+    });
+
+    expect(html).toContain('优化左侧任务列表展示');
+    expect(html).not.toContain('#');
+  });
+
+  it('保留选中态、新任务入口、加载态和空态', () => {
+    const selectedHtml = renderPanel({ selectedTaskId: 'task-1' });
+    const loadingHtml = renderPanel({ tasks: [], loading: true });
+    const emptyHtml = renderPanel({ tasks: [] });
+
+    expect(selectedHtml).toContain('bg-white/10');
+    expect(selectedHtml).toContain('新任务');
+    expect(loadingHtml).toContain('加载中...');
+    expect(emptyHtml).toContain('暂无任务。');
+  });
+});

--- a/packages/along-web/src/task-planning/TaskSidebar.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.tsx
@@ -1,6 +1,5 @@
 import type { TaskPlanningSnapshot } from '../types';
 import type { DraftTaskInput, RepositoryOption } from './api';
-import { formatTime, getLatestFailedStage } from './format';
 import { TaskStatusBadge } from './TaskStatusBadge';
 
 export function RepositorySelector({
@@ -97,33 +96,19 @@ export function TaskListPanel({
         ) : tasks.length === 0 ? (
           <div className="p-5 text-text-muted text-sm">暂无任务。</div>
         ) : (
-          tasks.map((snapshot) => {
-            const failedStage = getLatestFailedStage(snapshot);
-            return (
-              <button
-                type="button"
-                key={snapshot.task.taskId}
-                onClick={() => onSelect(snapshot)}
-                className={`w-full text-left px-4 md:px-5 py-4 border-b border-white/5 hover:bg-white/5 transition-colors ${
-                  selectedTaskId === snapshot.task.taskId
-                    ? 'bg-white/10'
-                    : 'bg-transparent'
-                }`}
-              >
-                <div className="flex items-center justify-between gap-3 mb-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <TaskStatusBadge snapshot={snapshot} />
-                    {failedStage && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border bg-rose-500/15 text-rose-300 border-rose-500/30">
-                        {failedStage.label}失败
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-[11px] text-text-muted shrink-0">
-                    {formatTime(snapshot.task.updatedAt)}
-                  </span>
-                </div>
-                <div className="font-medium text-sm truncate">
+          tasks.map((snapshot) => (
+            <button
+              type="button"
+              key={snapshot.task.taskId}
+              onClick={() => onSelect(snapshot)}
+              className={`w-full text-left px-4 md:px-5 py-2.5 border-b border-white/5 hover:bg-white/5 transition-colors ${
+                selectedTaskId === snapshot.task.taskId
+                  ? 'bg-white/10'
+                  : 'bg-transparent'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3 min-w-0">
+                <div className="min-w-0 flex-1 font-medium text-sm truncate">
                   {snapshot.task.seq != null && (
                     <span className="text-text-muted mr-1">
                       #{snapshot.task.seq}
@@ -131,12 +116,12 @@ export function TaskListPanel({
                   )}
                   {snapshot.task.title}
                 </div>
-                <div className="text-xs text-text-muted truncate mt-1">
-                  {failedStage?.latestRun?.error || snapshot.task.body}
+                <div className="shrink-0 whitespace-nowrap">
+                  <TaskStatusBadge snapshot={snapshot} />
                 </div>
-              </button>
-            );
-          })
+              </div>
+            </button>
+          ))
         )}
       </div>
     </>


### PR DESCRIPTION
along-task: #15

## 修改内容
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/TaskSidebar.tsx`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-15`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
左侧任务列表当前每个任务项展示了状态、失败阶段、更新时间、序号、标题和正文或错误摘要，占用多行。用户目标是提高列表信息密度，让一屏看到更多任务；该需求成立，且属于纯前端展示优化，不需要调整任务数据模型、接口或状态流转。

Summary
将 along web 左侧任务列表的任务项改为单行布局，只保留序号、标题、任务状态。移除任务项中的更新时间、正文摘要、错误摘要和失败阶段标签。点击选择任务、选中高亮、加载态、空态和新任务入口保持不变。

Implementation Changes
1. 调整 packages/along-web/src/task-planning/TaskSidebar.tsx 中 TaskListPanel 的任务项结构：每个任务按钮内部只渲染一行横向内容，左侧为序号和标题，右侧为 TaskStatusBadge。
2. 序号沿用 snapshot.task.seq；有序号时显示为 #序号，序号缺失时不补造占位内容，避免展示错误编号。
3. 标题保持单行 truncate，长标题省略，不能挤压状态徽标；状态徽标保持不换行并固定在行尾。
4. 移除该列表项对 formatTime 和 getLatestFailedStage 的展示依赖；如果删除后不再使用，对应 import 一并清理。
5. 不改动右侧任务详情、任务流、Agent 阶段和记录展示；失败阶段、错误详情、正文等信息仍通过详情区域查看。

Contracts / Interfaces
组件入参不变：TaskListPanel 仍接收 tasks、loading、selectedTaskId、isNewTaskOpen、onNewTask、onSelect。后端 API、TaskPlanningSnapshot 类型、任务状态枚举和持久化数据均不变。本次只改变左侧列表的展示契约：列表项只承担快速识别和选择任务，不再承载摘要信息。

Test Plan
1. 为 TaskListPanel 增加或补充渲染测试，覆盖任务项展示序号、标题和状态。
2. 测试同一任务项不再渲染更新时间、任务正文、错误摘要和失败阶段标签。
3. 覆盖选中任务仍有选中样式，新任务按钮、加载态和空态不受影响。
4. 执行 along-web 的 lint 和 build，确认 TypeScript、Biome 和 Vite 构建通过。

Assumptions
本需求只针对 along web 任务规划页左侧任务列表，不影响其他页面的任务列表或右侧详情信息。无需兼容旧的多行列表样式；如仍需要快速查看失败原因，应通过选中任务进入详情区查看。

## 交付信息
- Commit: 10d1ddcd25efdab11b66374f60902ad112e2e614