### PR TITLE
Task #20: 继续开发中断的web任务

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -46,10 +46,15 @@ function TaskPlanningMain({
         selectedRepository={taskPlanning.selectedRepository}
         sortedArtifacts={taskPlanning.sortedArtifacts}
         messageBody={taskPlanning.messageBody}
+        messageAttachments={taskPlanning.messageAttachments}
         busyAction={taskPlanning.busyAction}
         onDraftChange={taskPlanning.updateDraft}
+        onDraftAttachmentsChange={(attachments) =>
+          taskPlanning.setDraft((previous) => ({ ...previous, attachments }))
+        }
         onCreateTask={taskPlanning.createTask}
         onMessageChange={taskPlanning.setMessageBody}
+        onMessageAttachmentsChange={taskPlanning.setMessageAttachments}
         onSubmitMessage={taskPlanning.submitMessageFromFlow}
         onAction={taskPlanning.handleFlowAction}
       />

--- a/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
+++ b/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
@@ -1,0 +1,98 @@
+import type { TaskFlowAction, TaskPlanningSnapshot } from '../types';
+import { getFlowActionClass } from './format';
+import { ImageAttachmentPicker } from './TaskImageAttachments';
+
+function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
+  const submitFeedbackAction = flow.actions.find(
+    (action) => action.id === 'submit_feedback',
+  );
+  const requestRevisionAction = flow.actions.find(
+    (action) => action.id === 'request_revision',
+  );
+  const requestChangesAction = flow.actions.find(
+    (action) => action.id === 'request_changes',
+  );
+  return requestChangesAction?.enabled
+    ? [requestChangesAction]
+    : [submitFeedbackAction, requestRevisionAction].filter(
+        (action): action is TaskFlowAction => Boolean(action),
+      );
+}
+
+function MessageActionButtons({
+  actions,
+  busyAction,
+  hasDraft,
+}: {
+  actions: TaskFlowAction[];
+  busyAction: string | null;
+  hasDraft: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          type="submit"
+          disabled={!action.enabled || !hasDraft || Boolean(busyAction)}
+          title={!action.enabled ? action.disabledReason : action.description}
+          className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
+            action,
+          )}`}
+        >
+          {busyAction === 'message' ? '发送中' : action.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ExistingTaskComposer({
+  flow,
+  messageBody,
+  attachments,
+  busyAction,
+  onMessageChange,
+  onAttachmentsChange,
+  onSubmitMessage,
+}: {
+  flow: TaskPlanningSnapshot['flow'];
+  messageBody: string;
+  attachments: File[];
+  busyAction: string | null;
+  onMessageChange: (value: string) => void;
+  onAttachmentsChange: (files: File[]) => void;
+  onSubmitMessage: () => void;
+}) {
+  const messageActions = getMessageActions(flow);
+  const canSubmitMessage = messageActions.some((action) => action.enabled);
+  const hasDraft = Boolean(messageBody.trim()) || attachments.length > 0;
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmitMessage();
+      }}
+      className="flex flex-col gap-3"
+    >
+      <textarea
+        value={messageBody}
+        onChange={(event) => onMessageChange(event.target.value)}
+        placeholder="补充反馈、继续提问或说明交付后的修改要求"
+        rows={2}
+        disabled={!canSubmitMessage}
+        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
+      />
+      <ImageAttachmentPicker
+        attachments={attachments}
+        disabled={!canSubmitMessage}
+        onChange={onAttachmentsChange}
+      />
+      <MessageActionButtons
+        actions={messageActions}
+        busyAction={busyAction}
+        hasDraft={hasDraft}
+      />
+    </form>
+  );
+}

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -13,13 +13,10 @@ import type {
 } from '../types';
 import { AgentStagesPanel } from './AgentStagesPanel';
 import type { DraftTaskInput, RepositoryOption } from './api';
-import {
-  formatTime,
-  getFlowActionClass,
-  getTaskStatusLabel,
-  getThreadStatusLabel,
-} from './format';
+import { ExistingTaskComposer } from './ExistingTaskComposer';
+import { formatTime, getTaskStatusLabel, getThreadStatusLabel } from './format';
 import { FlowHistory, TaskFlowPanel } from './TaskFlowPanel';
+import { ImageAttachmentPicker } from './TaskImageAttachments';
 import { TaskProgressPanel } from './TaskProgressPanel';
 import { TaskRecordsPanel } from './TaskRecords';
 
@@ -113,86 +110,19 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
   );
 }
 
-function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
-  const submitFeedbackAction = flow.actions.find(
-    (action) => action.id === 'submit_feedback',
-  );
-  const requestRevisionAction = flow.actions.find(
-    (action) => action.id === 'request_revision',
-  );
-  const requestChangesAction = flow.actions.find(
-    (action) => action.id === 'request_changes',
-  );
-  return requestChangesAction?.enabled
-    ? [requestChangesAction]
-    : [submitFeedbackAction, requestRevisionAction].filter(
-        (action): action is TaskFlowAction => Boolean(action),
-      );
-}
-
-function ExistingTaskComposer({
-  flow,
-  messageBody,
-  busyAction,
-  onMessageChange,
-  onSubmitMessage,
-}: {
-  flow: TaskPlanningSnapshot['flow'];
-  messageBody: string;
-  busyAction: string | null;
-  onMessageChange: (value: string) => void;
-  onSubmitMessage: () => void;
-}) {
-  const messageActions = getMessageActions(flow);
-  const canSubmitMessage = messageActions.some((action) => action.enabled);
-  return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        onSubmitMessage();
-      }}
-      className="flex flex-col gap-3"
-    >
-      <textarea
-        value={messageBody}
-        onChange={(event) => onMessageChange(event.target.value)}
-        placeholder="补充反馈、继续提问或说明交付后的修改要求"
-        rows={2}
-        disabled={!canSubmitMessage}
-        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
-      />
-      <div className="flex flex-wrap gap-2">
-        {messageActions.map((action) => (
-          <button
-            key={action.id}
-            type="submit"
-            disabled={
-              !action.enabled || !messageBody.trim() || Boolean(busyAction)
-            }
-            title={!action.enabled ? action.disabledReason : action.description}
-            className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
-              action,
-            )}`}
-          >
-            {busyAction === 'message' ? '发送中' : action.label}
-          </button>
-        ))}
-      </div>
-    </form>
-  );
-}
-
 function NewTaskComposer({
   draft,
   selectedRepository,
   busyAction,
   onDraftChange,
+  onDraftAttachmentsChange,
   onCreateTask,
 }: {
   draft: DraftTaskInput;
   selectedRepository?: RepositoryOption;
   busyAction: string | null;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onDraftAttachmentsChange: (files: File[]) => void;
   onCreateTask: (event: FormEvent) => void;
 }) {
   return (
@@ -204,6 +134,10 @@ function NewTaskComposer({
         placeholder="输入任务目标或问题"
         rows={2}
         className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
+      />
+      <ImageAttachmentPicker
+        attachments={draft.attachments}
+        onChange={onDraftAttachmentsChange}
       />
       <label className="flex flex-col gap-1 text-xs text-text-muted">
         执行模式
@@ -225,7 +159,9 @@ function NewTaskComposer({
         <button
           type="submit"
           disabled={
-            !selectedRepository || !draft.body.trim() || busyAction === 'create'
+            !selectedRepository ||
+            (!draft.body.trim() && draft.attachments.length === 0) ||
+            busyAction === 'create'
           }
           className="shrink-0 px-3 py-2 rounded-lg text-xs font-semibold bg-brand text-white border border-brand hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
@@ -248,10 +184,13 @@ type TaskDetailProps = {
   selectedRepository?: RepositoryOption;
   sortedArtifacts: TaskArtifactRecord[];
   messageBody: string;
+  messageAttachments: File[];
   busyAction: string | null;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onDraftAttachmentsChange: (files: File[]) => void;
   onCreateTask: (event: FormEvent) => void;
   onMessageChange: (value: string) => void;
+  onMessageAttachmentsChange: (files: File[]) => void;
   onSubmitMessage: () => void;
   onAction: (action: TaskFlowAction) => void;
 };
@@ -340,6 +279,7 @@ function NewTaskDetail({
           selectedRepository={detail.selectedRepository}
           busyAction={detail.busyAction}
           onDraftChange={detail.onDraftChange}
+          onDraftAttachmentsChange={detail.onDraftAttachmentsChange}
           onCreateTask={detail.onCreateTask}
         />
       </div>
@@ -376,8 +316,10 @@ function SelectedTaskDetail({
           <ExistingTaskComposer
             flow={selected.flow}
             messageBody={detail.messageBody}
+            attachments={detail.messageAttachments}
             busyAction={detail.busyAction}
             onMessageChange={detail.onMessageChange}
+            onAttachmentsChange={detail.onMessageAttachmentsChange}
             onSubmitMessage={detail.onSubmitMessage}
           />
         </div>

--- a/packages/along-web/src/task-planning/TaskImageAttachments.tsx
+++ b/packages/along-web/src/task-planning/TaskImageAttachments.tsx
@@ -1,0 +1,196 @@
+import {
+  type ChangeEvent,
+  type DragEvent,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+const IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+const MAX_IMAGE_COUNT = 6;
+const MAX_SINGLE_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_TOTAL_IMAGE_BYTES = 30 * 1024 * 1024;
+
+function formatFileSize(bytes: number): string {
+  return `${Math.round((bytes / 1024 / 1024) * 10) / 10}MB`;
+}
+
+function validateImageFiles(existing: File[], incoming: File[]) {
+  const next = [...existing];
+  for (const file of incoming) {
+    if (!IMAGE_MIME_TYPES.includes(file.type)) {
+      return { files: existing, error: '只支持 PNG、JPEG、WebP 或 GIF 图片' };
+    }
+    if (file.size <= 0) return { files: existing, error: '不能上传空图片' };
+    if (file.size > MAX_SINGLE_IMAGE_BYTES) {
+      return {
+        files: existing,
+        error: `单张图片不能超过 ${formatFileSize(MAX_SINGLE_IMAGE_BYTES)}`,
+      };
+    }
+    if (next.length >= MAX_IMAGE_COUNT) {
+      return {
+        files: existing,
+        error: `单次最多上传 ${MAX_IMAGE_COUNT} 张图片`,
+      };
+    }
+    next.push(file);
+  }
+  const totalSize = next.reduce((sum, file) => sum + file.size, 0);
+  if (totalSize > MAX_TOTAL_IMAGE_BYTES) {
+    return {
+      files: existing,
+      error: `单次图片总大小不能超过 ${formatFileSize(MAX_TOTAL_IMAGE_BYTES)}`,
+    };
+  }
+  return { files: next, error: null };
+}
+
+function ImageAttachmentThumb({
+  file,
+  onRemove,
+}: {
+  file: File;
+  onRemove: () => void;
+}) {
+  const [url, setUrl] = useState('');
+  useEffect(() => {
+    const objectUrl = URL.createObjectURL(file);
+    setUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [file]);
+  return (
+    <div className="flex h-16 min-w-0 items-center gap-2 rounded-lg border border-border-color bg-black/25 p-2">
+      {url && (
+        <img
+          src={url}
+          alt={file.name}
+          className="h-12 w-12 shrink-0 rounded object-cover"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs text-text-secondary">{file.name}</div>
+        <div className="text-[11px] text-text-muted">
+          {formatFileSize(file.size)}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="shrink-0 rounded border border-border-color px-2 py-1 text-[11px] text-text-muted hover:text-text-primary"
+      >
+        删除
+      </button>
+    </div>
+  );
+}
+
+function ImageAttachmentList({
+  attachments,
+  onChange,
+}: {
+  attachments: File[];
+  onChange: (files: File[]) => void;
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      {attachments.map((file) => (
+        <ImageAttachmentThumb
+          key={`${file.name}-${file.size}-${file.lastModified}`}
+          file={file}
+          onRemove={() => onChange(attachments.filter((item) => item !== file))}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ImageAttachmentActions({
+  attachments,
+  disabled,
+  inputRef,
+}: Pick<ImageAttachmentPickerProps, 'attachments' | 'disabled'> & {
+  inputRef: RefObject<HTMLInputElement | null>;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        disabled={disabled || attachments.length >= MAX_IMAGE_COUNT}
+        onClick={() => inputRef.current?.click()}
+        className="rounded-lg border border-border-color bg-black/25 px-3 py-2 text-xs font-semibold text-text-secondary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        添加图片
+      </button>
+      <span className="text-[11px] text-text-muted">
+        {attachments.length}/{MAX_IMAGE_COUNT}
+      </span>
+    </div>
+  );
+}
+
+function HiddenImageInput({
+  inputRef,
+  onFileChange,
+}: {
+  inputRef: RefObject<HTMLInputElement | null>;
+  onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <input
+      ref={inputRef}
+      type="file"
+      accept={IMAGE_MIME_TYPES.join(',')}
+      multiple
+      className="hidden"
+      onChange={onFileChange}
+    />
+  );
+}
+
+export function ImageAttachmentPicker({
+  attachments,
+  disabled,
+  onChange,
+}: ImageAttachmentPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const addFiles = (files: File[]) => {
+    const result = validateImageFiles(attachments, files);
+    setError(result.error);
+    onChange(result.files);
+  };
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    addFiles(Array.from(event.target.files || []));
+    event.target.value = '';
+  };
+  const onDrop = (event: DragEvent<HTMLFieldSetElement>) => {
+    event.preventDefault();
+    if (disabled) return;
+    addFiles(Array.from(event.dataTransfer.files));
+  };
+  return (
+    <fieldset
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={onDrop}
+      className="flex flex-col gap-2"
+    >
+      <HiddenImageInput inputRef={inputRef} onFileChange={onFileChange} />
+      <legend className="sr-only">图片附件</legend>
+      <ImageAttachmentActions
+        attachments={attachments}
+        disabled={disabled}
+        inputRef={inputRef}
+      />
+      <ImageAttachmentList attachments={attachments} onChange={onChange} />
+      {error && <div className="text-xs text-status-error">{error}</div>}
+    </fieldset>
+  );
+}
+interface ImageAttachmentPickerProps {
+  attachments: File[];
+  disabled?: boolean;
+  onChange: (files: File[]) => void;
+}

--- a/packages/along-web/src/task-planning/TaskRecords.tsx
+++ b/packages/along-web/src/task-planning/TaskRecords.tsx
@@ -1,6 +1,54 @@
 import type { ReactNode } from 'react';
-import type { TaskArtifactRecord } from '../types';
+import type { TaskArtifactRecord, TaskAttachmentRecord } from '../types';
 import { formatTime, getArtifactClass, getArtifactLabel } from './format';
+
+function formatAttachmentSize(bytes: number): string {
+  return `${Math.round((bytes / 1024 / 1024) * 10) / 10}MB`;
+}
+
+function attachmentUrl(attachment: TaskAttachmentRecord): string {
+  return `/api/tasks/${attachment.taskId}/attachments/${attachment.attachmentId}`;
+}
+
+function ArtifactAttachments({
+  attachments,
+}: {
+  attachments: TaskAttachmentRecord[];
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+      {attachments.map((attachment) => (
+        <a
+          key={attachment.attachmentId}
+          href={attachmentUrl(attachment)}
+          target="_blank"
+          rel="noreferrer"
+          className="group min-w-0 rounded-lg border border-border-color bg-black/20 p-2 hover:border-brand/60"
+        >
+          {attachment.missing ? (
+            <div className="flex aspect-square items-center justify-center rounded bg-black/30 text-xs text-status-error">
+              文件缺失
+            </div>
+          ) : (
+            <img
+              src={attachmentUrl(attachment)}
+              alt={attachment.originalName}
+              className="aspect-square w-full rounded object-cover"
+              loading="lazy"
+            />
+          )}
+          <div className="mt-1 truncate text-[11px] text-text-secondary">
+            {attachment.originalName}
+          </div>
+          <div className="text-[11px] text-text-muted">
+            {formatAttachmentSize(attachment.sizeBytes)}
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}
 
 export function ArtifactItem({ artifact }: { artifact: TaskArtifactRecord }) {
   return (
@@ -16,6 +64,7 @@ export function ArtifactItem({ artifact }: { artifact: TaskArtifactRecord }) {
       <div className="text-sm whitespace-pre-wrap break-words leading-6">
         {artifact.body}
       </div>
+      <ArtifactAttachments attachments={artifact.attachments || []} />
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/actionTypes.ts
+++ b/packages/along-web/src/task-planning/actionTypes.ts
@@ -21,6 +21,7 @@ export interface UseTaskPlanningActionsInput {
   selectedRepository?: RepositoryOption;
   draft: DraftTaskInput;
   messageBody: string;
+  messageAttachments: File[];
   busyAction: string | null;
   repositoriesRefreshing: boolean;
   canApprove: boolean;
@@ -34,6 +35,7 @@ export interface UseTaskPlanningActionsInput {
     React.SetStateAction<TaskPlanningSnapshot | null>
   >;
   setMessageBody: React.Dispatch<React.SetStateAction<string>>;
+  setMessageAttachments: React.Dispatch<React.SetStateAction<File[]>>;
   setBusyAction: React.Dispatch<React.SetStateAction<string | null>>;
   setRepositoriesRefreshing: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;

--- a/packages/along-web/src/task-planning/api.ts
+++ b/packages/along-web/src/task-planning/api.ts
@@ -59,6 +59,7 @@ export interface DraftTaskInput {
   body: string;
   repository: string;
   executionMode: TaskExecutionMode;
+  attachments: File[];
 }
 
 interface TaskApiError {
@@ -69,6 +70,7 @@ export const emptyDraft: DraftTaskInput = {
   body: '',
   repository: '',
   executionMode: 'manual',
+  attachments: [],
 };
 
 function parseTaskSeq(snapshot: TaskPlanningSnapshot): number | null {

--- a/packages/along-web/src/task-planning/taskPlanningActionUtils.ts
+++ b/packages/along-web/src/task-planning/taskPlanningActionUtils.ts
@@ -1,0 +1,29 @@
+import type { TaskPlanningSnapshot } from '../types';
+import type { UseTaskPlanningActionsInput } from './actionTypes';
+import { mergeSnapshotIntoList } from './api';
+
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function applySnapshot(
+  snapshot: TaskPlanningSnapshot,
+  input: Pick<UseTaskPlanningActionsInput, 'setSelectedSnapshot' | 'setTasks'>,
+) {
+  input.setSelectedSnapshot(snapshot);
+  input.setTasks((previous) => mergeSnapshotIntoList(previous, snapshot));
+}
+
+export function buildMultipartPayload(
+  payload: Record<string, string | boolean>,
+  attachments: File[],
+): FormData {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(payload)) {
+    form.append(key, String(value));
+  }
+  for (const attachment of attachments) {
+    form.append('attachments', attachment);
+  }
+  return form;
+}

--- a/packages/along-web/src/task-planning/useTaskDraftActions.ts
+++ b/packages/along-web/src/task-planning/useTaskDraftActions.ts
@@ -1,0 +1,102 @@
+import type { FormEvent } from 'react';
+import type { UseTaskPlanningActionsInput } from './actionTypes';
+import {
+  type CreateTaskResponse,
+  type DraftTaskInput,
+  emptyDraft,
+  readJsonResponse,
+} from './api';
+import {
+  applySnapshot,
+  buildMultipartPayload,
+} from './taskPlanningActionUtils';
+
+function buildCreatePayload(input: UseTaskPlanningActionsInput, body: string) {
+  const payload: Record<string, string | boolean> = { body, autoRun: true };
+  if (input.draft.executionMode === 'autonomous') {
+    payload.executionMode = 'autonomous';
+  }
+  if (input.selectedRepository) {
+    payload.owner = input.selectedRepository.owner;
+    payload.repo = input.selectedRepository.repo;
+  }
+  return payload;
+}
+
+async function postCreateTask(
+  payload: Record<string, string | boolean>,
+  attachments: File[],
+) {
+  if (attachments.length > 0) {
+    const response = await fetch('/api/tasks', {
+      method: 'POST',
+      body: buildMultipartPayload(payload, attachments),
+    });
+    return readJsonResponse<CreateTaskResponse>(response);
+  }
+  const response = await fetch('/api/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return readJsonResponse<CreateTaskResponse>(response);
+}
+
+function clearSelectedTask(input: UseTaskPlanningActionsInput) {
+  input.setSelectedTaskId(null);
+  input.setSelectedSnapshot(null);
+  input.setMessageBody('');
+  input.setMessageAttachments([]);
+}
+
+function resetDraft(input: UseTaskPlanningActionsInput) {
+  input.setDraft((previous) => ({
+    ...emptyDraft,
+    repository: previous.repository,
+  }));
+}
+
+async function runCreateTask(input: UseTaskPlanningActionsInput, body: string) {
+  const result = await postCreateTask(
+    buildCreatePayload(input, body),
+    input.draft.attachments,
+  );
+  resetDraft(input);
+  input.setIsNewTaskOpen(false);
+  input.setSelectedTaskId(result.taskId);
+  applySnapshot(result.snapshot, input);
+}
+
+export function useDraftActions(
+  input: UseTaskPlanningActionsInput,
+  runBusy: (
+    input: UseTaskPlanningActionsInput,
+    actionKey: string,
+    action: () => Promise<void>,
+  ) => Promise<void>,
+) {
+  const updateDraft = (key: keyof DraftTaskInput, value: string) => {
+    input.setDraft((previous) => {
+      if (key === 'attachments') return previous;
+      if (key !== 'repository') return { ...previous, [key]: value };
+      return { ...emptyDraft, repository: value };
+    });
+    if (key !== 'repository') return;
+    clearSelectedTask(input);
+    input.setIsNewTaskOpen(false);
+  };
+  const openNewTask = () => {
+    resetDraft(input);
+    clearSelectedTask(input);
+    input.setIsNewTaskOpen(true);
+  };
+  const createTask = async (event: FormEvent) => {
+    event.preventDefault();
+    const body = input.draft.body.trim();
+    if ((!body && input.draft.attachments.length === 0) || input.busyAction) {
+      return;
+    }
+    await runBusy(input, 'create', () => runCreateTask(input, body));
+  };
+  return { createTask, openNewTask, updateDraft };
+}

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -1,4 +1,3 @@
-import type { FormEvent } from 'react';
 import type {
   TaskAgentStageRecord,
   TaskFlowAction,
@@ -9,27 +8,17 @@ import type {
   UseTaskPlanningActionsInput,
 } from './actionTypes';
 import {
-  type CreateTaskResponse,
-  type DraftTaskInput,
-  emptyDraft,
   type ManualCompleteResponse,
-  mergeSnapshotIntoList,
   readJsonResponse,
   type SubmitTaskMessageResponse,
 } from './api';
 import { type FlowActionParts, runFlowAction } from './flowActionRouter';
-
-function getErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function applySnapshot(
-  snapshot: TaskPlanningSnapshot,
-  input: Pick<UseTaskPlanningActionsInput, 'setSelectedSnapshot' | 'setTasks'>,
-) {
-  input.setSelectedSnapshot(snapshot);
-  input.setTasks((previous) => mergeSnapshotIntoList(previous, snapshot));
-}
+import {
+  applySnapshot,
+  buildMultipartPayload,
+  getErrorMessage,
+} from './taskPlanningActionUtils';
+import { useDraftActions } from './useTaskDraftActions';
 
 async function runBusy(
   input: UseTaskPlanningActionsInput,
@@ -45,68 +34,6 @@ async function runBusy(
   } finally {
     input.setBusyAction(null);
   }
-}
-
-function buildCreatePayload(input: UseTaskPlanningActionsInput, body: string) {
-  const payload: Record<string, string | boolean> = { body, autoRun: true };
-  if (input.draft.executionMode === 'autonomous') {
-    payload.executionMode = 'autonomous';
-  }
-  if (input.selectedRepository) {
-    payload.owner = input.selectedRepository.owner;
-    payload.repo = input.selectedRepository.repo;
-  }
-  return payload;
-}
-
-async function postCreateTask(payload: Record<string, string | boolean>) {
-  const response = await fetch('/api/tasks', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  return readJsonResponse<CreateTaskResponse>(response);
-}
-
-function useDraftActions(input: UseTaskPlanningActionsInput) {
-  const updateDraft = (key: keyof DraftTaskInput, value: string) => {
-    input.setDraft((previous) => {
-      if (key !== 'repository') return { ...previous, [key]: value };
-      return { ...emptyDraft, repository: value };
-    });
-    if (key === 'repository') {
-      input.setSelectedTaskId(null);
-      input.setSelectedSnapshot(null);
-      input.setMessageBody('');
-      input.setIsNewTaskOpen(false);
-    }
-  };
-  const openNewTask = () => {
-    input.setDraft((previous) => ({
-      ...emptyDraft,
-      repository: previous.repository,
-    }));
-    input.setSelectedTaskId(null);
-    input.setSelectedSnapshot(null);
-    input.setMessageBody('');
-    input.setIsNewTaskOpen(true);
-  };
-  const createTask = async (event: FormEvent) => {
-    event.preventDefault();
-    const body = input.draft.body.trim();
-    if (!body || input.busyAction) return;
-    await runBusy(input, 'create', async () => {
-      const result = await postCreateTask(buildCreatePayload(input, body));
-      input.setDraft((previous) => ({
-        ...emptyDraft,
-        repository: previous.repository,
-      }));
-      input.setIsNewTaskOpen(false);
-      input.setSelectedTaskId(result.taskId);
-      applySnapshot(result.snapshot, input);
-    });
-  };
-  return { createTask, openNewTask, updateDraft };
 }
 
 function useRepositoryActions(input: UseTaskPlanningActionsInput) {
@@ -135,6 +62,7 @@ function useSelectionActions(input: UseTaskPlanningActionsInput) {
     input.setSelectedTaskId(snapshot.task.taskId);
     input.setSelectedSnapshot(snapshot);
     input.setMessageBody('');
+    input.setMessageAttachments([]);
   };
   return { selectTask };
 }
@@ -169,21 +97,48 @@ function useMessageActions(
   api: ReturnType<typeof useSelectedTaskApi>,
 ) {
   const sendTaskMessage = async (body: string) => {
+    const attachments = input.messageAttachments;
     if (!input.selected || input.busyAction) return;
     await runBusy(input, 'message', async () => {
-      const result = await api.postSelected<SubmitTaskMessageResponse>(
-        'messages',
-        { body, autoRun: true },
-      );
+      const payload = { body, autoRun: true };
+      const result =
+        attachments.length > 0
+          ? await postSelectedMultipart<SubmitTaskMessageResponse>(
+              input,
+              'messages',
+              payload,
+              attachments,
+            )
+          : await api.postSelected<SubmitTaskMessageResponse>(
+              'messages',
+              payload,
+            );
       input.setMessageBody('');
+      input.setMessageAttachments([]);
       await api.updateFromOptionalSnapshot(result.snapshot);
     });
   };
   const submitMessageFromFlow = async () => {
     const body = input.messageBody.trim();
-    if (body) await sendTaskMessage(body);
+    if (body || input.messageAttachments.length > 0) {
+      await sendTaskMessage(body);
+    }
   };
   return { sendTaskMessage, submitMessageFromFlow };
+}
+
+async function postSelectedMultipart<T>(
+  input: UseTaskPlanningActionsInput,
+  path: string,
+  payload: Record<string, string | boolean>,
+  attachments: File[],
+): Promise<T> {
+  if (!input.selected) throw new Error('未选择 Task');
+  const response = await fetch(selectedTaskApiPath(input, path), {
+    method: 'POST',
+    body: buildMultipartPayload(payload, attachments),
+  });
+  return readJsonResponse<T>(response);
 }
 
 function useSimpleFlowActions(
@@ -290,7 +245,7 @@ function useFlowActions(input: UseTaskPlanningActionsInput) {
 
 export function useTaskPlanningActions(input: UseTaskPlanningActionsInput) {
   return {
-    ...useDraftActions(input),
+    ...useDraftActions(input, runBusy),
     ...useRepositoryActions(input),
     ...useSelectionActions(input),
     ...useFlowActions(input),

--- a/packages/along-web/src/task-planning/useTaskPlanningController.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningController.ts
@@ -26,6 +26,7 @@ function usePlanningBaseState() {
   const taskState = useTaskState();
   const repositoryState = useRepositories();
   const [messageBody, setMessageBody] = useState('');
+  const [messageAttachments, setMessageAttachments] = useState<File[]>([]);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [repositoriesRefreshing, setRepositoriesRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -34,6 +35,8 @@ function usePlanningBaseState() {
     repositoryState,
     messageBody,
     setMessageBody,
+    messageAttachments,
+    setMessageAttachments,
     busyAction,
     setBusyAction,
     repositoriesRefreshing,
@@ -123,6 +126,7 @@ function usePlanningActions(
     selectedRepository: derived.selectedRepository,
     draft: base.repositoryState.draft,
     messageBody: base.messageBody,
+    messageAttachments: base.messageAttachments,
     busyAction: base.busyAction,
     repositoriesRefreshing: base.repositoriesRefreshing,
     ...flowFlags,
@@ -132,6 +136,7 @@ function usePlanningActions(
     setIsNewTaskOpen: base.taskState.setIsNewTaskOpen,
     setSelectedSnapshot: base.taskState.setSelectedSnapshot,
     setMessageBody: base.setMessageBody,
+    setMessageAttachments: base.setMessageAttachments,
     setBusyAction: base.setBusyAction,
     setRepositoriesRefreshing: base.setRepositoriesRefreshing,
     setError: base.setError,
@@ -151,11 +156,13 @@ export function useTaskPlanningController() {
     ...base.repositoryState,
     ...derived,
     messageBody: base.messageBody,
+    messageAttachments: base.messageAttachments,
     loading: loadState.loading,
     busyAction: base.busyAction,
     repositoriesRefreshing: base.repositoriesRefreshing,
     error: base.error,
     setMessageBody: base.setMessageBody,
+    setMessageAttachments: base.setMessageAttachments,
     ...actions,
   };
 }

--- a/packages/along-web/src/types-task.ts
+++ b/packages/along-web/src/types-task.ts
@@ -22,6 +22,21 @@ export type TaskArtifactType =
   | 'approval'
   | 'agent_result';
 
+export interface TaskAttachmentRecord {
+  attachmentId: string;
+  taskId: string;
+  threadId: string;
+  artifactId: string;
+  kind: 'image';
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  relativePath: string;
+  createdAt: string;
+  missing?: boolean;
+}
+
 export interface TaskItemRecord {
   taskId: string;
   title: string;
@@ -64,6 +79,7 @@ export interface TaskArtifactRecord {
   role: 'user' | 'agent' | 'system';
   body: string;
   metadata: Record<string, unknown>;
+  attachments: TaskAttachmentRecord[];
   createdAt: string;
 }
 

--- a/packages/along/src/core/db-schema.ts
+++ b/packages/along/src/core/db-schema.ts
@@ -71,6 +71,16 @@ const TABLES = [
     FOREIGN KEY(task_id) REFERENCES task_items(task_id) ON DELETE CASCADE,
     FOREIGN KEY(thread_id) REFERENCES task_threads(thread_id) ON DELETE CASCADE
   );`,
+  `CREATE TABLE IF NOT EXISTS task_attachments (
+    attachment_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL, thread_id TEXT NOT NULL, artifact_id TEXT NOT NULL,
+    kind TEXT NOT NULL, original_name TEXT NOT NULL, mime_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL, sha256 TEXT NOT NULL, relative_path TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(task_id) REFERENCES task_items(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(thread_id) REFERENCES task_threads(thread_id) ON DELETE CASCADE,
+    FOREIGN KEY(artifact_id) REFERENCES task_artifacts(artifact_id) ON DELETE CASCADE
+  );`,
   `CREATE TABLE IF NOT EXISTS task_plan_revisions (
     plan_id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL, thread_id TEXT NOT NULL, version INTEGER NOT NULL,
@@ -140,6 +150,8 @@ const INDEXES = [
   'CREATE INDEX IF NOT EXISTS idx_task_items_status ON task_items(status, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_task_threads_task ON task_threads(task_id, purpose, status)',
   'CREATE INDEX IF NOT EXISTS idx_task_artifacts_thread ON task_artifacts(thread_id, created_at)',
+  'CREATE INDEX IF NOT EXISTS idx_task_attachments_artifact ON task_attachments(artifact_id, created_at)',
+  'CREATE INDEX IF NOT EXISTS idx_task_attachments_task ON task_attachments(task_id, attachment_id)',
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_task_plan_revisions_active_thread ON task_plan_revisions(thread_id) WHERE status = 'active'",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_task_feedback_rounds_open_thread ON task_feedback_rounds(thread_id) WHERE status IN ('open','processing','stale_partial')",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_task_agent_runs_active ON task_agent_runs(thread_id, agent_id, provider) WHERE status = 'running'",

--- a/packages/along/src/domain/task-attachment-read.ts
+++ b/packages/along/src/domain/task-attachment-read.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import { getDb } from '../core/db';
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
+import {
+  getTaskAttachmentAbsolutePath,
+  type InputImageAttachment,
+  mapTaskAttachment,
+  type ReadTaskAttachmentFileOutput,
+  type TaskAttachmentRow,
+  type TaskAttachmentTaskFields,
+} from './task-attachments';
+
+interface TaskAttachmentTaskRow {
+  task_id: string;
+  repo_owner: string | null;
+  repo_name: string | null;
+}
+
+function readTaskRow(taskId: string): Result<TaskAttachmentTaskFields | null> {
+  const dbRes = getDb();
+  if (!dbRes.success) return failure(dbRes.error);
+  try {
+    const row = dbRes.data
+      .prepare(
+        'SELECT task_id, repo_owner, repo_name FROM task_items WHERE task_id = ?',
+      )
+      .get(taskId) as TaskAttachmentTaskRow | null;
+    return success(
+      row
+        ? {
+            taskId: row.task_id,
+            repoOwner: row.repo_owner || undefined,
+            repoName: row.repo_name || undefined,
+          }
+        : null,
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`读取 Task 附件目录失败: ${message}`);
+  }
+}
+
+function mapInputImageRows(input: {
+  rows: TaskAttachmentRow[];
+  task: TaskAttachmentTaskFields;
+}): Result<InputImageAttachment[]> {
+  const images: InputImageAttachment[] = [];
+  for (const row of input.rows) {
+    const absolutePathRes = getTaskAttachmentAbsolutePath(
+      input.task,
+      row.relative_path,
+    );
+    if (!absolutePathRes.success) return failure(absolutePathRes.error);
+    if (!fs.existsSync(absolutePathRes.data)) {
+      return failure(`图片附件文件缺失: ${row.original_name}`);
+    }
+    images.push({
+      attachmentId: row.attachment_id,
+      originalName: row.original_name,
+      mimeType: row.mime_type,
+      absolutePath: absolutePathRes.data,
+    });
+  }
+  return success(images);
+}
+
+export function resolveInputImageAttachments(input: {
+  taskId: string;
+  inputArtifactIds?: string[];
+}): Result<InputImageAttachment[]> {
+  const artifactIds = input.inputArtifactIds || [];
+  if (artifactIds.length === 0) return success([]);
+
+  const taskRes = readTaskRow(input.taskId);
+  if (!taskRes.success) return failure(taskRes.error);
+  if (!taskRes.data) return failure(`Task 不存在: ${input.taskId}`);
+
+  const dbRes = getDb();
+  if (!dbRes.success) return failure(dbRes.error);
+  try {
+    const placeholders = artifactIds.map(() => '?').join(',');
+    const rows = dbRes.data
+      .prepare(
+        `
+          SELECT * FROM task_attachments
+          WHERE task_id = ? AND artifact_id IN (${placeholders})
+          ORDER BY created_at ASC
+        `,
+      )
+      .all(input.taskId, ...artifactIds) as TaskAttachmentRow[];
+    return mapInputImageRows({ rows, task: taskRes.data });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`读取输入图片附件失败: ${message}`);
+  }
+}
+
+export function readTaskAttachmentFile(input: {
+  taskId: string;
+  attachmentId: string;
+}): Result<ReadTaskAttachmentFileOutput> {
+  const dbRes = getDb();
+  if (!dbRes.success) return failure(dbRes.error);
+  try {
+    const row = dbRes.data
+      .prepare('SELECT * FROM task_attachments WHERE attachment_id = ?')
+      .get(input.attachmentId) as TaskAttachmentRow | null;
+    if (!row) return failure('附件不存在');
+    if (row.task_id !== input.taskId) return failure('附件不属于当前 Task');
+
+    return readTaskAttachmentFileForRow(input.taskId, row);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`读取图片附件失败: ${message}`);
+  }
+}
+
+function readTaskAttachmentFileForRow(
+  taskId: string,
+  row: TaskAttachmentRow,
+): Result<ReadTaskAttachmentFileOutput> {
+  const taskRes = readTaskRow(taskId);
+  if (!taskRes.success) return failure(taskRes.error);
+  if (!taskRes.data) return failure(`Task 不存在: ${taskId}`);
+  const absolutePathRes = getTaskAttachmentAbsolutePath(
+    taskRes.data,
+    row.relative_path,
+  );
+  if (!absolutePathRes.success) return failure(absolutePathRes.error);
+  if (!fs.existsSync(absolutePathRes.data)) return failure('附件文件不存在');
+  return success({
+    attachment: mapTaskAttachment(row, taskRes.data),
+    absolutePath: absolutePathRes.data,
+  });
+}

--- a/packages/along/src/domain/task-attachments.test.ts
+++ b/packages/along/src/domain/task-attachments.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testPaths = vi.hoisted(() => ({
+  root: '/tmp/along-task-attachments-test',
+}));
+
+vi.mock('../core/config', () => ({
+  config: {
+    USER_ALONG_DIR: testPaths.root,
+    getTaskDir: (owner: string, repo: string, taskId: string) =>
+      `${testPaths.root}/${owner}/${repo}/tasks/${taskId}`,
+  },
+}));
+
+vi.mock('../core/db', () => ({
+  getDb: () => ({ success: false, error: 'db not available in unit test' }),
+}));
+
+import {
+  getTaskAttachmentAbsolutePath,
+  prepareTaskImageAttachments,
+} from './task-attachments';
+
+describe('task-attachments', () => {
+  beforeEach(() => {
+    fs.rmSync(testPaths.root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testPaths.root, { recursive: true, force: true });
+  });
+
+  it('准备图片附件时，期望校验并写入 task attachments 目录', () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00]);
+    const result = prepareTaskImageAttachments({
+      task: {
+        taskId: 'task-1',
+        repoOwner: 'ranwawa',
+        repoName: 'along',
+      },
+      uploads: [
+        {
+          originalName: 'screen.png',
+          mimeType: 'image/png',
+          bytes: pngBytes,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      kind: 'image',
+      originalName: 'screen.png',
+      mimeType: 'image/png',
+      sizeBytes: pngBytes.byteLength,
+      relativePath: expect.stringMatching(/^attachments\/att_.+\.png$/),
+    });
+    expect(fs.existsSync(result.data[0].absolutePath)).toBe(true);
+  });
+
+  it('当图片 MIME 与内容不匹配时，期望返回中文错误且不写文件', () => {
+    const result = prepareTaskImageAttachments({
+      task: { taskId: 'task-1' },
+      uploads: [
+        {
+          originalName: 'fake.png',
+          mimeType: 'image/png',
+          bytes: new Uint8Array([0x00, 0x01, 0x02]),
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error).toBe('无法识别图片类型或图片 MIME 与内容不匹配');
+    expect(fs.existsSync(testPaths.root)).toBe(false);
+  });
+
+  it('解析附件路径时，期望拒绝路径穿越', () => {
+    const result = getTaskAttachmentAbsolutePath(
+      { taskId: 'task-1' },
+      '../secret.png',
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error).toBe('附件路径非法');
+  });
+});

--- a/packages/along/src/domain/task-attachments.ts
+++ b/packages/along/src/domain/task-attachments.ts
@@ -1,0 +1,290 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { config } from '../core/config';
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
+
+export const TASK_ATTACHMENT_LIMITS = {
+  maxCount: 6,
+  maxSingleBytes: 10 * 1024 * 1024,
+  maxTotalBytes: 30 * 1024 * 1024,
+} as const;
+
+export const TASK_ATTACHMENT_IMAGE_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const;
+
+type TaskAttachmentImageMimeType =
+  (typeof TASK_ATTACHMENT_IMAGE_MIME_TYPES)[number];
+
+export interface TaskAttachmentUploadInput {
+  originalName: string;
+  mimeType: string;
+  bytes: Uint8Array;
+}
+
+export interface TaskAttachmentRecord {
+  attachmentId: string;
+  taskId: string;
+  threadId: string;
+  artifactId: string;
+  kind: 'image';
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  sha256: string;
+  relativePath: string;
+  createdAt: string;
+  missing?: boolean;
+}
+
+export interface PreparedTaskAttachment {
+  attachmentId: string;
+  kind: 'image';
+  originalName: string;
+  mimeType: TaskAttachmentImageMimeType;
+  sizeBytes: number;
+  sha256: string;
+  relativePath: string;
+  absolutePath: string;
+}
+
+export interface TaskAttachmentRow {
+  attachment_id: string;
+  task_id: string;
+  thread_id: string;
+  artifact_id: string;
+  kind: 'image';
+  original_name: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  relative_path: string;
+  created_at: string;
+}
+
+export interface TaskAttachmentTaskFields {
+  taskId: string;
+  repoOwner?: string;
+  repoName?: string;
+}
+
+export interface InputImageAttachment {
+  attachmentId: string;
+  originalName: string;
+  mimeType: string;
+  absolutePath: string;
+}
+
+export interface ReadTaskAttachmentFileOutput {
+  attachment: TaskAttachmentRecord;
+  absolutePath: string;
+}
+
+const MIME_EXTENSIONS: Record<TaskAttachmentImageMimeType, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+function isImageMimeType(value: string): value is TaskAttachmentImageMimeType {
+  return TASK_ATTACHMENT_IMAGE_MIME_TYPES.includes(
+    value as TaskAttachmentImageMimeType,
+  );
+}
+
+function formatBytes(bytes: number): string {
+  return `${Math.round((bytes / 1024 / 1024) * 10) / 10}MB`;
+}
+
+function generateAttachmentId(): string {
+  return `att_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+function detectImageMimeType(bytes: Uint8Array): string | undefined {
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return 'image/png';
+  }
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return 'image/gif';
+  }
+  const header = Buffer.from(bytes.slice(0, 12)).toString('ascii');
+  if (header.startsWith('RIFF') && header.slice(8, 12) === 'WEBP') {
+    return 'image/webp';
+  }
+  return undefined;
+}
+
+function makePreparedAttachment(input: {
+  upload: TaskAttachmentUploadInput;
+  task: TaskAttachmentTaskFields;
+}): PreparedTaskAttachment {
+  const attachmentId = generateAttachmentId();
+  const mimeType = input.upload.mimeType as TaskAttachmentImageMimeType;
+  const extension = MIME_EXTENSIONS[mimeType];
+  const relativePath = path.join('attachments', `${attachmentId}.${extension}`);
+  const absolutePathRes = getTaskAttachmentAbsolutePath(
+    input.task,
+    relativePath,
+  );
+  if (!absolutePathRes.success) throw new Error(absolutePathRes.error);
+  const tempPath = `${absolutePathRes.data}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tempPath, input.upload.bytes);
+  fs.renameSync(tempPath, absolutePathRes.data);
+  return {
+    attachmentId,
+    kind: 'image',
+    originalName: path.basename(input.upload.originalName || 'image'),
+    mimeType,
+    sizeBytes: input.upload.bytes.byteLength,
+    sha256: crypto
+      .createHash('sha256')
+      .update(input.upload.bytes)
+      .digest('hex'),
+    relativePath,
+    absolutePath: absolutePathRes.data,
+  };
+}
+
+function validateUploads(
+  uploads: TaskAttachmentUploadInput[] | undefined,
+): Result<TaskAttachmentUploadInput[]> {
+  const items = uploads || [];
+  if (items.length > TASK_ATTACHMENT_LIMITS.maxCount) {
+    return failure(`单次最多上传 ${TASK_ATTACHMENT_LIMITS.maxCount} 张图片`);
+  }
+  const totalBytes = items.reduce(
+    (sum, item) => sum + item.bytes.byteLength,
+    0,
+  );
+  if (totalBytes > TASK_ATTACHMENT_LIMITS.maxTotalBytes) {
+    return failure(
+      `单次图片总大小不能超过 ${formatBytes(
+        TASK_ATTACHMENT_LIMITS.maxTotalBytes,
+      )}`,
+    );
+  }
+  for (const item of items) {
+    const size = item.bytes.byteLength;
+    if (size <= 0) return failure('不能上传空图片文件');
+    if (size > TASK_ATTACHMENT_LIMITS.maxSingleBytes) {
+      return failure(
+        `单张图片不能超过 ${formatBytes(
+          TASK_ATTACHMENT_LIMITS.maxSingleBytes,
+        )}`,
+      );
+    }
+    if (!isImageMimeType(item.mimeType)) {
+      return failure('只支持上传 PNG、JPEG、WebP 或 GIF 图片');
+    }
+    const detected = detectImageMimeType(item.bytes);
+    if (!detected || detected !== item.mimeType) {
+      return failure('无法识别图片类型或图片 MIME 与内容不匹配');
+    }
+  }
+  return success(items);
+}
+
+export function getTaskAttachmentBaseDir(
+  task: TaskAttachmentTaskFields,
+): string {
+  if (task.repoOwner && task.repoName) {
+    return config.getTaskDir(task.repoOwner, task.repoName, task.taskId);
+  }
+  return path.join(config.USER_ALONG_DIR, 'tasks', task.taskId);
+}
+
+export function getTaskAttachmentAbsolutePath(
+  task: TaskAttachmentTaskFields,
+  relativePath: string,
+): Result<string> {
+  const baseDir = path.resolve(getTaskAttachmentBaseDir(task));
+  const absolutePath = path.resolve(baseDir, relativePath);
+  if (
+    absolutePath !== baseDir &&
+    !absolutePath.startsWith(`${baseDir}${path.sep}`)
+  ) {
+    return failure('附件路径非法');
+  }
+  return success(absolutePath);
+}
+
+export function mapTaskAttachment(
+  row: TaskAttachmentRow,
+  task: TaskAttachmentTaskFields,
+): TaskAttachmentRecord {
+  const absolutePathRes = getTaskAttachmentAbsolutePath(
+    task,
+    row.relative_path,
+  );
+  const missing =
+    !absolutePathRes.success || !fs.existsSync(absolutePathRes.data);
+  return {
+    attachmentId: row.attachment_id,
+    taskId: row.task_id,
+    threadId: row.thread_id,
+    artifactId: row.artifact_id,
+    kind: 'image',
+    originalName: row.original_name,
+    mimeType: row.mime_type,
+    sizeBytes: row.size_bytes,
+    sha256: row.sha256,
+    relativePath: row.relative_path,
+    createdAt: row.created_at,
+    missing: missing || undefined,
+  };
+}
+
+export function prepareTaskImageAttachments(input: {
+  task: TaskAttachmentTaskFields;
+  uploads?: TaskAttachmentUploadInput[];
+}): Result<PreparedTaskAttachment[]> {
+  const validation = validateUploads(input.uploads);
+  if (!validation.success) return failure(validation.error);
+  if (validation.data.length === 0) return success([]);
+
+  const attachmentsDir = path.join(
+    getTaskAttachmentBaseDir(input.task),
+    'attachments',
+  );
+  const prepared: PreparedTaskAttachment[] = [];
+  try {
+    fs.mkdirSync(attachmentsDir, { recursive: true });
+    for (const upload of validation.data) {
+      prepared.push(makePreparedAttachment({ upload, task: input.task }));
+    }
+    return success(prepared);
+  } catch (error: unknown) {
+    cleanupPreparedTaskAttachments(prepared);
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`保存图片附件失败: ${message}`);
+  }
+}
+
+export function cleanupPreparedTaskAttachments(
+  attachments: PreparedTaskAttachment[],
+) {
+  for (const attachment of attachments) {
+    try {
+      fs.rmSync(attachment.absolutePath, { force: true });
+    } catch {}
+  }
+}

--- a/packages/along/src/domain/task-claude-image-prompt.ts
+++ b/packages/along/src/domain/task-claude-image-prompt.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { InputImageAttachment } from './task-attachments';
+
+type ClaudeImageMimeType =
+  | 'image/png'
+  | 'image/jpeg'
+  | 'image/webp'
+  | 'image/gif';
+
+export type ClaudePrompt = string | AsyncIterable<SDKUserMessage>;
+
+export function buildClaudePrompt(
+  prompt: string,
+  images: InputImageAttachment[],
+): ClaudePrompt {
+  if (images.length === 0) return prompt;
+  const message: SDKUserMessage = {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'text', text: prompt },
+        ...images.map((image) => ({
+          type: 'image' as const,
+          source: {
+            type: 'base64' as const,
+            media_type: image.mimeType as ClaudeImageMimeType,
+            data: readFileSync(image.absolutePath).toString('base64'),
+          },
+        })),
+      ],
+    },
+    parent_tool_use_id: null,
+  };
+  return (async function* () {
+    yield message;
+  })();
+}

--- a/packages/along/src/domain/task-claude-runner.test.ts
+++ b/packages/along/src/domain/task-claude-runner.test.ts
@@ -1,7 +1,13 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy runner tests use large shared mock setup.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const queryMock = vi.hoisted(() => vi.fn());
+const attachmentMocks = vi.hoisted(() => ({
+  resolveInputImageAttachments: vi.fn(),
+}));
 const planningMocks = vi.hoisted(() => ({
   ensureTaskAgentBinding: vi.fn(),
   createTaskAgentRun: vi.fn(),
@@ -14,6 +20,10 @@ const planningMocks = vi.hoisted(() => ({
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: queryMock,
+}));
+
+vi.mock('./task-attachment-read', () => ({
+  resolveInputImageAttachments: attachmentMocks.resolveInputImageAttachments,
 }));
 
 vi.mock('./task-planning', () => ({
@@ -74,6 +84,10 @@ function errorConversation(sessionId: string) {
 describe('task-claude-runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    attachmentMocks.resolveInputImageAttachments.mockReturnValue({
+      success: true,
+      data: [],
+    });
     planningMocks.ensureTaskAgentBinding.mockReturnValue({
       success: true,
       data: {
@@ -164,6 +178,59 @@ describe('task-claude-runner', () => {
       data: undefined,
     });
     queryMock.mockReturnValue(successfulConversation('session-2'));
+  });
+
+  it('当输入 artifact 包含图片时，期望 Claude 收到图文 SDKUserMessage', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'along-claude-'));
+    const imagePath = path.join(tempDir, 'screen.png');
+    writeFileSync(imagePath, 'fake-image');
+    attachmentMocks.resolveInputImageAttachments.mockReturnValueOnce({
+      success: true,
+      data: [
+        {
+          attachmentId: 'att-1',
+          originalName: 'screen.png',
+          mimeType: 'image/png',
+          absolutePath: imagePath,
+        },
+      ],
+    });
+
+    try {
+      const result = await runTaskClaudeTurn({
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        prompt: '看图生成计划',
+        cwd: '/tmp/project',
+        inputArtifactIds: ['art-user'],
+      });
+
+      expect(result.success).toBe(true);
+      const prompt = queryMock.mock.calls[0]?.[0]?.prompt;
+      const messages = [];
+      for await (const message of prompt) messages.push(message);
+      expect(messages[0]).toMatchObject({
+        type: 'user',
+        parent_tool_use_id: null,
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '看图生成计划' },
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/png',
+                data: Buffer.from('fake-image').toString('base64'),
+              },
+            },
+          ],
+        },
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('当存在 provider session 时，期望下一轮 Claude 调用使用 resume', async () => {

--- a/packages/along/src/domain/task-claude-runner.ts
+++ b/packages/along/src/domain/task-claude-runner.ts
@@ -19,6 +19,10 @@ import {
   startTaskAgentRunHeartbeat,
 } from './task-agent-run-lifecycle';
 import {
+  buildClaudePrompt,
+  type ClaudePrompt,
+} from './task-claude-image-prompt';
+import {
   getAssistantMessageText,
   getResultError,
   getResultStructuredOutput,
@@ -31,6 +35,7 @@ import {
   type TaskAgentRunRecord,
   updateTaskAgentProviderSession,
 } from './task-planning';
+import { resolveAndRecordInputImages } from './task-runner-images';
 
 const PROVIDER = 'claude';
 
@@ -93,17 +98,19 @@ async function runStartedClaudeTurn(
   prompt: string,
   started: StartedTaskAgentRun,
 ): Promise<Result<RunTaskClaudeTurnOutput>> {
-  const stopHeartbeat = startTaskAgentRunHeartbeat(
-    started.progressContext,
-    started.usedResume
-      ? 'Agent 已启动，正在恢复上次会话。'
-      : 'Agent 已启动，正在准备任务上下文。',
-    input.cwd,
-  );
+  const stopHeartbeat = startClaudeHeartbeat(started, input.cwd);
 
   try {
+    const promptRes = await prepareClaudePrompt(input, prompt, started);
+    if (!promptRes.success) {
+      return failClaudeTurn(
+        started.progressContext,
+        promptRes.error,
+        started.binding.providerSessionId,
+      );
+    }
     const conversation = query({
-      prompt,
+      prompt: promptRes.data,
       options: buildOptions(input, started.binding.providerSessionId),
     });
     const stateRes = await collectClaudeConversation(
@@ -122,6 +129,32 @@ async function runStartedClaudeTurn(
   } finally {
     stopHeartbeat();
   }
+}
+
+function startClaudeHeartbeat(started: StartedTaskAgentRun, cwd: string) {
+  return startTaskAgentRunHeartbeat(
+    started.progressContext,
+    started.usedResume
+      ? 'Agent 已启动，正在恢复上次会话。'
+      : 'Agent 已启动，正在准备任务上下文。',
+    cwd,
+  );
+}
+
+async function prepareClaudePrompt(
+  input: RunTaskClaudeTurnInput,
+  prompt: string,
+  started: StartedTaskAgentRun,
+): Promise<Result<ClaudePrompt>> {
+  const imagesRes = await resolveAndRecordInputImages({
+    taskId: input.taskId,
+    inputArtifactIds: input.inputArtifactIds,
+    context: started.progressContext,
+    summary: '本轮传入 {count} 张用户上传图片。',
+  });
+  return imagesRes.success
+    ? success(buildClaudePrompt(prompt, imagesRes.data))
+    : failure(imagesRes.error);
 }
 
 async function collectClaudeConversation(

--- a/packages/along/src/domain/task-codex-runner.test.ts
+++ b/packages/along/src/domain/task-codex-runner.test.ts
@@ -11,6 +11,9 @@ const planningMocks = vi.hoisted(() => ({
   recordTaskAgentResult: vi.fn(),
   updateTaskAgentProviderSession: vi.fn(),
 }));
+const attachmentMocks = vi.hoisted(() => ({
+  resolveInputImageAttachments: vi.fn(),
+}));
 
 vi.mock('./task-planning', () => ({
   AGENT_RUN_STATUS: {
@@ -38,11 +41,19 @@ vi.mock('./task-planning', () => ({
   updateTaskAgentProviderSession: planningMocks.updateTaskAgentProviderSession,
 }));
 
+vi.mock('./task-attachment-read', () => ({
+  resolveInputImageAttachments: attachmentMocks.resolveInputImageAttachments,
+}));
+
 import { runTaskCodexTurn } from './task-codex-runner';
 
 describe('task-codex-runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    attachmentMocks.resolveInputImageAttachments.mockReturnValue({
+      success: true,
+      data: [],
+    });
     planningMocks.ensureTaskAgentBinding.mockReturnValue({
       success: true,
       data: {
@@ -128,6 +139,60 @@ describe('task-codex-runner', () => {
       success: true,
       data: undefined,
     });
+  });
+
+  it('当输入 artifact 包含图片时，期望 Codex 收到 text 和 local_image', async () => {
+    attachmentMocks.resolveInputImageAttachments.mockReturnValueOnce({
+      success: true,
+      data: [
+        {
+          attachmentId: 'att-1',
+          originalName: 'screen.png',
+          mimeType: 'image/png',
+          absolutePath: '/tmp/screen.png',
+        },
+      ],
+    });
+    const thread = {
+      id: 'codex-thread-1',
+      run: vi.fn().mockResolvedValue({
+        finalResponse: '完成',
+        items: [],
+        usage: null,
+      }),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const result = await runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '看图生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+      inputArtifactIds: ['art-user'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(thread.run).toHaveBeenCalledWith(
+      [
+        { type: 'text', text: '看图生成计划' },
+        { type: 'local_image', path: '/tmp/screen.png' },
+      ],
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          type: 'input_images',
+          count: 1,
+          files: ['screen.png'],
+        }),
+      }),
+    );
   });
 
   it('使用 Codex SDK 新建 thread 并保存结构化输出', async () => {

--- a/packages/along/src/domain/task-codex-runner.ts
+++ b/packages/along/src/domain/task-codex-runner.ts
@@ -4,7 +4,6 @@ import { failure, success } from '../core/result';
 import {
   type TaskAgentProgressContext,
   writeTaskAgentProgress,
-  writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
   finishTaskAgentSuccess,
@@ -18,6 +17,7 @@ import type {
   RunTaskClaudeTurnInput,
   RunTaskClaudeTurnOutput,
 } from './task-claude-runner';
+import { writeCodexTurnSessionEvents } from './task-codex-session-events';
 import {
   buildThreadOptions,
   createDefaultCodexClient,
@@ -31,6 +31,11 @@ import {
   TASK_AGENT_PROGRESS_PHASE,
   updateTaskAgentProviderSession,
 } from './task-planning';
+import {
+  buildLocalImagePromptInput,
+  type LocalImagePromptItem,
+  resolveAndRecordInputImages,
+} from './task-runner-images';
 
 const PROVIDER = 'codex';
 
@@ -40,10 +45,14 @@ export interface TaskCodexTurn {
   usage: unknown;
 }
 
+export type TaskCodexInputItem =
+  | { type: 'text'; text: string }
+  | { type: 'local_image'; path: string };
+
 export interface TaskCodexThread {
   readonly id: string | null;
   run(
-    input: string,
+    input: string | TaskCodexInputItem[],
     options?: { outputSchema?: unknown; signal?: AbortSignal },
   ): Promise<TaskCodexTurn>;
 }
@@ -87,17 +96,14 @@ async function runStartedCodexTurn(
   const outputSchema = getCodexOutputSchema(input);
   let thread: TaskCodexThread | undefined;
   let latestThreadId = binding.providerSessionId;
-  const stopHeartbeat = startTaskAgentRunHeartbeat(
-    progressContext,
-    usedResume
-      ? 'Agent 已启动，正在恢复 Codex thread。'
-      : 'Agent 已启动，正在创建 Codex thread。',
-    input.cwd,
-  );
+  const stopHeartbeat = startCodexHeartbeat(started, input.cwd);
 
   try {
+    const promptRes = await prepareCodexPrompt(input, prompt, progressContext);
+    if (!promptRes.success)
+      return failCodexTurn(progressContext, promptRes.error, latestThreadId);
     thread = openCodexThread(input, progressContext, binding.providerSessionId);
-    const turn = await runCodexPrompt(thread, prompt, outputSchema);
+    const turn = await runCodexPrompt(thread, promptRes.data, outputSchema);
     latestThreadId = thread.id || binding.providerSessionId;
     writeCodexTurnSessionEvents(progressContext, turn);
     return completeCodexTurn(
@@ -115,24 +121,30 @@ async function runStartedCodexTurn(
   }
 }
 
-function writeCodexTurnSessionEvents(
+function startCodexHeartbeat(started: StartedTaskAgentRun, cwd: string) {
+  return startTaskAgentRunHeartbeat(
+    started.progressContext,
+    started.usedResume
+      ? 'Agent 已启动，正在恢复 Codex thread。'
+      : 'Agent 已启动，正在创建 Codex thread。',
+    cwd,
+  );
+}
+
+async function prepareCodexPrompt(
+  input: RunTaskCodexTurnInput,
+  prompt: string,
   context: TaskAgentProgressContext,
-  turn: TaskCodexTurn,
-) {
-  if (turn.finalResponse.trim()) {
-    writeTaskAgentSessionEvent(context, 'agent', 'output', turn.finalResponse, {
-      type: 'final_response',
-    });
-  }
-  if (turn.items.length > 0) {
-    writeTaskAgentSessionEvent(
-      context,
-      'tool',
-      'message',
-      `Codex 返回 ${turn.items.length} 条会话 item。`,
-      { type: 'items', count: turn.items.length },
-    );
-  }
+): Promise<Result<string | LocalImagePromptItem[]>> {
+  const imagesRes = await resolveAndRecordInputImages({
+    taskId: input.taskId,
+    inputArtifactIds: input.inputArtifactIds,
+    context,
+    summary: '本轮传入 {count} 张用户上传图片。',
+  });
+  return imagesRes.success
+    ? success(buildLocalImagePromptInput(prompt, imagesRes.data))
+    : failure(imagesRes.error);
 }
 
 function failCodexTurn(
@@ -184,7 +196,7 @@ function openCodexThread(
 
 async function runCodexPrompt(
   thread: TaskCodexThread,
-  prompt: string,
+  prompt: string | TaskCodexInputItem[],
   outputSchema: unknown,
 ): Promise<TaskCodexTurn> {
   const timeoutMs = readCodexTurnTimeoutMs();
@@ -207,7 +219,7 @@ async function runCodexPrompt(
 
 async function runCodexThreadWithTimeout(
   thread: TaskCodexThread,
-  prompt: string,
+  prompt: string | TaskCodexInputItem[],
   outputSchema: unknown,
   abortController: AbortController,
   timeout: ReturnType<typeof setTimeout>,

--- a/packages/along/src/domain/task-codex-session-events.ts
+++ b/packages/along/src/domain/task-codex-session-events.ts
@@ -1,0 +1,23 @@
+import type { TaskAgentProgressContext } from './task-agent-progress';
+import { writeTaskAgentSessionEvent } from './task-agent-progress';
+import type { TaskCodexTurn } from './task-codex-runner';
+
+export function writeCodexTurnSessionEvents(
+  context: TaskAgentProgressContext,
+  turn: TaskCodexTurn,
+) {
+  if (turn.finalResponse.trim()) {
+    writeTaskAgentSessionEvent(context, 'agent', 'output', turn.finalResponse, {
+      type: 'final_response',
+    });
+  }
+  if (turn.items.length > 0) {
+    writeTaskAgentSessionEvent(
+      context,
+      'tool',
+      'message',
+      `Codex 返回 ${turn.items.length} 条会话 item。`,
+      { type: 'items', count: turn.items.length },
+    );
+  }
+}

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -6,6 +6,15 @@ import { getDb } from '../core/db';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
 import {
+  cleanupPreparedTaskAttachments,
+  mapTaskAttachment,
+  type PreparedTaskAttachment,
+  prepareTaskImageAttachments,
+  type TaskAttachmentRecord,
+  type TaskAttachmentRow,
+  type TaskAttachmentUploadInput,
+} from './task-attachments';
+import {
   areImplementationStepsApproved,
   findImplementationStepsApprovalArtifact,
   findImplementationStepsArtifact,
@@ -178,6 +187,7 @@ export interface TaskArtifactRecord {
   role: ArtifactRole;
   body: string;
   metadata: Record<string, unknown>;
+  attachments: TaskAttachmentRecord[];
   createdAt: string;
 }
 
@@ -390,6 +400,7 @@ export interface CreatePlanningTaskInput {
   repoName?: string;
   cwd?: string;
   executionMode?: TaskExecutionMode;
+  attachments?: TaskAttachmentUploadInput[];
 }
 
 export interface UpdatePlanningTaskTitleInput {
@@ -400,6 +411,7 @@ export interface UpdatePlanningTaskTitleInput {
 export interface SubmitTaskMessageInput {
   taskId: string;
   body: string;
+  attachments?: TaskAttachmentUploadInput[];
 }
 
 export interface PublishTaskPlanInput {
@@ -728,6 +740,7 @@ function mapArtifact(row: TaskArtifactRow): TaskArtifactRecord {
     role: row.role,
     body: row.body,
     metadata: parseMetadata(row.metadata),
+    attachments: [],
     createdAt: row.created_at,
   };
 }
@@ -1832,25 +1845,72 @@ function insertArtifact(input: {
     role: input.role,
     body: input.body,
     metadata: input.metadata || {},
+    attachments: [],
     createdAt: input.createdAt,
   };
+}
+
+function insertTaskAttachmentRows(input: {
+  taskId: string;
+  threadId: string;
+  artifactId: string;
+  attachments: PreparedTaskAttachment[];
+  createdAt: string;
+}) {
+  const dbRes = getDb();
+  if (!dbRes.success) throw new Error(dbRes.error);
+  const statement = dbRes.data.prepare(
+    `
+      INSERT INTO task_attachments (
+        attachment_id, task_id, thread_id, artifact_id, kind, original_name,
+        mime_type, size_bytes, sha256, relative_path, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+  );
+  for (const attachment of input.attachments) {
+    statement.run(
+      attachment.attachmentId,
+      input.taskId,
+      input.threadId,
+      input.artifactId,
+      attachment.kind,
+      attachment.originalName,
+      attachment.mimeType,
+      attachment.sizeBytes,
+      attachment.sha256,
+      attachment.relativePath,
+      input.createdAt,
+    );
+  }
 }
 
 export function createPlanningTask(
   input: CreatePlanningTaskInput,
 ): Result<TaskPlanningSnapshot> {
   const title = input.title.trim();
-  const body = input.body.trim();
+  const body =
+    input.body.trim() ||
+    (input.attachments?.length ? '（用户上传了图片）' : '');
   if (!title) return failure('Task 标题不能为空');
   if (!body) return failure('Task 内容不能为空');
 
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
   const db = dbRes.data;
+  const taskId = generateId('task');
+  const threadId = generateId('thread');
+  const preparedAttachmentsRes = prepareTaskImageAttachments({
+    task: {
+      taskId,
+      repoOwner: input.repoOwner,
+      repoName: input.repoName,
+    },
+    uploads: input.attachments,
+  });
+  if (!preparedAttachmentsRes.success) return preparedAttachmentsRes;
+  const preparedAttachments = preparedAttachmentsRes.data;
 
   try {
-    const taskId = generateId('task');
-    const threadId = generateId('thread');
     const now = iso_timestamp();
 
     const txn = db.transaction(() => {
@@ -1904,7 +1964,7 @@ export function createPlanningTask(
         now,
       );
 
-      insertArtifact({
+      const artifact = insertArtifact({
         taskId,
         threadId,
         type: ARTIFACT_TYPE.USER_MESSAGE,
@@ -1915,7 +1975,15 @@ export function createPlanningTask(
           repoOwner: input.repoOwner,
           repoName: input.repoName,
           cwd: input.cwd,
+          attachmentCount: preparedAttachments.length,
         },
+        createdAt: now,
+      });
+      insertTaskAttachmentRows({
+        taskId,
+        threadId,
+        artifactId: artifact.artifactId,
+        attachments: preparedAttachments,
         createdAt: now,
       });
     });
@@ -1926,6 +1994,7 @@ export function createPlanningTask(
       ? success(snapshot.data)
       : failure('创建 Task 后读取快照失败');
   } catch (error: unknown) {
+    cleanupPreparedTaskAttachments(preparedAttachments);
     const message = error instanceof Error ? error.message : String(error);
     return failure(`创建 Task 失败: ${message}`);
   }
@@ -2038,7 +2107,19 @@ export function readTaskPlanningSnapshot(
     const thread = mapThread(threadRow);
     const currentPlan = currentPlanRow ? mapPlan(currentPlanRow) : null;
     const openRound = openRoundRow ? mapRound(openRoundRow) : null;
-    const artifacts = artifactRows.map(mapArtifact);
+    const attachmentRows = db
+      .prepare(
+        'SELECT * FROM task_attachments WHERE thread_id = ? ORDER BY created_at ASC',
+      )
+      .all(threadRow.thread_id) as TaskAttachmentRow[];
+    const attachmentsByArtifact = groupAttachmentsByArtifact(
+      attachmentRows,
+      task,
+    );
+    const artifacts = artifactRows.map((row) => ({
+      ...mapArtifact(row),
+      attachments: attachmentsByArtifact.get(row.artifact_id) || [],
+    }));
     const plans = planRows.map(mapPlan);
     const agentBindings = bindingRows.map(mapBinding);
     const agentRuns = runRows.map(mapRun);
@@ -2073,6 +2154,19 @@ export function readTaskPlanningSnapshot(
     const message = error instanceof Error ? error.message : String(error);
     return failure(`读取 Task Planning 快照失败: ${message}`);
   }
+}
+
+function groupAttachmentsByArtifact(
+  rows: TaskAttachmentRow[],
+  task: TaskItemRecord,
+): Map<string, TaskAttachmentRecord[]> {
+  const grouped = new Map<string, TaskAttachmentRecord[]>();
+  for (const row of rows) {
+    const existing = grouped.get(row.artifact_id) || [];
+    existing.push(mapTaskAttachment(row, task));
+    grouped.set(row.artifact_id, existing);
+  }
+  return grouped;
 }
 
 export function listTaskPlanningSnapshots(
@@ -2124,7 +2218,9 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
   const db = dbRes.data;
-  const body = input.body.trim();
+  const body =
+    input.body.trim() ||
+    (input.attachments?.length ? '（用户上传了图片）' : '');
   if (!body) return failure('用户消息不能为空');
 
   const threadRes = getActiveThreadRow(input.taskId);
@@ -2132,10 +2228,11 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
   const thread = threadRes.data;
   if (!thread)
     return failure(`Task 不存在或缺少 active thread: ${input.taskId}`);
+  const taskRow = db
+    .prepare('SELECT * FROM task_items WHERE task_id = ?')
+    .get(input.taskId) as TaskItemRow | null;
+  if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
   if (thread.status === THREAD_STATUS.APPROVED) {
-    const taskRow = db
-      .prepare('SELECT * FROM task_items WHERE task_id = ?')
-      .get(input.taskId) as TaskItemRow | null;
     if (
       taskRow?.status !== TASK_STATUS.DELIVERED &&
       taskRow?.status !== TASK_STATUS.COMPLETED
@@ -2143,6 +2240,16 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
       return failure('当前 Planning 已批准，不能继续提交反馈');
     }
   }
+  const preparedAttachmentsRes = prepareTaskImageAttachments({
+    task: {
+      taskId: thread.task_id,
+      repoOwner: taskRow.repo_owner || undefined,
+      repoName: taskRow.repo_name || undefined,
+    },
+    uploads: input.attachments,
+  });
+  if (!preparedAttachmentsRes.success) return preparedAttachmentsRes;
+  const preparedAttachments = preparedAttachmentsRes.data;
 
   try {
     const now = iso_timestamp();
@@ -2157,8 +2264,22 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
         role: ARTIFACT_ROLE.USER,
         body,
         metadata: thread.current_plan_id
-          ? { kind: 'planning_feedback', basedOnPlanId: thread.current_plan_id }
-          : { kind: 'additional_context' },
+          ? {
+              kind: 'planning_feedback',
+              basedOnPlanId: thread.current_plan_id,
+              attachmentCount: preparedAttachments.length,
+            }
+          : {
+              kind: 'additional_context',
+              attachmentCount: preparedAttachments.length,
+            },
+        createdAt: now,
+      });
+      insertTaskAttachmentRows({
+        taskId: thread.task_id,
+        threadId: thread.thread_id,
+        artifactId: createdArtifact.artifactId,
+        attachments: preparedAttachments,
         createdAt: now,
       });
 
@@ -2261,6 +2382,7 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
     if (!createdArtifact) return failure('提交消息后缺少 artifact');
     return success({ artifact: createdArtifact, round: roundResult });
   } catch (error: unknown) {
+    cleanupPreparedTaskAttachments(preparedAttachments);
     const message = error instanceof Error ? error.message : String(error);
     return failure(`提交 Task 消息失败: ${message}`);
   }

--- a/packages/along/src/domain/task-runner-images.ts
+++ b/packages/along/src/domain/task-runner-images.ts
@@ -1,0 +1,85 @@
+import type { Result } from '../core/result';
+import { success } from '../core/result';
+import type { TaskAgentProgressContext } from './task-agent-progress';
+import { writeTaskAgentSessionEvent } from './task-agent-progress';
+import type { InputImageAttachment } from './task-attachments';
+
+export type LocalImagePromptItem =
+  | { type: 'text'; text: string }
+  | { type: 'local_image'; path: string };
+
+export async function resolveInputImagesIfNeeded(input: {
+  taskId: string;
+  inputArtifactIds?: string[];
+}): Promise<Result<InputImageAttachment[]>> {
+  if (!input.inputArtifactIds || input.inputArtifactIds.length === 0) {
+    return success([]);
+  }
+  const { resolveInputImageAttachments } = await import(
+    './task-attachment-read'
+  );
+  return resolveInputImageAttachments(input);
+}
+
+export async function resolveAndRecordInputImages(input: {
+  taskId: string;
+  inputArtifactIds?: string[];
+  context: TaskAgentProgressContext;
+  summary: string;
+}): Promise<Result<InputImageAttachment[]>> {
+  const imagesRes = await resolveInputImagesIfNeeded(input);
+  if (!imagesRes.success) return imagesRes;
+  writeImageInputSessionEvent({
+    context: input.context,
+    images: imagesRes.data,
+    summary: input.summary.replace('{count}', String(imagesRes.data.length)),
+  });
+  return imagesRes;
+}
+
+export function writeImageInputSessionEvent(input: {
+  context: TaskAgentProgressContext;
+  images: InputImageAttachment[];
+  summary: string;
+}) {
+  if (input.images.length === 0) return;
+  writeTaskAgentSessionEvent(
+    input.context,
+    'system',
+    'message',
+    input.summary,
+    {
+      type: 'input_images',
+      count: input.images.length,
+      files: input.images.map((image) => image.originalName),
+    },
+  );
+}
+
+export function buildLocalImagePromptInput(
+  prompt: string,
+  images: InputImageAttachment[],
+): string | LocalImagePromptItem[] {
+  if (images.length === 0) return prompt;
+  return [
+    { type: 'text', text: prompt },
+    ...images.map(
+      (image): LocalImagePromptItem => ({
+        type: 'local_image',
+        path: image.absolutePath,
+      }),
+    ),
+  ];
+}
+
+export function appendImagePathsToPrompt(
+  prompt: string,
+  images: InputImageAttachment[],
+): string {
+  if (images.length === 0) return prompt;
+  const lines = images.map(
+    (image, index) =>
+      `${index + 1}. ${image.originalName}: ${image.absolutePath}`,
+  );
+  return `${prompt}\n\n用户上传图片路径：\n${lines.join('\n')}`;
+}

--- a/packages/along/src/domain/task-spawn-command.ts
+++ b/packages/along/src/domain/task-spawn-command.ts
@@ -1,0 +1,110 @@
+import { spawn } from 'node:child_process';
+import { config, type EditorConfig } from '../core/config';
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
+
+export interface TaskAgentSpawnCommand {
+  command: string;
+  args: string[];
+  cwd: string;
+  stdin?: string;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+}
+
+export interface TaskAgentSpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type TaskAgentSpawnRunner = (
+  command: TaskAgentSpawnCommand,
+) => Promise<Result<TaskAgentSpawnResult>>;
+
+export interface TaskSpawnCommandInput {
+  editor: string;
+  prompt: string;
+  cwd: string;
+  model?: string;
+  personalityVersion?: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function getTaskAgentEditor(editorId: string): Result<EditorConfig> {
+  const editor = config.EDITORS.find((item) => item.id === editorId);
+  return editor
+    ? success(editor)
+    : failure(`未知 Task agent editor: ${editorId}`);
+}
+
+function pushModel(args: string[], flag: string, model?: string) {
+  if (!model) return;
+  args.push(flag, model);
+}
+
+export function buildTaskSpawnCommand(
+  input: TaskSpawnCommandInput,
+): Result<TaskAgentSpawnCommand> {
+  const editorRes = getTaskAgentEditor(input.editor);
+  if (!editorRes.success) return editorRes;
+
+  switch (editorRes.data.id) {
+    case 'opencode': {
+      const args = ['run'];
+      pushModel(args, '--model', input.model);
+      if (input.personalityVersion) {
+        args.push('--agent', input.personalityVersion);
+      }
+      args.push(input.prompt);
+      return success({ command: 'opencode', args, cwd: input.cwd });
+    }
+    case 'pi': {
+      const args = ['--print'];
+      pushModel(args, '--model', input.model);
+      args.push(input.prompt);
+      return success({ command: 'pi', args, cwd: input.cwd });
+    }
+    default:
+      return failure(
+        `Task agent editor "${editorRes.data.id}" 暂未实现 CLI runner`,
+      );
+  }
+}
+
+export async function defaultTaskAgentSpawnRunner(
+  command: TaskAgentSpawnCommand,
+): Promise<Result<TaskAgentSpawnResult>> {
+  return new Promise((resolve) => {
+    const proc = spawn(command.command, command.args, {
+      cwd: command.cwd,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout?.setEncoding('utf-8');
+    proc.stderr?.setEncoding('utf-8');
+    proc.stdout?.on('data', (chunk) => {
+      stdout += chunk;
+      command.onStdout?.(chunk);
+    });
+    proc.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+      command.onStderr?.(chunk);
+    });
+    proc.on('error', (error) => {
+      resolve(failure(getErrorMessage(error)));
+    });
+    proc.on('close', (exitCode) => {
+      resolve(success({ exitCode: exitCode ?? 1, stdout, stderr }));
+    });
+    proc.stdin?.on('error', () => {});
+
+    if (command.stdin !== undefined) proc.stdin.end(command.stdin);
+    else proc.stdin.end();
+  });
+}

--- a/packages/along/src/domain/task-spawn-runner.test.ts
+++ b/packages/along/src/domain/task-spawn-runner.test.ts
@@ -9,6 +9,9 @@ const planningMocks = vi.hoisted(() => ({
   recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
 }));
+const attachmentMocks = vi.hoisted(() => ({
+  resolveInputImageAttachments: vi.fn(),
+}));
 
 vi.mock('./task-planning', () => ({
   AGENT_RUN_STATUS: {
@@ -35,11 +38,19 @@ vi.mock('./task-planning', () => ({
   },
 }));
 
+vi.mock('./task-attachment-read', () => ({
+  resolveInputImageAttachments: attachmentMocks.resolveInputImageAttachments,
+}));
+
 import { buildTaskSpawnCommand, runTaskSpawnTurn } from './task-spawn-runner';
 
 describe('task-spawn-runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    attachmentMocks.resolveInputImageAttachments.mockReturnValue({
+      success: true,
+      data: [],
+    });
     planningMocks.ensureTaskAgentBinding.mockReturnValue({
       success: true,
       data: {
@@ -121,6 +132,46 @@ describe('task-spawn-runner', () => {
         createdAt: '2026-01-01T00:00:00.000Z',
       },
     });
+  });
+
+  it('当输入 artifact 包含图片时，期望外部 CLI prompt 包含图片路径', async () => {
+    attachmentMocks.resolveInputImageAttachments.mockReturnValueOnce({
+      success: true,
+      data: [
+        {
+          attachmentId: 'att-1',
+          originalName: 'screen.png',
+          mimeType: 'image/png',
+          absolutePath: '/tmp/screen.png',
+        },
+      ],
+    });
+    const spawnRunner = vi.fn().mockResolvedValue({
+      success: true,
+      data: { exitCode: 0, stdout: '完成', stderr: '' },
+    });
+
+    const result = await runTaskSpawnTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'implementer',
+      editor: 'pi',
+      prompt: '实现批准方案',
+      cwd: '/tmp/project',
+      inputArtifactIds: ['art-user'],
+      spawnRunner,
+    });
+
+    expect(result.success).toBe(true);
+    expect(spawnRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.stringContaining(
+            '用户上传图片路径：\n1. screen.png: /tmp/screen.png',
+          ),
+        ]),
+      }),
+    );
   });
 
   it('为 PI 构造非交互命令', () => {

--- a/packages/along/src/domain/task-spawn-runner.ts
+++ b/packages/along/src/domain/task-spawn-runner.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import { config, type EditorConfig } from '../core/config';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
@@ -20,25 +19,20 @@ import type {
   RunTaskClaudeTurnOutput,
 } from './task-claude-runner';
 import { TASK_AGENT_PROGRESS_PHASE } from './task-planning';
+import {
+  appendImagePathsToPrompt,
+  resolveAndRecordInputImages,
+} from './task-runner-images';
+import {
+  buildTaskSpawnCommand,
+  defaultTaskAgentSpawnRunner,
+  getTaskAgentEditor,
+  type TaskAgentSpawnCommand,
+  type TaskAgentSpawnResult,
+  type TaskAgentSpawnRunner,
+} from './task-spawn-command';
 
-export interface TaskAgentSpawnCommand {
-  command: string;
-  args: string[];
-  cwd: string;
-  stdin?: string;
-  onStdout?: (chunk: string) => void;
-  onStderr?: (chunk: string) => void;
-}
-
-export interface TaskAgentSpawnResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-export type TaskAgentSpawnRunner = (
-  command: TaskAgentSpawnCommand,
-) => Promise<Result<TaskAgentSpawnResult>>;
+export { buildTaskSpawnCommand } from './task-spawn-command';
 
 export interface RunTaskSpawnTurnInput extends RunTaskClaudeTurnInput {
   editor: string;
@@ -47,81 +41,6 @@ export interface RunTaskSpawnTurnInput extends RunTaskClaudeTurnInput {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function getEditor(editorId: string): Result<EditorConfig> {
-  const editor = config.EDITORS.find((item) => item.id === editorId);
-  return editor
-    ? success(editor)
-    : failure(`未知 Task agent editor: ${editorId}`);
-}
-
-function pushModel(args: string[], flag: string, model?: string) {
-  if (!model) return;
-  args.push(flag, model);
-}
-
-export function buildTaskSpawnCommand(
-  input: RunTaskSpawnTurnInput,
-): Result<TaskAgentSpawnCommand> {
-  const editorRes = getEditor(input.editor);
-  if (!editorRes.success) return editorRes;
-
-  switch (editorRes.data.id) {
-    case 'opencode': {
-      const args = ['run'];
-      pushModel(args, '--model', input.model);
-      if (input.personalityVersion) {
-        args.push('--agent', input.personalityVersion);
-      }
-      args.push(input.prompt);
-      return success({ command: 'opencode', args, cwd: input.cwd });
-    }
-    case 'pi': {
-      const args = ['--print'];
-      pushModel(args, '--model', input.model);
-      args.push(input.prompt);
-      return success({ command: 'pi', args, cwd: input.cwd });
-    }
-    default:
-      return failure(
-        `Task agent editor "${editorRes.data.id}" 暂未实现 CLI runner`,
-      );
-  }
-}
-
-export async function defaultTaskAgentSpawnRunner(
-  command: TaskAgentSpawnCommand,
-): Promise<Result<TaskAgentSpawnResult>> {
-  return new Promise((resolve) => {
-    const proc = spawn(command.command, command.args, {
-      cwd: command.cwd,
-      env: process.env,
-    });
-
-    let stdout = '';
-    let stderr = '';
-    proc.stdout?.setEncoding('utf-8');
-    proc.stderr?.setEncoding('utf-8');
-    proc.stdout?.on('data', (chunk) => {
-      stdout += chunk;
-      command.onStdout?.(chunk);
-    });
-    proc.stderr?.on('data', (chunk) => {
-      stderr += chunk;
-      command.onStderr?.(chunk);
-    });
-    proc.on('error', (error) => {
-      resolve(failure(getErrorMessage(error)));
-    });
-    proc.on('close', (exitCode) => {
-      resolve(success({ exitCode: exitCode ?? 1, stdout, stderr }));
-    });
-    proc.stdin?.on('error', () => {});
-
-    if (command.stdin !== undefined) proc.stdin.end(command.stdin);
-    else proc.stdin.end();
-  });
 }
 
 function summarizeFailure(output: TaskAgentSpawnResult): string {
@@ -142,36 +61,82 @@ export async function runTaskSpawnTurn(
   const prompt = input.prompt.trim();
   if (!prompt) return failure('Task agent prompt 不能为空');
 
-  const commandRes = buildTaskSpawnCommand({ ...input, prompt });
-  if (!commandRes.success) return commandRes;
-
-  const editorRes = getEditor(input.editor);
+  const editorRes = getTaskAgentEditor(input.editor);
   if (!editorRes.success) return editorRes;
   const permissionRes = ensureEditorPermissions(editorRes.data, input.cwd);
   if (!permissionRes.success) return permissionRes;
 
   const startedRes = startTaskAgentRun(input, input.editor);
   if (!startedRes.success) return startedRes;
-
-  const stopHeartbeat = startTaskAgentRunHeartbeat(
-    startedRes.data.progressContext,
-    `Agent 已启动，正在执行 ${editorRes.data.name}。`,
-    commandRes.data.cwd,
-  );
+  const commandRes = await prepareSpawnCommand(input, prompt, startedRes.data);
+  if (!commandRes.success) {
+    return failSpawnTurn(
+      startedRes.data.progressContext,
+      editorRes.data.name,
+      commandRes.error,
+    );
+  }
   const runner = input.spawnRunner || defaultTaskAgentSpawnRunner;
+  return runPreparedSpawnCommand(
+    input,
+    commandRes.data,
+    editorRes.data,
+    startedRes.data,
+    runner,
+  );
+}
+
+function runPreparedSpawnCommand(
+  input: RunTaskSpawnTurnInput,
+  command: TaskAgentSpawnCommand,
+  editor: EditorConfig,
+  started: StartedTaskAgentRun,
+  runner: TaskAgentSpawnRunner,
+) {
+  const stopHeartbeat = startSpawnHeartbeat(started, editor.name, command.cwd);
   try {
     const streamState = { seen: false };
     return executeSpawnTurn(
       input,
-      commandRes.data,
-      editorRes.data,
-      startedRes.data,
+      command,
+      editor,
+      started,
       runner,
       streamState,
     );
   } finally {
     stopHeartbeat();
   }
+}
+
+async function prepareSpawnCommand(
+  input: RunTaskSpawnTurnInput,
+  prompt: string,
+  started: StartedTaskAgentRun,
+): Promise<Result<TaskAgentSpawnCommand>> {
+  const imagesRes = await resolveAndRecordInputImages({
+    taskId: input.taskId,
+    inputArtifactIds: input.inputArtifactIds,
+    context: started.progressContext,
+    summary: '本轮传入 {count} 张用户上传图片路径。',
+  });
+  if (!imagesRes.success) return failure(imagesRes.error);
+  return buildTaskSpawnCommand({
+    ...input,
+    prompt: appendImagePathsToPrompt(prompt, imagesRes.data),
+  });
+}
+
+function startSpawnHeartbeat(
+  started: StartedTaskAgentRun,
+  editorName: string,
+  cwd: string,
+) {
+  return startTaskAgentRunHeartbeat(
+    started.progressContext,
+    `Agent 已启动，正在执行 ${editorName}。`,
+    cwd,
+  );
 }
 
 function ensureEditorPermissions(

--- a/packages/along/src/domain/task-title-summary.ts
+++ b/packages/along/src/domain/task-title-summary.ts
@@ -25,6 +25,7 @@ const SYSTEM_PROMPT = `你是 Along 的任务标题总结 Agent。
 export interface TaskTitleSummaryInput {
   taskId: string;
   body: string;
+  attachmentCount?: number;
 }
 
 interface ResolvedTitleProvider {
@@ -151,7 +152,10 @@ export async function generateTaskTitle(body: string): Promise<Result<string>> {
 export async function runTaskTitleSummary(
   input: TaskTitleSummaryInput,
 ): Promise<Result<TaskPlanningSnapshot | null>> {
-  const titleRes = await generateTaskTitle(input.body);
+  const body = input.attachmentCount
+    ? `${input.body}\n\n[用户上传图片数量：${input.attachmentCount}]`
+    : input.body;
+  const titleRes = await generateTaskTitle(body);
   if (!titleRes.success) return titleRes;
 
   const updateRes = updatePlanningTaskTitle({

--- a/packages/along/src/integration/task-api-attachments.ts
+++ b/packages/along/src/integration/task-api-attachments.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { errorResponse } from './task-api-utils';
+
+export async function readTaskAttachmentResponse(
+  taskId: string,
+  attachmentId: string,
+): Promise<Response> {
+  const { readTaskAttachmentFile } = await import(
+    '../domain/task-attachment-read'
+  );
+  const fileRes = readTaskAttachmentFile({ taskId, attachmentId });
+  if (!fileRes.success) {
+    const status = getAttachmentErrorStatus(fileRes.error);
+    return errorResponse(fileRes.error, status);
+  }
+  return new Response(readFileSync(fileRes.data.absolutePath), {
+    status: 200,
+    headers: {
+      'Content-Type': fileRes.data.attachment.mimeType,
+      'Cache-Control': 'private, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}
+
+function getAttachmentErrorStatus(error: string): number {
+  if (error.includes('不属于当前 Task')) return 403;
+  if (error.includes('不存在')) return 404;
+  return 400;
+}

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -1,6 +1,6 @@
-import { consola } from 'consola';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
+import type { TaskAttachmentUploadInput } from '../domain/task-attachments';
 import {
   areImplementationStepsApproved,
   findImplementationStepsArtifact,
@@ -16,8 +16,9 @@ import {
   submitTaskMessage,
   type TaskPlanningSnapshot,
 } from '../domain/task-planning';
-import { runTaskTitleSummary } from '../domain/task-title-summary';
 import type { TaskApiContext } from './task-api';
+import { readTaskAttachmentResponse } from './task-api-attachments';
+import { scheduleTitleSummary } from './task-api-title-summary';
 import {
   deriveTitle,
   errorResponse,
@@ -30,18 +31,13 @@ import {
   readStringField,
   readTaskAgentStageField,
   readTaskExecutionModeField,
+  readTaskRequestPayload,
   resolveTaskCwd,
   scheduleDeliveryIfNeeded,
   scheduleImplementationIfNeeded,
   schedulePlannerIfNeeded,
   type UnknownRecord,
 } from './task-api-utils';
-
-const logger = consola.withTag('task-api');
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 export function handleTaskListRequest(url: URL): Response {
   const limit = readPositiveInt(url.searchParams.get('limit'), 100);
@@ -57,59 +53,51 @@ export async function handleTaskCreateRequest(
   req: Request,
   context: TaskApiContext,
 ): Promise<Response> {
-  const bodyRes = await readJsonObject(req);
+  const bodyRes = await readTaskRequestPayload(req);
   if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
 
-  const taskBody = readStringField(bodyRes.data, 'body');
+  const taskBody =
+    readStringField(bodyRes.data.payload, 'body') ||
+    (bodyRes.data.attachments.length > 0 ? '（用户上传了图片）' : undefined);
   if (!taskBody) return errorResponse('Task 内容不能为空', 400);
 
-  const createRes = createTaskFromPayload(bodyRes.data, context, taskBody);
+  const createRes = createTaskFromPayload(
+    bodyRes.data.payload,
+    context,
+    taskBody,
+    bodyRes.data.attachments,
+  );
   if (!createRes.success) return errorResponse(createRes.error, 400);
 
   scheduleTitleSummary(context, {
     taskId: createRes.data.task.taskId,
     body: taskBody,
+    ...(bodyRes.data.attachments.length
+      ? { attachmentCount: bodyRes.data.attachments.length }
+      : {}),
   });
 
-  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
+  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data.payload, context, {
     taskId: createRes.data.task.taskId,
     reason: 'task_created',
   });
   if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
 
   return jsonResponse(
-    buildScheduledPayload(createRes.data.task.taskId, scheduledRes.data, {
+    {
+      taskId: createRes.data.task.taskId,
+      scheduled: scheduledRes.data,
       snapshot: createRes.data,
-    }),
+    },
     scheduledRes.data ? 202 : 201,
   );
-}
-
-function scheduleTitleSummary(
-  context: TaskApiContext,
-  input: { taskId: string; body: string },
-) {
-  if (context.scheduleTitleSummary) {
-    context.scheduleTitleSummary(input);
-    return;
-  }
-  void runTaskTitleSummary(input)
-    .then((result) => {
-      if (!result.success) {
-        logger.warn(`[Task ${input.taskId}] 标题自动总结失败: ${result.error}`);
-      }
-    })
-    .catch((error: unknown) => {
-      logger.error(
-        `[Task ${input.taskId}] 标题自动总结异常: ${getErrorMessage(error)}`,
-      );
-    });
 }
 
 function createTaskFromPayload(
   payload: UnknownRecord,
   context: TaskApiContext,
   taskBody: string,
+  attachments: TaskAttachmentUploadInput[] = [],
 ): Result<TaskPlanningSnapshot> {
   const cwdRes = resolveTaskCwd(payload, context);
   if (!cwdRes.success) return cwdRes;
@@ -124,6 +112,7 @@ function createTaskFromPayload(
     repoName: repository.repoName,
     cwd: cwdRes.data,
     executionMode: executionModeRes.data,
+    ...(attachments.length ? { attachments } : {}),
   });
 }
 
@@ -139,22 +128,37 @@ export async function handleTaskMessageRequest(
   taskId: string,
   context: TaskApiContext,
 ): Promise<Response> {
-  const bodyRes = await readJsonObject(req);
+  const bodyRes = await readTaskRequestPayload(req);
   if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
 
-  const message = readStringField(bodyRes.data, 'body');
+  const message =
+    readStringField(bodyRes.data.payload, 'body') ||
+    (bodyRes.data.attachments.length > 0 ? '（用户上传了图片）' : undefined);
   if (!message) return errorResponse('用户消息不能为空', 400);
 
-  const submitRes = submitTaskMessage({ taskId, body: message });
+  const submitRes = submitTaskMessage({
+    taskId,
+    body: message,
+    ...(bodyRes.data.attachments.length
+      ? { attachments: bodyRes.data.attachments }
+      : {}),
+  });
   if (!submitRes.success) return errorResponse(submitRes.error, 409);
 
-  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data, context, {
+  const scheduledRes = schedulePlannerIfNeeded(bodyRes.data.payload, context, {
     taskId,
     reason: 'user_message',
   });
   if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
 
   return readSnapshotForMessage(taskId, scheduledRes.data, submitRes.data);
+}
+
+export function handleTaskAttachmentRequest(
+  taskId: string,
+  attachmentId: string,
+): Response | Promise<Response> {
+  return readTaskAttachmentResponse(taskId, attachmentId);
 }
 
 function readSnapshotForMessage(
@@ -165,10 +169,12 @@ function readSnapshotForMessage(
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   return jsonResponse(
-    buildScheduledPayload(taskId, scheduled, {
+    {
+      taskId,
+      scheduled,
       submitted,
       snapshot: snapshotRes.data,
-    }),
+    },
     scheduled ? 202 : 200,
   );
 }
@@ -326,12 +332,4 @@ function scheduledResponse(
   if (!scheduledRes.success) return errorResponse(scheduledRes.error, 400);
   if (!scheduledRes.data) return errorResponse(disabledMessage, 503);
   return jsonResponse({ taskId, scheduled: true }, 202);
-}
-
-function buildScheduledPayload(
-  taskId: string,
-  scheduled: boolean,
-  extra: UnknownRecord,
-) {
-  return { taskId, scheduled, ...extra };
 }

--- a/packages/along/src/integration/task-api-title-summary.ts
+++ b/packages/along/src/integration/task-api-title-summary.ts
@@ -1,0 +1,30 @@
+import { consola } from 'consola';
+import { runTaskTitleSummary } from '../domain/task-title-summary';
+import type { TaskApiContext } from './task-api';
+
+const logger = consola.withTag('task-api');
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function scheduleTitleSummary(
+  context: TaskApiContext,
+  input: { taskId: string; body: string; attachmentCount?: number },
+) {
+  if (context.scheduleTitleSummary) {
+    context.scheduleTitleSummary(input);
+    return;
+  }
+  void runTaskTitleSummary(input)
+    .then((result) => {
+      if (!result.success) {
+        logger.warn(`[Task ${input.taskId}] 标题自动总结失败: ${result.error}`);
+      }
+    })
+    .catch((error: unknown) => {
+      logger.error(
+        `[Task ${input.taskId}] 标题自动总结异常: ${getErrorMessage(error)}`,
+      );
+    });
+}

--- a/packages/along/src/integration/task-api-utils.ts
+++ b/packages/along/src/integration/task-api-utils.ts
@@ -1,5 +1,6 @@
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
+import type { TaskAttachmentUploadInput } from '../domain/task-attachments';
 import {
   readTaskAgentBinding,
   readTaskPlanningSnapshot,
@@ -17,6 +18,11 @@ import type {
 } from './task-api';
 
 export type UnknownRecord = Record<string, unknown>;
+
+export interface ParsedTaskRequest {
+  payload: UnknownRecord;
+  attachments: TaskAttachmentUploadInput[];
+}
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
@@ -66,7 +72,49 @@ export function readBooleanField(
   key: string,
 ): boolean | undefined {
   const value = payload[key];
-  return typeof value === 'boolean' ? value : undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return undefined;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
+export async function readTaskRequestPayload(
+  req: Request,
+): Promise<Result<ParsedTaskRequest>> {
+  const contentType = req.headers.get('content-type') || '';
+  if (contentType.toLowerCase().startsWith('multipart/form-data')) {
+    return readMultipartTaskRequest(req);
+  }
+  const jsonRes = await readJsonObject(req);
+  if (!jsonRes.success) return failure(jsonRes.error);
+  return success({ payload: jsonRes.data, attachments: [] });
+}
+
+async function readMultipartTaskRequest(
+  req: Request,
+): Promise<Result<ParsedTaskRequest>> {
+  try {
+    const form = await req.formData();
+    const payload: UnknownRecord = {};
+    const attachments: TaskAttachmentUploadInput[] = [];
+    for (const [key, value] of form.entries()) {
+      if (key === 'attachments') {
+        if (value instanceof File) {
+          attachments.push({
+            originalName: value.name,
+            mimeType: value.type,
+            bytes: new Uint8Array(await value.arrayBuffer()),
+          });
+        }
+        continue;
+      }
+      if (typeof value === 'string') payload[key] = value;
+    }
+    return success({ payload, attachments });
+  } catch {
+    return failure('请求体必须是合法 multipart/form-data');
+  }
 }
 
 export function readTaskExecutionModeField(

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -113,6 +113,49 @@ it('当创建 Task 指定全自动模式时，期望 executionMode 传给创建�
   );
 });
 
+it('当 multipart 创建 Task 带图片时，期望附件传给创建层且仍调度 planner', async () => {
+  const scheduled: unknown[] = [];
+  const form = new FormData();
+  form.append('body', '请看截图处理这个问题。');
+  form.append('owner', 'ranwawa');
+  form.append('repo', 'along');
+  form.append(
+    'attachments',
+    new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'screen.png', {
+      type: 'image/png',
+    }),
+  );
+
+  const response = await handleTaskApiRequest(
+    new Request('http://localhost/api/tasks', {
+      method: 'POST',
+      body: form,
+    }),
+    new URL('http://localhost/api/tasks'),
+    {
+      defaultCwd: '/tmp/default',
+      resolveRepoPath: () => '/tmp/along',
+      schedulePlanner: (input) => scheduled.push(input),
+      scheduleTitleSummary: () => {},
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expect(planningMocks.createPlanningTask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      body: '请看截图处理这个问题。',
+      attachments: [
+        expect.objectContaining({
+          originalName: 'screen.png',
+          mimeType: 'image/png',
+          bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        }),
+      ],
+    }),
+  );
+  expectScheduledRunner(scheduled, '/tmp/along', 'task_created');
+});
+
 it('当创建 Task 指定非法执行模式时，期望返回 400', async () => {
   const response = await handleTaskApiRequest(
     jsonRequest('/api/tasks', {
@@ -170,6 +213,40 @@ it('当追加用户消息时，期望记录消息并调度同一个 Task planner
     body: '继续讨论这个方案。',
   });
   expectScheduledRunner(scheduled, '/tmp/project', 'user_message');
+});
+
+it('当 multipart 追加用户消息带图片时，期望附件传给消息层', async () => {
+  const form = new FormData();
+  form.append('body', '补一张截图。');
+  form.append('autoRun', 'false');
+  form.append(
+    'attachments',
+    new File([new Uint8Array([0xff, 0xd8, 0xff])], 'error.jpg', {
+      type: 'image/jpeg',
+    }),
+  );
+
+  const response = await handleTaskApiRequest(
+    new Request('http://localhost/api/tasks/task-1/messages', {
+      method: 'POST',
+      body: form,
+    }),
+    new URL('http://localhost/api/tasks/task-1/messages'),
+    { defaultCwd: '/tmp/default', schedulePlanner: () => {} },
+  );
+
+  expect(response.status).toBe(200);
+  expect(planningMocks.submitTaskMessage).toHaveBeenCalledWith({
+    taskId: 'task-1',
+    body: '补一张截图。',
+    attachments: [
+      expect.objectContaining({
+        originalName: 'error.jpg',
+        mimeType: 'image/jpeg',
+        bytes: new Uint8Array([0xff, 0xd8, 0xff]),
+      }),
+    ],
+  });
 });
 
 it('当批准 Task Plan 时，期望不再调度 planner', async () => {

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -1,6 +1,7 @@
 import type { TaskPlanningSnapshot } from '../domain/task-planning';
 import {
   handleTaskApproveRequest,
+  handleTaskAttachmentRequest,
   handleTaskCompleteRequest,
   handleTaskCreateRequest,
   handleTaskDeliveryRequest,
@@ -42,6 +43,7 @@ export interface ScheduledTaskDeliveryRun {
 export interface ScheduledTaskTitleSummaryRun {
   taskId: string;
   body: string;
+  attachmentCount?: number;
 }
 
 export interface TaskApiContext {
@@ -88,8 +90,12 @@ export async function handleTaskApiRequest(
   const parts = url.pathname.split('/').filter(Boolean);
   const taskId = parts[2];
   const action = parts[3];
+  const attachmentId = parts[4];
   if (!taskId) return errorResponse('缺少 taskId', 404);
   if (!action && req.method === 'GET') return handleTaskGetRequest(taskId);
+  if (action === 'attachments' && attachmentId && req.method === 'GET') {
+    return handleTaskAttachmentRequest(taskId, attachmentId);
+  }
 
   return handleTaskActionRequest(req, taskId, action, context);
 }


### PR DESCRIPTION
along-task: #20

## 修改内容
- `packages/along-web/src/TaskPlanningView.tsx`
- `packages/along-web/src/task-planning/ExistingTaskComposer.tsx`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskImageAttachments.tsx`
- `packages/along-web/src/task-planning/TaskRecords.tsx`
- `packages/along-web/src/task-planning/actionTypes.ts`
- `packages/along-web/src/task-planning/api.ts`
- `packages/along-web/src/task-planning/taskPlanningActionUtils.ts`
- `packages/along-web/src/task-planning/useTaskDraftActions.ts`
- `packages/along-web/src/task-planning/useTaskPlanningActions.ts`
- `packages/along-web/src/task-planning/useTaskPlanningController.ts`
- `packages/along-web/src/types-task.ts`
- `packages/along/src/core/db-schema.ts`
- `packages/along/src/domain/task-attachment-read.ts`
- `packages/along/src/domain/task-attachments.test.ts`
- `packages/along/src/domain/task-attachments.ts`
- `packages/along/src/domain/task-claude-image-prompt.ts`
- `packages/along/src/domain/task-claude-runner.test.ts`
- `packages/along/src/domain/task-claude-runner.ts`
- `packages/along/src/domain/task-codex-runner.test.ts`
- `packages/along/src/domain/task-codex-runner.ts`
- `packages/along/src/domain/task-codex-session-events.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/domain/task-runner-images.ts`
- `packages/along/src/domain/task-spawn-command.ts`
- `packages/along/src/domain/task-spawn-runner.test.ts`
- `packages/along/src/domain/task-spawn-runner.ts`
- `packages/along/src/domain/task-title-summary.ts`
- `packages/along/src/integration/task-api-attachments.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api-title-summary.ts`
- `packages/along/src/integration/task-api-utils.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-api.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/web-20`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
问题成立且值得继续。数据库中已恢复到 web along #17 的真实任务：task_f9327fbbefeb，标题为“增加图片上传功能”，已批准 Plan v1 和实施步骤，目标是让 Along Web 的 Task 创建与讨论支持图片上传，并把图片作为结构化 artifact 传给 Agent。

中断根因不是业务方案或代码逻辑失败，而是 Implementation Agent 多次调用 Codex 供应商接口失败：403 Forbidden，insufficient balance。当前应继续使用任务 17 的专属 worktree：/Users/macbookpro/.along/ranwawa/along/tasks/17/worktree，分支 feat/task-17；该 worktree 已有未提交实现，不能重置、覆盖或从主仓重新开始。

当前已完成较多主体实现：后端 task_attachments、附件落库与读取、multipart API、Codex/Claude/Spawn 图片输入传递、Web 上传与缩略图展示、相关后端 runner/API/domain 测试。已观察到 bun run test 通过，bun run build:web 通过；但 bun run quality:changed 仍失败，主要是新增或扩展后的文件/函数超过 Biome 行数限制，以及 TaskImageAttachments 使用 role=group 应改为语义元素。这些质量门禁必须作为接续开发的收尾重点。

Summary
接着 task 17 的现有 worktree 完成图片上传功能，而不是重新设计。实施目标是保留已完成的数据流与契约，补齐质量门禁要求，确保纯文本 JSON 路径不回归，multipart 图片路径端到端可用，Agent 收到的图片上下文可审计且失败行为明确。

Mermaid
flowchart TD
  A[恢复 task 17 worktree] --> B[保留现有附件实现]
  B --> C[修正质量门禁结构问题]
  C --> D[复核后端持久化/API/Agent 输入契约]
  C --> E[复核 Web 上传/预览/提交状态]
  D --> F[运行后端测试]
  E --> G[运行 Web build]
  F --> H[运行 quality:changed]
  G --> H
  H --> I{全部通过?}
  I -->|是| J[提交 feat task 图片上传能力]
  I -->|否| K[按失败项继续修复]
  K --> H

Contracts / Interfaces
1. 数据模型：保留 task_attachments 表，图片文件存储在 Task 数据目录 attachments 子目录；数据库只保存 attachmentId、taskId、threadId、artifactId、kind=image、originalName、mimeType、sizeBytes、sha256、relativePath、createdAt。
2. Snapshot：TaskArtifactRecord 必须稳定返回 attachments 数组；文件缺失时附件记录仍返回，并标记 missing=true。
3. API：POST /api/tasks 与 POST /api/tasks/:taskId/messages 在无附件时继续使用现有 JSON；有附件时使用 multipart/form-data，文本字段沿用 body、autoRun、executionMode、owner、repo，图片字段为重复 attachments。
4. 附件限制：只支持 image/png、image/jpeg、image/webp、image/gif；单张最大 10MB，单次最多 6 张，总量最大 30MB；校验失败返回中文错误，且不得创建孤立 artifact、数据库记录或残留部分文件。
5. 图片读取：GET /api/tasks/:taskId/attachments/:attachmentId 必须校验附件属于该 Task，并只从记录的 Task 附件目录解析文件，禁止路径穿越。
6. Agent 输入：Codex 使用 text + local_image；Claude 使用图文 SDKUserMessage；Spawn 类外部 CLI 在 prompt 中附加本地图片路径清单。缺失图片文件时 Agent run 应失败，不允许静默忽略。

Implementation Changes
1. 接续工作区
使用 /Users/macbookpro/.along/ranwawa/along/tasks/17/worktree 作为唯一开发目录，保留当前未提交改动与新增文件。不要在主仓 /Users/macbookpro/Documents/rww/along 直接继续实现，也不要重置 feat/task-17。

2. 质量门禁修复
按 Biome 失败项重构，不使用 as any、ts-ignore、eslint/biome ignore 或降低规则阈值绕过。将 TaskImageAttachments 的 role=group 改为 fieldset 等语义元素；拆分 ExistingTaskComposer、ImageAttachmentPicker、useTaskPlanningActions、task-api-handlers、task-codex-runner、task-claude-runner、task-spawn-runner 中超行数的函数或文件，把 multipart 构造、附件读取响应、runner 图片准备等逻辑提取到局部 helper 或专用模块，保持行为不变。

3. 后端收敛
复核 task-attachments、task-attachment-read、task-planning、task-api-utils、task-api-handlers、task-api 的现有实现，确保附件校验先于落库，文件写入失败不提交数据库事务，数据库失败清理本轮写入文件，snapshot 能按 artifact 聚合附件，附件读取接口能正确区分不存在、不属于当前 Task、文件缺失和非法路径。

4. Agent 多模态输入收敛
复核 task-runner-images 以及 Codex、Claude、Spawn runner 的调用路径，确保所有基于 inputArtifactIds 的 Planning、Implementation steps、Implementation、修复回合都能自动解析图片。session event 只记录图片数量和文件名，不写入 base64 或大体积内容。

5. Web 收敛
复核 TaskPlanningView、TaskDetail、TaskImageAttachments、TaskRecords、useTaskPlanningActions、useTaskPlanningController、types-task 的状态流。新建 Task 与已有 Task 反馈都应支持添加、拖放、删除、数量/大小/类型提示；有附件时发送 FormData，无附件保持 JSON；提交成功清空文本和附件，提交失败保留草稿；记录区展示缩略图并链接到附件读取接口。

6. 测试补齐与提交
保留并维护当前新增后端测试；如果重构拆出新模块，需要同步调整测试覆盖。Web 包当前没有独立 test 脚本，本轮以 build:web 覆盖类型和构建风险；若已有相关前端测试受影响，则补充或更新同级测试。全部验证通过后使用 conventional commit，建议类型 feat，提交信息可为：feat(task): 支持任务图片上传。

Failure Handling
非图片、空文件、MIME 与内容不匹配、单张/总量/数量超限、文件写入失败、数据库写入失败都返回明确中文错误。multipart 创建或提交失败不得留下孤立文件、孤立附件记录或半创建 Task。附件记录存在但文件缺失时，前端显示“文件缺失”，Agent 运行失败并记录原因。供应商余额不足属于外部运行中断，不作为代码规避项处理。

Test Plan
1. 运行后端定向测试：bun --filter @ranwawa/along test -- task-attachments.test.ts task-planning.test.ts task-api.test.ts task-codex-runner.test.ts task-claude-runner.test.ts task-spawn-runner.test.ts。
2. 运行完整后端测试：bun run test。
3. 运行 Web 构建：bun run build:web。
4. 运行质量门禁：bun run quality:changed，必须从当前失败状态修到通过。
5. 如重构影响共享类型、API handler 或 runner，再补跑对应定向测试，确认纯文本 JSON Task 创建/反馈、multipart 图片 Task 创建/反馈、附件读取、缺失文件失败、Codex/Claude/Spawn 图片输入均覆盖。

Assumptions
本任务只接续并完成 web along #17，不扩展 GitHub issue comment 附件导入、PDF/视频/远程 URL 或云存储。图片随本机 ~/.along 数据目录生命周期管理。现有纯文本 JSON API 必须继续工作，但不为旧版前端额外设计兼容层。

## 交付信息
- Commit: baf053e844dad37b3d5e4fc33a42456fd982616f