### PR TITLE
Task #21: 添加关闭功能解决卡住任务

### DIFF
--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -108,6 +108,15 @@ describe('TaskListPanel', () => {
     expect(html).not.toContain('实现失败');
   });
 
+  it('已关闭任务显示独立状态', () => {
+    const html = renderPanel({
+      tasks: [makeSnapshot({ task: makeTask({ status: 'closed' }) })],
+    });
+
+    expect(html).toContain('已关闭');
+    expect(html).toContain('zinc');
+  });
+
   it('序号缺失时不补造占位内容', () => {
     const html = renderPanel({
       tasks: [makeSnapshot({ task: makeTask({ seq: undefined }) })],

--- a/packages/along-web/src/task-planning/actionTypes.ts
+++ b/packages/along-web/src/task-planning/actionTypes.ts
@@ -1,6 +1,7 @@
 import type { TaskPlanningSnapshot } from '../types';
 import type {
   ApproveTaskPlanResponse,
+  CloseTaskResponse,
   CompleteTaskResponse,
   DeliveryRunResponse,
   DraftTaskInput,
@@ -14,7 +15,8 @@ export type SimpleActionResponse =
   | PlannerRunResponse
   | ImplementationRunResponse
   | DeliveryRunResponse
-  | CompleteTaskResponse;
+  | CompleteTaskResponse
+  | CloseTaskResponse;
 
 export interface UseTaskPlanningActionsInput {
   selected: TaskPlanningSnapshot | null;

--- a/packages/along-web/src/task-planning/api.ts
+++ b/packages/along-web/src/task-planning/api.ts
@@ -42,6 +42,11 @@ export interface CompleteTaskResponse {
   snapshot: TaskPlanningSnapshot;
 }
 
+export interface CloseTaskResponse {
+  taskId: string;
+  snapshot: TaskPlanningSnapshot;
+}
+
 export interface RepositoryOption {
   owner: string;
   repo: string;

--- a/packages/along-web/src/task-planning/flowActionRouter.test.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.test.ts
@@ -162,4 +162,24 @@ describe('flowActionRouter', () => {
       { confirmImplementationSteps: true },
     );
   });
+
+  it('当关闭任务时，期望直接调度 close API', () => {
+    const actions = makeActions();
+    const action: TaskFlowAction = {
+      id: 'close_task',
+      label: '关闭任务',
+      description: '终止当前 Task 流程',
+      enabled: true,
+      stage: 'completed',
+      variant: 'danger',
+    };
+
+    runFlowAction(action, makeInput(makeSnapshot('implementation')), actions);
+
+    expect(actions.runSimpleAction).toHaveBeenCalledWith(
+      'close_task',
+      'close',
+      true,
+    );
+  });
 });

--- a/packages/along-web/src/task-planning/flowActionRouter.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.ts
@@ -74,4 +74,7 @@ function runStageAction(
   if (id === 'accept_delivery') {
     runSimpleAction('accept_delivery', 'complete', true);
   }
+  if (id === 'close_task') {
+    runSimpleAction('close_task', 'close', true);
+  }
 }

--- a/packages/along-web/src/task-planning/format.ts
+++ b/packages/along-web/src/task-planning/format.ts
@@ -66,6 +66,8 @@ export function getTaskStatusLabel(status: TaskStatus): string {
       return '已交付';
     case 'completed':
       return '已完成';
+    case 'closed':
+      return '已关闭';
     default:
       return status;
   }
@@ -87,6 +89,8 @@ export function getTaskStatusClass(status: TaskStatus): string {
       return 'bg-teal-500/15 text-teal-300 border-teal-500/30';
     case 'completed':
       return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
+    case 'closed':
+      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
     default:
       return 'bg-white/10 text-text-secondary border-border-color';
   }
@@ -102,6 +106,8 @@ export function getStageStatusLabel(status: TaskAgentStageStatus): string {
       return '已完成';
     case 'failed':
       return '失败';
+    case 'cancelled':
+      return '已取消';
     default:
       return status;
   }
@@ -115,6 +121,8 @@ export function getStageStatusClass(status: TaskAgentStageStatus): string {
       return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
     case 'failed':
       return 'bg-rose-500/15 text-rose-300 border-rose-500/30';
+    case 'cancelled':
+      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
     default:
       return 'bg-white/5 text-text-muted border-border-color';
   }
@@ -193,6 +201,8 @@ export function getArtifactLabel(type: TaskArtifactType): string {
       return '批准';
     case 'agent_result':
       return 'Agent';
+    case 'task_closed':
+      return '关闭';
     default:
       return type;
   }
@@ -210,6 +220,8 @@ export function getArtifactClass(type: TaskArtifactType): string {
       return 'border-emerald-500/25 bg-emerald-500/15';
     case 'agent_result':
       return 'border-white/10 bg-white/5';
+    case 'task_closed':
+      return 'border-zinc-500/25 bg-zinc-500/10';
     default:
       return 'border-border-color bg-white/5';
   }

--- a/packages/along-web/src/types-task.ts
+++ b/packages/along-web/src/types-task.ts
@@ -5,7 +5,8 @@ export type TaskStatus =
   | 'implemented'
   | 'delivering'
   | 'delivered'
-  | 'completed';
+  | 'completed'
+  | 'closed';
 
 export type TaskExecutionMode = 'manual' | 'autonomous';
 
@@ -20,7 +21,8 @@ export type TaskArtifactType =
   | 'plan_revision'
   | 'planning_update'
   | 'approval'
-  | 'agent_result';
+  | 'agent_result'
+  | 'task_closed';
 
 export interface TaskItemRecord {
   taskId: string;
@@ -92,7 +94,11 @@ export interface TaskFeedbackRoundRecord {
   resolvedAt?: string;
 }
 
-export type TaskAgentRunStatus = 'running' | 'succeeded' | 'failed';
+export type TaskAgentRunStatus =
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled';
 
 export type TaskAgentProgressPhase =
   | 'starting'
@@ -209,7 +215,8 @@ export type TaskFlowActionId =
   | 'manual_complete'
   | 'start_delivery'
   | 'accept_delivery'
-  | 'request_changes';
+  | 'request_changes'
+  | 'close_task';
 
 export type TaskFlowEventType =
   | 'task_created'
@@ -221,8 +228,10 @@ export type TaskFlowEventType =
   | 'agent_run_started'
   | 'agent_run_succeeded'
   | 'agent_run_failed'
+  | 'agent_run_cancelled'
   | 'delivery_updated'
-  | 'task_completed';
+  | 'task_completed'
+  | 'task_closed';
 
 export interface TaskFlowAction {
   id: TaskFlowActionId;

--- a/packages/along/src/domain/task-claude-runner.test.ts
+++ b/packages/along/src/domain/task-claude-runner.test.ts
@@ -21,6 +21,7 @@ vi.mock('./task-planning', () => ({
     RUNNING: 'running',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
+    CANCELLED: 'cancelled',
   },
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,

--- a/packages/along/src/domain/task-codex-runner.test.ts
+++ b/packages/along/src/domain/task-codex-runner.test.ts
@@ -17,6 +17,7 @@ vi.mock('./task-planning', () => ({
     RUNNING: 'running',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
+    CANCELLED: 'cancelled',
   },
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,

--- a/packages/along/src/domain/task-delivery.test.ts
+++ b/packages/along/src/domain/task-delivery.test.ts
@@ -16,6 +16,7 @@ vi.mock('./task-planning', () => ({
     RUNNING: 'running',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
+    CANCELLED: 'cancelled',
   },
   TASK_STATUS: {
     IMPLEMENTED: 'implemented',

--- a/packages/along/src/domain/task-delivery.ts
+++ b/packages/along/src/domain/task-delivery.ts
@@ -167,6 +167,9 @@ export async function runTaskDelivery(
     });
   }
 
+  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+    return failure('Task 已关闭，不能交付');
+  }
   if (snapshot.task.status !== TASK_STATUS.IMPLEMENTED) {
     return failure(`当前 Task 状态不能交付: ${snapshot.task.status}`);
   }

--- a/packages/along/src/domain/task-implementation-agent.ts
+++ b/packages/along/src/domain/task-implementation-agent.ts
@@ -150,6 +150,9 @@ function readApprovedImplementationContext(
   if (!snapshotRes.success) return failure(snapshotRes.error);
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+    return failure('Task 已关闭，不能开始实现');
+  }
 
   const approvedPlan = findApprovedPlan(snapshot);
   if (!approvedPlan) return failure('当前 Task 没有已批准方案，不能开始实现');

--- a/packages/along/src/domain/task-planning-agent.test.ts
+++ b/packages/along/src/domain/task-planning-agent.test.ts
@@ -8,6 +8,9 @@ const planningMocks = vi.hoisted(() => ({
 const runnerMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./task-planning', () => ({
+  TASK_STATUS: {
+    CLOSED: 'closed',
+  },
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
   publishTaskPlanRevision: planningMocks.publishTaskPlanRevision,
   publishPlanningUpdate: planningMocks.publishPlanningUpdate,

--- a/packages/along/src/domain/task-planning-agent.ts
+++ b/packages/along/src/domain/task-planning-agent.ts
@@ -15,6 +15,7 @@ import {
   publishPlanningUpdate,
   publishTaskPlanRevision,
   readTaskPlanningSnapshot,
+  TASK_STATUS,
   type TaskPlanningSnapshot,
 } from './task-planning';
 
@@ -148,6 +149,9 @@ export async function runTaskPlanningAgent(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
+  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+    return failure('Task 已关闭，不能运行 Planner');
+  }
 
   const agentId = input.agentId || 'planner';
   const result = await runPlannerAgentTurn({

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -315,6 +315,19 @@ const mockDbState = vi.hoisted(() => {
           return { changes: row ? 1 : 0 };
         }
 
+        if (
+          normalized ===
+          'UPDATE task_threads SET open_round_id = NULL, updated_at = ? WHERE thread_id = ?'
+        ) {
+          const [updatedAt, threadId] = args;
+          const row = findThread(String(threadId));
+          if (row) {
+            row.open_round_id = null;
+            row.updated_at = updatedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
         if (normalized.startsWith('INSERT INTO task_feedback_rounds')) {
           const [
             roundId,
@@ -466,6 +479,19 @@ const mockDbState = vi.hoisted(() => {
           if (row) {
             row.status = status;
             row.resolution = resolution;
+            row.resolved_at = resolvedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
+          normalized ===
+          'UPDATE task_feedback_rounds SET status = ?, resolved_at = ? WHERE round_id = ?'
+        ) {
+          const [status, resolvedAt, roundId] = args;
+          const row = state.rounds.find((item) => item.round_id === roundId);
+          if (row) {
+            row.status = status;
             row.resolved_at = resolvedAt;
           }
           return { changes: row ? 1 : 0 };
@@ -628,6 +654,21 @@ const mockDbState = vi.hoisted(() => {
         }
 
         if (normalized.startsWith('UPDATE task_agent_runs SET status = ?')) {
+          if (normalized.includes('WHERE run_id = ? AND status = ?')) {
+            const [status, outputIds, error, endedAt, runId, currentStatus] =
+              args;
+            const row = state.runs.find(
+              (item) => item.run_id === runId && item.status === currentStatus,
+            );
+            if (row) {
+              row.status = status;
+              row.output_artifact_ids = outputIds;
+              row.error = error;
+              row.ended_at = endedAt;
+            }
+            return { changes: row ? 1 : 0 };
+          }
+
           const [status, endSessionId, outputIds, error, endedAt, runId] = args;
           const row = state.runs.find((item) => item.run_id === runId);
           if (row) {
@@ -719,6 +760,7 @@ vi.mock('../core/db', () => ({
 import {
   AGENT_RUN_STATUS,
   approveCurrentTaskPlan,
+  closeTask,
   completeDeliveredTask,
   createPlanningTask,
   createTaskAgentRun,
@@ -923,6 +965,131 @@ describe('task-planning', () => {
         ?.label,
     ).toBe('已完成');
     expect(completed.data.flow.conclusion).toBe('任务已完成，关键产物已归档。');
+  });
+
+  it.each([
+    TASK_STATUS.PLANNING,
+    TASK_STATUS.PLANNING_APPROVED,
+    TASK_STATUS.IMPLEMENTING,
+    TASK_STATUS.IMPLEMENTED,
+    TASK_STATUS.DELIVERING,
+    TASK_STATUS.DELIVERED,
+  ])('当 %s 状态关闭任务时，期望进入 closed 并记录关闭事件', (status) => {
+    const { taskId } = createTaskWithPlan();
+    const approve = approveCurrentTaskPlan(taskId);
+    expect(approve.success).toBe(true);
+    const statusRes = updateTaskStatus(taskId, status);
+    expect(statusRes.success).toBe(true);
+
+    const closed = closeTask(taskId, '无需继续');
+    expect(closed.success).toBe(true);
+    if (!closed.success) throw new Error(closed.error);
+
+    expect(closed.data.task.status).toBe(TASK_STATUS.CLOSED);
+    expect(closed.data.flow.currentStageId).toBe('completed');
+    expect(closed.data.flow.conclusion).toBe('任务已关闭，不再继续推进。');
+    expect(closed.data.flow.actions).toEqual([]);
+    expect(closed.data.artifacts.at(-1)).toMatchObject({
+      type: 'task_closed',
+      role: 'system',
+      metadata: expect.objectContaining({
+        previousStatus: status,
+        reason: '无需继续',
+      }),
+    });
+    expect(
+      closed.data.flow.events.find((event) => event.type === 'task_closed'),
+    ).toMatchObject({
+      title: '任务已关闭',
+      summary: expect.stringContaining(`关闭前状态：${status}`),
+    });
+  });
+
+  it('当关闭已完成任务时，期望返回冲突语义的失败结果', () => {
+    const { taskId } = createTaskWithPlan();
+    const approve = approveCurrentTaskPlan(taskId);
+    expect(approve.success).toBe(true);
+    const delivered = updateTaskStatus(taskId, TASK_STATUS.DELIVERED);
+    expect(delivered.success).toBe(true);
+    const completed = completeDeliveredTask(taskId);
+    expect(completed.success).toBe(true);
+
+    const closed = closeTask(taskId);
+    expect(closed.success).toBe(false);
+    if (closed.success) throw new Error('expected failure');
+    expect(closed.error).toBe('已完成 Task 不能关闭');
+  });
+
+  it('当重复关闭任务时，期望幂等返回当前 closed snapshot', () => {
+    const { taskId } = createTaskWithPlan();
+    const first = closeTask(taskId);
+    expect(first.success).toBe(true);
+    const second = closeTask(taskId);
+    expect(second.success).toBe(true);
+    if (!second.success) throw new Error(second.error);
+
+    expect(second.data.task.status).toBe(TASK_STATUS.CLOSED);
+    expect(
+      second.data.artifacts.filter(
+        (artifact) => artifact.type === 'task_closed',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('当关闭带开放反馈和运行中 Agent 的任务时，期望关闭反馈并取消运行', () => {
+    const { taskId } = createTaskWithPlan();
+    const feedback = submitTaskMessage({ taskId, body: '需要补充约束。' });
+    expect(feedback.success).toBe(true);
+    const snapshot = readTaskPlanningSnapshot(taskId);
+    expect(snapshot.success).toBe(true);
+    if (!snapshot.success || !snapshot.data)
+      throw new Error('missing snapshot');
+    const run = createTaskAgentRun({
+      taskId,
+      threadId: snapshot.data.thread.threadId,
+      agentId: 'planner',
+      provider: 'codex',
+    });
+    expect(run.success).toBe(true);
+
+    const closed = closeTask(taskId);
+    expect(closed.success).toBe(true);
+    if (!closed.success) throw new Error(closed.error);
+
+    expect(closed.data.openRound).toBeNull();
+    expect(closed.data.agentRuns[0].status).toBe(AGENT_RUN_STATUS.CANCELLED);
+    expect(closed.data.agentStages[0].status).not.toBe(
+      AGENT_RUN_STATUS.RUNNING,
+    );
+    expect(closed.data.flow.blockers).not.toContain(
+      '当前反馈轮次已打开，等待 Planner 处理你的补充反馈。',
+    );
+  });
+
+  it('当任务已关闭后继续推进流程时，期望拒绝且不改变 closed 状态', () => {
+    const { taskId } = createTaskWithPlan();
+    const closed = closeTask(taskId);
+    expect(closed.success).toBe(true);
+
+    expect(approveCurrentTaskPlan(taskId).success).toBe(false);
+    expect(submitTaskMessage({ taskId, body: '继续' }).success).toBe(false);
+    expect(updateTaskStatus(taskId, TASK_STATUS.IMPLEMENTED).success).toBe(
+      false,
+    );
+    expect(
+      createTaskAgentRun({
+        taskId,
+        threadId: closed.success ? closed.data.thread.threadId : 'thread',
+        agentId: 'implementer',
+        provider: 'codex',
+      }).success,
+    ).toBe(false);
+
+    const refreshed = readTaskPlanningSnapshot(taskId);
+    expect(refreshed.success).toBe(true);
+    if (!refreshed.success || !refreshed.data)
+      throw new Error('missing refreshed snapshot');
+    expect(refreshed.data.task.status).toBe(TASK_STATUS.CLOSED);
   });
 
   it('当反馈改变执行约束时，期望生成新版计划并批准新版计划', () => {

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -20,6 +20,7 @@ export const TASK_STATUS = {
   DELIVERING: 'delivering',
   DELIVERED: 'delivered',
   COMPLETED: 'completed',
+  CLOSED: 'closed',
 } as const;
 
 export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
@@ -54,6 +55,7 @@ export const ARTIFACT_TYPE = {
   PLANNING_UPDATE: 'planning_update',
   APPROVAL: 'approval',
   AGENT_RESULT: 'agent_result',
+  TASK_CLOSED: 'task_closed',
 } as const;
 
 export type ArtifactType = (typeof ARTIFACT_TYPE)[keyof typeof ARTIFACT_TYPE];
@@ -97,6 +99,7 @@ export const AGENT_RUN_STATUS = {
   RUNNING: 'running',
   SUCCEEDED: 'succeeded',
   FAILED: 'failed',
+  CANCELLED: 'cancelled',
 } as const;
 
 export type AgentRunStatus =
@@ -309,7 +312,8 @@ export type TaskFlowActionId =
   | 'manual_complete'
   | 'start_delivery'
   | 'accept_delivery'
-  | 'request_changes';
+  | 'request_changes'
+  | 'close_task';
 
 export type TaskFlowEventType =
   | 'task_created'
@@ -321,8 +325,10 @@ export type TaskFlowEventType =
   | 'agent_run_started'
   | 'agent_run_succeeded'
   | 'agent_run_failed'
+  | 'agent_run_cancelled'
   | 'delivery_updated'
-  | 'task_completed';
+  | 'task_completed'
+  | 'task_closed';
 
 export interface TaskFlowAction {
   id: TaskFlowActionId;
@@ -969,6 +975,7 @@ function getCurrentTaskFlowStageId(input: {
   openRound: TaskFeedbackRoundRecord | null;
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowStageId {
+  if (input.task.status === TASK_STATUS.CLOSED) return 'completed';
   if (input.task.status === TASK_STATUS.COMPLETED) return 'completed';
   if (input.task.status === TASK_STATUS.DELIVERED) return 'delivery';
   if (input.openRound) return 'plan_discussion';
@@ -1042,6 +1049,12 @@ function buildTaskFlowConclusion(input: {
   failedStage?: TaskAgentStageRecord;
   runningStage?: TaskAgentStageRecord;
 }): Pick<TaskFlowSnapshot, 'conclusion' | 'severity'> {
+  if (input.task.status === TASK_STATUS.CLOSED) {
+    return {
+      conclusion: '任务已关闭，不再继续推进。',
+      severity: 'blocked',
+    };
+  }
   if (input.task.status === TASK_STATUS.COMPLETED) {
     return { conclusion: '任务已完成，关键产物已归档。', severity: 'success' };
   }
@@ -1145,6 +1158,8 @@ function buildTaskFlowActions(input: {
   artifacts: TaskArtifactRecord[];
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowAction[] {
+  if (input.task.status === TASK_STATUS.CLOSED) return [];
+
   const failedStage = getLatestFailedAgentStage(input.agentStages);
   const implementationStage = getStageByAgentStage(
     input.agentStages,
@@ -1330,6 +1345,18 @@ function buildTaskFlowActions(input: {
       stage: 'delivery',
       variant: 'secondary',
     }),
+    ...(input.task.status === TASK_STATUS.COMPLETED
+      ? []
+      : [
+          buildTaskFlowAction({
+            id: 'close_task',
+            label: '关闭任务',
+            description: '终止当前 Task 流程并保留历史记录',
+            enabled: true,
+            stage: getCurrentTaskFlowStageId(input),
+            variant: 'danger',
+          }),
+        ]),
   ];
 }
 
@@ -1399,6 +1426,7 @@ function getTaskFlowStageSummary(input: {
       if (input.task.status === TASK_STATUS.DELIVERING) return '交付中';
       return '等待实现完成';
     case 'completed':
+      if (input.task.status === TASK_STATUS.CLOSED) return '任务已关闭';
       return input.task.status === TASK_STATUS.COMPLETED
         ? '任务已完成'
         : '等待验收';
@@ -1478,7 +1506,10 @@ function buildTaskFlowStages(input: {
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowStage[] {
   const currentIndex = TASK_FLOW_STAGE_ORDER.indexOf(input.currentStageId);
-  const failedStage = getLatestFailedAgentStage(input.agentStages);
+  const failedStage =
+    input.task.status === TASK_STATUS.CLOSED
+      ? undefined
+      : getLatestFailedAgentStage(input.agentStages);
 
   return TASK_FLOW_STAGE_ORDER.map((stageId, index) => {
     let state: TaskFlowStageState =
@@ -1597,6 +1628,26 @@ function buildTaskFlowEvents(input: {
         occurredAt: artifact.createdAt,
       });
     }
+    if (artifact.type === ARTIFACT_TYPE.TASK_CLOSED) {
+      const previousStatus =
+        typeof artifact.metadata.previousStatus === 'string'
+          ? artifact.metadata.previousStatus
+          : undefined;
+      const reason =
+        typeof artifact.metadata.reason === 'string'
+          ? artifact.metadata.reason
+          : undefined;
+      events.push({
+        eventId: artifact.artifactId,
+        type: 'task_closed',
+        stage: 'completed',
+        title: '任务已关闭',
+        summary: [previousStatus ? `关闭前状态：${previousStatus}` : '', reason]
+          .filter(Boolean)
+          .join('；'),
+        occurredAt: artifact.createdAt,
+      });
+    }
   }
 
   for (const plan of input.plans) {
@@ -1628,19 +1679,15 @@ function buildTaskFlowEvents(input: {
     if (run.endedAt) {
       events.push({
         eventId: `${run.runId}:end`,
-        type:
-          run.status === AGENT_RUN_STATUS.FAILED
-            ? 'agent_run_failed'
-            : 'agent_run_succeeded',
+        type: getAgentRunEndEventType(run.status),
         stage,
-        title:
-          run.status === AGENT_RUN_STATUS.FAILED
-            ? `${run.agentId} 运行失败`
-            : `${run.agentId} 运行完成`,
+        title: getAgentRunEndEventTitle(run),
         summary:
           run.status === AGENT_RUN_STATUS.FAILED
             ? getAgentRunFailureSummary(run)
-            : undefined,
+            : run.status === AGENT_RUN_STATUS.CANCELLED
+              ? run.error || '任务关闭时已取消运行'
+              : undefined,
         occurredAt: run.endedAt,
       });
     }
@@ -1671,6 +1718,24 @@ function buildTaskFlowEvents(input: {
   );
 }
 
+function getAgentRunEndEventType(
+  status: AgentRunStatus,
+): Extract<
+  TaskFlowEventType,
+  'agent_run_failed' | 'agent_run_succeeded' | 'agent_run_cancelled'
+> {
+  if (status === AGENT_RUN_STATUS.FAILED) return 'agent_run_failed';
+  if (status === AGENT_RUN_STATUS.CANCELLED) return 'agent_run_cancelled';
+  return 'agent_run_succeeded';
+}
+
+function getAgentRunEndEventTitle(run: TaskAgentRunRecord): string {
+  if (run.status === AGENT_RUN_STATUS.FAILED) return `${run.agentId} 运行失败`;
+  if (run.status === AGENT_RUN_STATUS.CANCELLED)
+    return `${run.agentId} 运行已取消`;
+  return `${run.agentId} 运行完成`;
+}
+
 function buildTaskFlowSnapshot(input: {
   task: TaskItemRecord;
   thread: TaskThreadRecord;
@@ -1683,10 +1748,15 @@ function buildTaskFlowSnapshot(input: {
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowSnapshot {
   const currentStageId = getCurrentTaskFlowStageId(input);
-  const failedStage = getLatestFailedAgentStage(input.agentStages);
-  const runningStage = input.agentStages.find(
-    (stage) => stage.status === AGENT_RUN_STATUS.RUNNING,
-  );
+  const isClosed = input.task.status === TASK_STATUS.CLOSED;
+  const failedStage = isClosed
+    ? undefined
+    : getLatestFailedAgentStage(input.agentStages);
+  const runningStage = isClosed
+    ? undefined
+    : input.agentStages.find(
+        (stage) => stage.status === AGENT_RUN_STATUS.RUNNING,
+      );
   const conclusion = buildTaskFlowConclusion({
     failedStage,
     runningStage,
@@ -1700,7 +1770,7 @@ function buildTaskFlowSnapshot(input: {
   if (!input.task.cwd && !input.task.worktreePath) {
     blockers.push('缺少工作目录，Agent 调度或人工接管可能无法定位仓库。');
   }
-  if (failedStage?.manualResume?.reason) {
+  if (!isClosed && failedStage?.manualResume?.reason) {
     blockers.push(failedStage.manualResume.reason);
   }
 
@@ -1834,6 +1904,126 @@ function insertArtifact(input: {
     metadata: input.metadata || {},
     createdAt: input.createdAt,
   };
+}
+
+function ensureTaskIsOpen(
+  snapshot: TaskPlanningSnapshot,
+  action: string,
+): Result<void> {
+  return snapshot.task.status === TASK_STATUS.CLOSED
+    ? failure(`Task 已关闭，不能${action}`)
+    : success(undefined);
+}
+
+function readTaskStatus(taskId: string): Result<TaskStatus | null> {
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+
+  try {
+    const row = dbRes.data
+      .prepare('SELECT * FROM task_items WHERE task_id = ?')
+      .get(taskId) as TaskItemRow | null;
+    return success(row ? row.status : null);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`读取 Task 状态失败: ${message}`);
+  }
+}
+
+export function closeTask(
+  taskId: string,
+  reason?: string,
+): Result<TaskPlanningSnapshot> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  const snapshot = snapshotRes.data;
+  if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  if (snapshot.task.status === TASK_STATUS.COMPLETED) {
+    return failure('已完成 Task 不能关闭');
+  }
+  if (snapshot.task.status === TASK_STATUS.CLOSED) return success(snapshot);
+
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+  const db = dbRes.data;
+
+  try {
+    const now = iso_timestamp();
+    const closeReason = reason?.trim();
+    const runningRuns = snapshot.agentRuns.filter(
+      (run) => run.status === AGENT_RUN_STATUS.RUNNING,
+    );
+
+    const txn = db.transaction(() => {
+      insertArtifact({
+        taskId: snapshot.task.taskId,
+        threadId: snapshot.thread.threadId,
+        type: ARTIFACT_TYPE.TASK_CLOSED,
+        role: ARTIFACT_ROLE.SYSTEM,
+        body: closeReason
+          ? `任务已关闭：${closeReason}`
+          : '任务已关闭，不再继续推进。',
+        metadata: {
+          previousStatus: snapshot.task.status,
+          reason: closeReason || null,
+          closedAt: now,
+        },
+        createdAt: now,
+      });
+
+      if (snapshot.openRound) {
+        db.prepare(
+          `
+            UPDATE task_feedback_rounds
+            SET status = ?, resolved_at = ?
+            WHERE round_id = ?
+          `,
+        ).run(ROUND_STATUS.CLOSED, now, snapshot.openRound.roundId);
+      }
+
+      db.prepare(
+        `
+          UPDATE task_threads
+          SET open_round_id = NULL, updated_at = ?
+          WHERE thread_id = ?
+        `,
+      ).run(now, snapshot.thread.threadId);
+
+      for (const run of runningRuns) {
+        db.prepare(
+          `
+            UPDATE task_agent_runs
+            SET status = ?,
+                output_artifact_ids = ?,
+                error = ?,
+                ended_at = ?
+            WHERE run_id = ? AND status = ?
+          `,
+        ).run(
+          AGENT_RUN_STATUS.CANCELLED,
+          JSON.stringify(run.outputArtifactIds),
+          '任务已关闭，运行已取消。',
+          now,
+          run.runId,
+          AGENT_RUN_STATUS.RUNNING,
+        );
+      }
+
+      db.prepare(
+        'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
+      ).run(TASK_STATUS.CLOSED, now, snapshot.task.taskId);
+    });
+
+    txn();
+    const refreshedSnapshotRes = readTaskPlanningSnapshot(taskId);
+    if (!refreshedSnapshotRes.success) return refreshedSnapshotRes;
+    return refreshedSnapshotRes.data
+      ? success(refreshedSnapshotRes.data)
+      : failure(`Task ${taskId} 关闭后读取快照失败`);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`关闭 Task 失败: ${message}`);
+  }
 }
 
 export function createPlanningTask(
@@ -2132,10 +2322,13 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
   const thread = threadRes.data;
   if (!thread)
     return failure(`Task 不存在或缺少 active thread: ${input.taskId}`);
+  const taskRow = db
+    .prepare('SELECT * FROM task_items WHERE task_id = ?')
+    .get(input.taskId) as TaskItemRow | null;
+  if (taskRow?.status === TASK_STATUS.CLOSED) {
+    return failure('Task 已关闭，不能继续讨论');
+  }
   if (thread.status === THREAD_STATUS.APPROVED) {
-    const taskRow = db
-      .prepare('SELECT * FROM task_items WHERE task_id = ?')
-      .get(input.taskId) as TaskItemRow | null;
     if (
       taskRow?.status !== TASK_STATUS.DELIVERED &&
       taskRow?.status !== TASK_STATUS.COMPLETED
@@ -2279,6 +2472,8 @@ export function publishTaskPlanRevision(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${input.taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '发布新版 Plan');
+  if (!openRes.success) return openRes;
   if (snapshot.thread.status === THREAD_STATUS.APPROVED) {
     return failure('当前 Planning 已批准，不能发布新版 Plan');
   }
@@ -2402,6 +2597,8 @@ export function publishPlanningUpdate(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${input.taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '发布 Update');
+  if (!openRes.success) return openRes;
   if (snapshot.thread.status === THREAD_STATUS.APPROVED) {
     return failure('当前 Planning 已批准，不能发布 Update');
   }
@@ -2483,6 +2680,11 @@ export function recordTaskAgentResult(
 ): Result<TaskArtifactRecord> {
   const body = input.body.trim();
   if (!body) return failure('Agent Result 内容不能为空');
+  const statusRes = readTaskStatus(input.taskId);
+  if (!statusRes.success) return statusRes;
+  if (statusRes.data === TASK_STATUS.CLOSED) {
+    return failure('Task 已关闭，不能记录 Agent Result');
+  }
 
   try {
     const artifact = insertArtifact({
@@ -2513,6 +2715,8 @@ export function approveCurrentTaskPlan(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '批准计划');
+  if (!openRes.success) return openRes;
   if (!snapshot.currentPlan) return failure('当前没有可批准的正式 Plan');
   if (snapshot.openRound) {
     return failure(`当前仍有待处理反馈轮次: ${snapshot.openRound.roundId}`);
@@ -2580,6 +2784,8 @@ export function approveTaskImplementationSteps(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '确认实施步骤');
+  if (!openRes.success) return openRes;
 
   const approvedPlan = snapshot.plans.find(
     (plan) =>
@@ -2642,6 +2848,8 @@ export function completeDeliveredTask(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '验收完成');
+  if (!openRes.success) return openRes;
   if (snapshot.task.status === TASK_STATUS.COMPLETED) return success(snapshot);
   if (snapshot.task.status !== TASK_STATUS.DELIVERED) {
     return failure('只有已交付 Task 可以验收完成');
@@ -2814,6 +3022,16 @@ export function updateTaskStatus(
   if (!dbRes.success) return dbRes;
 
   try {
+    const taskRow = dbRes.data
+      .prepare('SELECT * FROM task_items WHERE task_id = ?')
+      .get(taskId) as TaskItemRow | null;
+    if (!taskRow) return failure(`Task 不存在: ${taskId}`);
+    if (
+      taskRow.status === TASK_STATUS.CLOSED &&
+      status !== TASK_STATUS.CLOSED
+    ) {
+      return failure('Task 已关闭，不能更新状态');
+    }
     const result = dbRes.data
       .prepare(
         'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
@@ -2835,6 +3053,16 @@ export function updateTaskDelivery(
   if (!dbRes.success) return dbRes;
 
   try {
+    const taskRow = dbRes.data
+      .prepare('SELECT * FROM task_items WHERE task_id = ?')
+      .get(input.taskId) as TaskItemRow | null;
+    if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
+    if (
+      taskRow.status === TASK_STATUS.CLOSED &&
+      input.status !== TASK_STATUS.CLOSED
+    ) {
+      return failure('Task 已关闭，不能更新交付信息');
+    }
     const result = dbRes.data
       .prepare(
         `
@@ -2931,6 +3159,8 @@ export function completeTaskAgentStageManually(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${input.taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '人工标记阶段完成');
+  if (!openRes.success) return openRes;
 
   const stageDefinition = getTaskAgentStageDefinition(input.stage);
   if (!stageDefinition) return failure(`未知 Task Agent 阶段: ${input.stage}`);
@@ -3164,6 +3394,13 @@ export function createTaskAgentRun(
   const inputArtifactIds = input.inputArtifactIds || [];
 
   try {
+    const taskRow = dbRes.data
+      .prepare('SELECT * FROM task_items WHERE task_id = ?')
+      .get(input.taskId) as TaskItemRow | null;
+    if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
+    if (taskRow.status === TASK_STATUS.CLOSED) {
+      return failure('Task 已关闭，不能创建 Agent Run');
+    }
     dbRes.data
       .prepare(
         `
@@ -3211,6 +3448,13 @@ export function finishTaskAgentRun(
   const endedAt = iso_timestamp();
 
   try {
+    const existingRow = dbRes.data
+      .prepare('SELECT * FROM task_agent_runs WHERE run_id = ?')
+      .get(input.runId) as TaskAgentRunRow | null;
+    if (!existingRow) return failure('结束 Agent Run 后读取失败');
+    if (existingRow.status !== AGENT_RUN_STATUS.RUNNING) {
+      return success(mapRun(existingRow));
+    }
     dbRes.data
       .prepare(
         `

--- a/packages/along/src/domain/task-spawn-runner.test.ts
+++ b/packages/along/src/domain/task-spawn-runner.test.ts
@@ -15,6 +15,7 @@ vi.mock('./task-planning', () => ({
     RUNNING: 'running',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
+    CANCELLED: 'cancelled',
   },
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy API handler file keeps related route handlers together.
 import { consola } from 'consola';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
@@ -8,6 +9,7 @@ import {
 import {
   approveCurrentTaskPlan,
   approveTaskImplementationSteps,
+  closeTask,
   completeDeliveredTask,
   completeTaskAgentStageManually,
   createPlanningTask,
@@ -187,6 +189,22 @@ export function handleTaskApproveRequest(taskId: string): Response {
   });
 }
 
+export async function handleTaskCloseRequest(
+  req: Request,
+  taskId: string,
+): Promise<Response> {
+  const bodyRes = await readJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+
+  const existing = readTaskPlanningSnapshot(taskId);
+  if (!existing.success) return errorResponse(existing.error, 500);
+  if (!existing.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+
+  const closeRes = closeTask(taskId, readStringField(bodyRes.data, 'reason'));
+  if (!closeRes.success) return errorResponse(closeRes.error, 409);
+  return jsonResponse({ taskId, snapshot: closeRes.data });
+}
+
 export async function handleTaskPlannerRequest(
   req: Request,
   taskId: string,
@@ -218,6 +236,9 @@ export async function handleTaskImplementationRequest(
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  if (snapshotRes.data.task.status === 'closed') {
+    return errorResponse('Task 已关闭，不能开始实现', 409);
+  }
   if (!snapshotRes.data.thread.approvedPlanId) {
     return errorResponse('当前 Task 没有已批准方案，不能开始实现', 409);
   }
@@ -270,6 +291,9 @@ export async function handleTaskDeliveryRequest(
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  if (snapshotRes.data.task.status === 'closed') {
+    return errorResponse('Task 已关闭，不能开始交付', 409);
+  }
   if (snapshotRes.data.task.status !== 'implemented') {
     return errorResponse('当前 Task 只有在已实现后才能交付', 409);
   }
@@ -315,6 +339,9 @@ function readExistingTaskError(taskId: string): Response | null {
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+  if (snapshotRes.data.task.status === 'closed') {
+    return errorResponse('Task 已关闭，不能继续推进', 409);
+  }
   return null;
 }
 

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -12,6 +12,7 @@ import {
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
   approveTaskImplementationSteps: vi.fn(),
   approveCurrentTaskPlan: vi.fn(),
+  closeTask: vi.fn(),
   completeDeliveredTask: vi.fn(),
   completeTaskAgentStageManually: vi.fn(),
   createPlanningTask: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('../domain/task-planning', () => ({
   },
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  closeTask: planningMocks.closeTask,
   completeDeliveredTask: planningMocks.completeDeliveredTask,
   completeTaskAgentStageManually: planningMocks.completeTaskAgentStageManually,
   createPlanningTask: planningMocks.createPlanningTask,

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -5,6 +5,7 @@ type PlanningMock = ReturnType<typeof vi.fn>;
 export type PlanningMocks = {
   approveTaskImplementationSteps: PlanningMock;
   approveCurrentTaskPlan: PlanningMock;
+  closeTask: PlanningMock;
   completeDeliveredTask: PlanningMock;
   completeTaskAgentStageManually: PlanningMock;
   createPlanningTask: PlanningMock;
@@ -46,6 +47,7 @@ export function resetPlanningMocks(planningMocks: PlanningMocks) {
   mockTaskReads(planningMocks);
   mockTaskMessage(planningMocks);
   mockPlanApproval(planningMocks);
+  mockTaskClose(planningMocks);
   mockImplementationStepsApproval(planningMocks);
   mockManualComplete(planningMocks);
   mockDeliveredComplete(planningMocks);
@@ -121,6 +123,16 @@ function mockPlanApproval(planningMocks: PlanningMocks) {
       artifactId: 'art-plan',
       body: '## Plan',
       createdAt: '2026-01-01T00:00:01.000Z',
+    },
+  });
+}
+
+function mockTaskClose(planningMocks: PlanningMocks) {
+  planningMocks.closeTask.mockReturnValue({
+    success: true,
+    data: {
+      ...snapshot,
+      task: { ...snapshot.task, status: 'closed' },
     },
   });
 }

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -11,6 +11,7 @@ import {
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
   approveTaskImplementationSteps: vi.fn(),
   approveCurrentTaskPlan: vi.fn(),
+  closeTask: vi.fn(),
   completeDeliveredTask: vi.fn(),
   completeTaskAgentStageManually: vi.fn(),
   createPlanningTask: vi.fn(),
@@ -32,6 +33,7 @@ vi.mock('../domain/task-planning', () => ({
   },
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  closeTask: planningMocks.closeTask,
   completeDeliveredTask: planningMocks.completeDeliveredTask,
   completeTaskAgentStageManually: planningMocks.completeTaskAgentStageManually,
   createPlanningTask: planningMocks.createPlanningTask,
@@ -227,6 +229,22 @@ it('当验收已交付 Task 时，期望返回完成后的 snapshot', async () =
   expect(response.status).toBe(200);
   expect(payload.taskId).toBe('task-1');
   expect(planningMocks.completeDeliveredTask).toHaveBeenCalledWith('task-1');
+});
+
+it('当关闭 Task 时，期望返回关闭后的 snapshot', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/close', { reason: '不再继续' }),
+    new URL('http://localhost/api/tasks/task-1/close'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as {
+    taskId: string;
+    snapshot: typeof snapshot;
+  };
+
+  expect(response.status).toBe(200);
+  expect(payload.taskId).toBe('task-1');
+  expect(planningMocks.closeTask).toHaveBeenCalledWith('task-1', '不再继续');
 });
 
 it('当读取不存在的 Task 时，期望返回 404', async () => {

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -1,6 +1,7 @@
 import type { TaskPlanningSnapshot } from '../domain/task-planning';
 import {
   handleTaskApproveRequest,
+  handleTaskCloseRequest,
   handleTaskCompleteRequest,
   handleTaskCreateRequest,
   handleTaskDeliveryRequest,
@@ -64,6 +65,7 @@ type TaskActionHandler = (
 
 const ACTION_ROUTES: Record<string, TaskActionHandler> = {
   approve: (_req, taskId) => handleTaskApproveRequest(taskId),
+  close: (req, taskId) => handleTaskCloseRequest(req, taskId),
   complete: (_req, taskId) => handleTaskCompleteRequest(taskId),
   delivery: handleTaskDeliveryRequest,
   implementation: handleTaskImplementationRequest,

--- a/packages/along/src/integration/task-autonomous-continuation.ts
+++ b/packages/along/src/integration/task-autonomous-continuation.ts
@@ -58,6 +58,7 @@ export function continueAutonomousTaskAfterPlanning(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
+  if (snapshot.task.status === TASK_STATUS.CLOSED) return success('skipped');
   if (!isAutonomous(snapshot)) return success('skipped');
   if (
     !snapshot.currentPlan ||
@@ -87,6 +88,7 @@ export function continueAutonomousTaskAfterImplementation(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
+  if (snapshot.task.status === TASK_STATUS.CLOSED) return success('skipped');
   if (!isAutonomous(snapshot)) return success('skipped');
 
   if (snapshot.task.status === TASK_STATUS.PLANNING_APPROVED) {


### PR DESCRIPTION
along-task: #21

## 修改内容
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/actionTypes.ts`
- `packages/along-web/src/task-planning/api.ts`
- `packages/along-web/src/task-planning/flowActionRouter.test.ts`
- `packages/along-web/src/task-planning/flowActionRouter.ts`
- `packages/along-web/src/task-planning/format.ts`
- `packages/along-web/src/types-task.ts`
- `packages/along/src/domain/task-claude-runner.test.ts`
- `packages/along/src/domain/task-codex-runner.test.ts`
- `packages/along/src/domain/task-delivery.test.ts`
- `packages/along/src/domain/task-delivery.ts`
- `packages/along/src/domain/task-implementation-agent.ts`
- `packages/along/src/domain/task-planning-agent.test.ts`
- `packages/along/src/domain/task-planning-agent.ts`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/domain/task-spawn-runner.test.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api-scheduling.test.ts`
- `packages/along/src/integration/task-api.test-utils.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-api.ts`
- `packages/along/src/integration/task-autonomous-continuation.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-21`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
- 问题成立，当前 Task 只有 planning/planning_approved/implementing/implemented/delivering/delivered/completed 这些流程状态；当 Agent run、反馈轮次或交付链路异常卡住时，用户缺少一个明确的终止语义，只能让任务长期停留在中间状态。
- 这个需求值得做，但不应把“关闭”伪装成 completed。completed 表示交付已验收，关闭表示放弃继续推进或人工决定终止，两者必须区分，避免污染完成率和交付记录。
- 本次只做单个 Task 的关闭能力，不做批量关闭、恢复关闭任务、删除 worktree 或清理本地分支；关闭是状态终止和审计记录，不是资源清理。

Summary
- 新增 Task 终态 closed，并在 Web 端提供“关闭任务”危险操作。
- 用户点击关闭后，后端将 Task 原子切换为 closed，记录关闭事件，并使该 Task 不再进入规划、实现、交付、验收、人工完成或失败恢复流程。
- 已关闭任务仍可在列表和详情中查看历史记录、计划、Agent run、PR 和 commit 信息，但流程面板显示“任务已关闭”，不再展示继续执行类操作。

Mermaid
```mermaid
stateDiagram-v2
  [*] --> planning
  planning --> planning_approved: 批准计划
  planning_approved --> implementing: 开始实现
  implementing --> implemented: 实现完成
  implemented --> delivering: 开始交付
  delivering --> delivered: PR/交付完成
  delivered --> completed: 验收完成
  planning --> closed: 关闭任务
  planning_approved --> closed: 关闭任务
  implementing --> closed: 关闭任务
  implemented --> closed: 关闭任务
  delivering --> closed: 关闭任务
  delivered --> closed: 关闭任务
  completed --> [*]
  closed --> [*]
```

Contracts / Interfaces
- 后端 TaskStatus 增加 closed，前后端类型、状态文案、样式、流程阶段判断必须同步更新。
- 新增接口 POST /api/tasks/:taskId/close，请求体允许为空，可选字段 reason?: string；响应为 { taskId, snapshot }。
- 接口语义：Task 不存在返回 404；Task 已 completed 返回 409；Task 已 closed 时幂等返回当前 snapshot；其他状态均可关闭。
- 新增 Task artifact 类型 task_closed，role 使用 system，metadata 至少包含 previousStatus、reason、closedAt，用于审计和历史流转展示。
- 如引入 AgentRunStatus cancelled，需要同步后端类型、前端类型、状态文案和所有 run 状态分支；如果实现中判断现有存储更适合复用 failed，则也必须在关闭事件中区分“用户关闭”与“运行失败”，不能把关闭展示成失败。

Implementation Changes
- 在 packages/along/src/domain/task-planning.ts 中补齐 closed 状态常量、类型和关闭领域函数。关闭函数必须在事务内读取当前快照、写入 task_closed artifact、关闭或取消开放反馈轮次、结束当前 running agent run、更新 task_items.status=closed，并返回刷新后的 snapshot。
- 为所有会改写 Task 流程状态的入口增加 closed guard，包括批准计划、提交反馈触发 Planner、重新规划、开始实现、人工完成阶段、开始交付、验收完成、继续修改，以及实现/交付 Agent 后续回写状态的路径。已关闭任务只能读取和追加必要的系统记录，不能被迟到的 Agent 回调重新改回 implementing/implemented/delivered/completed。
- 在 packages/along/src/integration/task-api.ts 和 task-api-handlers.ts 增加 close action 路由与 handler，复用现有 readJsonObject/errorResponse/jsonResponse 风格。
- 更新 flow snapshot 构建逻辑：closed 优先于 openRound、failedStage、runningStage 判断；currentStageId 指向 completed 或新增合适终态展示；conclusion 显示“任务已关闭，不再继续推进。”；actions 中为非 completed/closed 状态增加 close_task danger 操作，closed 后不再返回继续执行类 action。
- 更新 packages/along-web/src/types-task.ts、format.ts、flowActionRouter.ts、api.ts 和相关组件：增加 closed 状态、关闭按钮文案“关闭任务”、危险样式、点击后直接 POST close 并刷新 snapshot；关闭操作不要求填写表单，不删除任务记录。
- 更新任务列表和详情展示：已关闭任务显示独立 badge；流程历史中显示关闭事件，摘要包含关闭前状态；详情保留原有元信息、Agent 记录和交付信息。

Failure Handling
- 关闭写库失败时接口返回 500 或领域错误，前端沿用现有 busyAction/error 展示，不做本地乐观状态修改。
- 关闭过程中如果存在 running agent run，必须将其从前端“运行中/卡住”视图移除；实际外部进程若稍后返回，后续状态回写必须被 closed guard 拒绝或忽略，不能覆盖 closed。
- 关闭不会清理 worktree、branch、commit 或 PR；这些字段保留用于追溯，避免误删用户资产。

Test Plan
- 后端单元测试：从 planning、planning_approved、implementing、implemented、delivering、delivered 调用 close 均得到 closed snapshot，并写入 task_closed artifact。
- 后端单元测试：completed 关闭返回冲突；closed 重复关闭保持幂等；不存在 task 返回 404/失败结果。
- 后端单元测试：关闭带 open feedback round 和 running agent run 的任务后，flow 不再显示开放反馈、运行中或失败恢复为当前阻塞状态。
- 后端单元测试：已关闭任务调用 planner/approve/implementation/delivery/complete/manual-complete/message 等入口会被拒绝，不会改变状态。
- 前端测试：closed badge 文案和样式正确；非终态显示“关闭任务”操作；点击后调用 /api/tasks/:id/close 并用返回 snapshot 更新列表和详情；closed/completed 不显示关闭操作。
- 回归验证：运行 bun --filter @ranwawa/along test，并补跑 along-web 相关测试；如仓库没有统一 web test 脚本，至少运行对应 package 的测试或类型检查并说明结果。

Assumptions
- “关闭”表示终止 Along Task 流程，不代表 GitHub Issue/PR 关闭，也不代表实现完成。
- 本轮不提供批量关闭和重新打开能力；如果后续发现误关闭频繁，再单独设计 reopen 或归档筛选。

## 交付信息
- Commit: 36411abaf356df9b4fb5717694ae7c071c9abbb9