### PR TITLE
Task #16: 任务列表按序号降序排列

### DIFF
--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -117,6 +117,30 @@ describe('TaskListPanel', () => {
     expect(html).not.toContain('#');
   });
 
+  it('按照传入的任务顺序渲染列表，最新序号显示在最上方', () => {
+    const html = renderPanel({
+      tasks: [
+        makeSnapshot({
+          task: makeTask({
+            taskId: 'task-20',
+            title: '最新任务',
+            seq: 20,
+          }),
+        }),
+        makeSnapshot({
+          task: makeTask({
+            taskId: 'task-8',
+            title: '较早任务',
+            seq: 8,
+          }),
+        }),
+      ],
+    });
+
+    expect(html.indexOf('#20')).toBeLessThan(html.indexOf('#8'));
+    expect(html.indexOf('最新任务')).toBeLessThan(html.indexOf('较早任务'));
+  });
+
   it('保留选中态、新任务入口、加载态和空态', () => {
     const selectedHtml = renderPanel({ selectedTaskId: 'task-1' });
     const loadingHtml = renderPanel({ tasks: [], loading: true });

--- a/packages/along-web/src/task-planning/api.test.ts
+++ b/packages/along-web/src/task-planning/api.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskPlanningSnapshot, TaskStatus } from '../types';
+import { mergeSnapshotIntoList, sortTaskSnapshotsBySeqDesc } from './api';
+
+function makeSnapshot(
+  taskId: string,
+  seq: number | undefined,
+  overrides: Partial<TaskPlanningSnapshot['task']> = {},
+): TaskPlanningSnapshot {
+  return {
+    task: {
+      taskId,
+      title: taskId,
+      body: '',
+      source: 'test',
+      status: 'planning',
+      commitShas: [],
+      seq,
+      executionMode: 'manual',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    },
+    thread: {
+      threadId: `${taskId}-thread`,
+      taskId,
+      purpose: 'planning',
+      status: 'drafting',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    currentPlan: null,
+    openRound: null,
+    artifacts: [],
+    plans: [],
+    agentRuns: [],
+    agentProgressEvents: [],
+    agentSessionEvents: [],
+    agentStages: [],
+    flow: {
+      currentStageId: 'requirements',
+      conclusion: '',
+      severity: 'normal',
+      stages: [],
+      actions: [],
+      blockers: [],
+      events: [],
+    },
+  };
+}
+
+function taskIds(snapshots: TaskPlanningSnapshot[]): string[] {
+  return snapshots.map((snapshot) => snapshot.task.taskId);
+}
+
+describe('sortTaskSnapshotsBySeqDesc', () => {
+  it('按任务序号降序排列', () => {
+    const snapshots = [
+      makeSnapshot('task-2', 2),
+      makeSnapshot('task-9', 9),
+      makeSnapshot('task-5', 5),
+    ];
+
+    expect(taskIds(sortTaskSnapshotsBySeqDesc(snapshots))).toEqual([
+      'task-9',
+      'task-5',
+      'task-2',
+    ]);
+  });
+
+  it('状态和更新时间变化不影响序号排序', () => {
+    const snapshots = [
+      makeSnapshot('completed-newer-update', 3, {
+        status: 'completed' satisfies TaskStatus,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+      }),
+      makeSnapshot('planning-older-update', 8, {
+        status: 'planning' satisfies TaskStatus,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }),
+      makeSnapshot('implementing-middle-update', 5, {
+        status: 'implementing' satisfies TaskStatus,
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    ];
+
+    expect(taskIds(sortTaskSnapshotsBySeqDesc(snapshots))).toEqual([
+      'planning-older-update',
+      'implementing-middle-update',
+      'completed-newer-update',
+    ]);
+  });
+
+  it('缺失或不可解析序号排在底部并保持兜底顺序', () => {
+    const snapshots = [
+      makeSnapshot('missing-seq', undefined),
+      makeSnapshot('valid-seq', 4),
+      makeSnapshot('nan-seq', Number.NaN),
+      makeSnapshot('same-seq-first', 2),
+      makeSnapshot('same-seq-second', 2),
+    ];
+
+    expect(taskIds(sortTaskSnapshotsBySeqDesc(snapshots))).toEqual([
+      'valid-seq',
+      'same-seq-first',
+      'same-seq-second',
+      'missing-seq',
+      'nan-seq',
+    ]);
+  });
+
+  it('支持空列表和单任务列表', () => {
+    const snapshot = makeSnapshot('task-1', 1);
+
+    expect(sortTaskSnapshotsBySeqDesc([])).toEqual([]);
+    expect(sortTaskSnapshotsBySeqDesc([snapshot])).toEqual([snapshot]);
+  });
+});
+
+describe('mergeSnapshotIntoList', () => {
+  it('刷新同一批任务状态后保持按序号降序的相对顺序', () => {
+    const previous = [
+      makeSnapshot('task-9', 9, { status: 'planning' }),
+      makeSnapshot('task-5', 5, { status: 'implementing' }),
+      makeSnapshot('task-2', 2, { status: 'completed' }),
+    ];
+
+    const next = mergeSnapshotIntoList(
+      previous,
+      makeSnapshot('task-5', 5, {
+        status: 'completed',
+        updatedAt: '2026-01-05T00:00:00.000Z',
+      }),
+    );
+
+    expect(taskIds(next)).toEqual(['task-9', 'task-5', 'task-2']);
+  });
+});

--- a/packages/along-web/src/task-planning/api.ts
+++ b/packages/along-web/src/task-planning/api.ts
@@ -71,16 +71,54 @@ export const emptyDraft: DraftTaskInput = {
   executionMode: 'manual',
 };
 
+function parseTaskSeq(snapshot: TaskPlanningSnapshot): number | null {
+  const seq: unknown = snapshot.task.seq;
+  if (typeof seq === 'number') {
+    return Number.isFinite(seq) ? seq : null;
+  }
+  if (typeof seq === 'string') {
+    const trimmed = seq.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function sortTaskSnapshotsBySeqDesc(
+  snapshots: TaskPlanningSnapshot[],
+): TaskPlanningSnapshot[] {
+  return snapshots
+    .map((snapshot, index) => ({
+      index,
+      seq: parseTaskSeq(snapshot),
+      snapshot,
+    }))
+    .sort((left, right) => {
+      if (left.seq != null && right.seq != null) {
+        const seqDiff = right.seq - left.seq;
+        return seqDiff === 0 ? left.index - right.index : seqDiff;
+      }
+      if (left.seq != null) return -1;
+      if (right.seq != null) return 1;
+      return left.index - right.index;
+    })
+    .map((entry) => entry.snapshot);
+}
+
 export function mergeSnapshotIntoList(
   previous: TaskPlanningSnapshot[],
   snapshot: TaskPlanningSnapshot,
 ): TaskPlanningSnapshot[] {
-  const next = previous.filter(
-    (item) => item.task.taskId !== snapshot.task.taskId,
+  const existingIndex = previous.findIndex(
+    (item) => item.task.taskId === snapshot.task.taskId,
   );
-  return [snapshot, ...next].sort((left, right) =>
-    right.task.updatedAt.localeCompare(left.task.updatedAt),
-  );
+  if (existingIndex >= 0) {
+    const next = [...previous];
+    next[existingIndex] = snapshot;
+    return sortTaskSnapshotsBySeqDesc(next);
+  }
+  return sortTaskSnapshotsBySeqDesc([...previous, snapshot]);
 }
 
 function isTaskApiError(value: unknown): value is TaskApiError {

--- a/packages/along-web/src/task-planning/useTaskPlanningState.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningState.ts
@@ -14,6 +14,7 @@ import {
   type RepositoryListResponse,
   type RepositoryOption,
   readJsonResponse,
+  sortTaskSnapshotsBySeqDesc,
 } from './api';
 
 function getErrorMessage(err: unknown): string {
@@ -127,8 +128,9 @@ async function loadTasksForState(input: TaskLoaderInput) {
   });
   const response = await fetch(`/api/tasks?${params.toString()}`);
   const snapshots = await readJsonResponse<TaskPlanningSnapshot[]>(response);
-  input.setTasks(snapshots);
-  updateSelectedTaskAfterLoad(input, snapshots);
+  const sortedSnapshots = sortTaskSnapshotsBySeqDesc(snapshots);
+  input.setTasks(sortedSnapshots);
+  updateSelectedTaskAfterLoad(input, sortedSnapshots);
 }
 
 function updateSelectedTaskAfterLoad(


### PR DESCRIPTION
along-task: #16

## 修改内容
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/api.test.ts`
- `packages/along-web/src/task-planning/api.ts`
- `packages/along-web/src/task-planning/useTaskPlanningState.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `fix/task-16`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
问题成立。左侧任务列表的稳定排序应由任务自身的创建序号决定，而不是由状态、更新时间、分组遍历顺序或接口返回的偶然顺序决定。当前需求的工程收益明确：最近创建的任务固定显示在顶部，任务状态变化后不应改变其在列表中的相对位置。

Summary
将 Web 端左侧任务列表的默认排序契约调整为“任务序号降序”。序号越大的任务越靠前；状态变更、反馈轮次变化、计划更新、任务内容编辑等非创建序号变化，不得影响列表顺序。

Implementation Changes
1. 在 Web 端左侧任务列表的数据整理层统一排序，不把排序分散到渲染组件、状态筛选组件或单个状态分组内。
2. 排序主键使用任务的业务序号字段；若当前模型中已有用于展示的任务序号，应复用该字段。排序方向固定为降序。
3. 如果列表当前会按状态分组、状态优先级、更新时间或接口返回顺序展示，需要移除这些因素对主列表顺序的影响。状态仍可作为展示标签、筛选条件或视觉状态，但不能作为默认排序键。
4. 对缺失序号或序号不可解析的异常任务，放在列表底部，并保持稳定的兜底顺序，避免渲染抖动或运行时异常。
5. 排序逻辑应在任务集合进入左侧列表视图前完成，保证搜索、筛选、状态刷新、轮询或局部更新后都复用同一排序结果。
6. 不主动设计旧排序兼容开关；本次变更直接调整默认行为。若后续需要多种排序模式，应另开任务设计显式排序控件。

Contracts / Interfaces
1. 左侧任务列表默认顺序：按任务业务序号降序排列。
2. 状态变化不得改变任务在默认列表中的相对顺序，除非任务序号本身变化。
3. 新创建任务获得更大的序号后，应自然出现在列表顶部。
4. 异常数据处理：无序号任务不阻断列表渲染，排在有序号任务之后。

Test Plan
1. 增加或更新排序逻辑单元测试：输入不同状态、不同更新时间、不同序号的任务集合，断言输出按序号降序。
2. 增加状态变更场景测试：同一批任务仅状态变化后，列表顺序保持不变。
3. 增加异常数据测试：缺失序号、空列表、单任务列表均能正常渲染。
4. 如项目已有 Web 组件测试，覆盖左侧任务列表渲染顺序，确认最新序号任务显示在最上方。
5. 执行项目现有的 lint、typecheck 和相关 test 脚本；若无法执行，实施结果中必须说明原因和剩余风险。

Assumptions
1. “序号”指任务创建时生成并用于表达新旧关系的业务序号，而不是任务状态序号、数组下标或更新时间。
2. 本次只调整 Web 左侧任务列表默认排序，不改变任务创建、状态流转、后端存储结构或其他页面的排序规则。

## 交付信息
- Commit: 7662f139ac260989f3949667b99ea087b4210014