### PR TITLE
Task #23: 聊天框交互逻辑优化

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -47,6 +47,7 @@ function TaskPlanningMain({
         sortedArtifacts={taskPlanning.sortedArtifacts}
         messageBody={taskPlanning.messageBody}
         messageAttachments={taskPlanning.messageAttachments}
+        messageExecutionMode={taskPlanning.messageExecutionMode}
         busyAction={taskPlanning.busyAction}
         onDraftChange={taskPlanning.updateDraft}
         onDraftAttachmentsChange={(attachments) =>
@@ -55,6 +56,7 @@ function TaskPlanningMain({
         onCreateTask={taskPlanning.createTask}
         onMessageChange={taskPlanning.setMessageBody}
         onMessageAttachmentsChange={taskPlanning.setMessageAttachments}
+        onMessageExecutionModeChange={taskPlanning.setMessageExecutionMode}
         onSubmitMessage={taskPlanning.submitMessageFromFlow}
         onAction={taskPlanning.handleFlowAction}
       />

--- a/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
+++ b/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
@@ -1,6 +1,9 @@
-import type { TaskFlowAction, TaskPlanningSnapshot } from '../types';
-import { getFlowActionClass } from './format';
-import { ImageAttachmentPicker } from './TaskImageAttachments';
+import type {
+  TaskExecutionMode,
+  TaskFlowAction,
+  TaskPlanningSnapshot,
+} from '../types';
+import { TaskComposerInput } from './TaskComposerInput';
 
 function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
   const submitFeedbackAction = flow.actions.find(
@@ -19,80 +22,49 @@ function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
       );
 }
 
-function MessageActionButtons({
-  actions,
-  busyAction,
-  hasDraft,
-}: {
-  actions: TaskFlowAction[];
-  busyAction: string | null;
-  hasDraft: boolean;
-}) {
-  return (
-    <div className="flex flex-wrap gap-2">
-      {actions.map((action) => (
-        <button
-          key={action.id}
-          type="submit"
-          disabled={!action.enabled || !hasDraft || Boolean(busyAction)}
-          title={!action.enabled ? action.disabledReason : action.description}
-          className={`px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${getFlowActionClass(
-            action,
-          )}`}
-        >
-          {busyAction === 'message' ? '发送中' : action.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 export function ExistingTaskComposer({
   flow,
   messageBody,
   attachments,
+  executionMode,
   busyAction,
   onMessageChange,
   onAttachmentsChange,
+  onExecutionModeChange,
   onSubmitMessage,
 }: {
   flow: TaskPlanningSnapshot['flow'];
   messageBody: string;
   attachments: File[];
+  executionMode: TaskExecutionMode;
   busyAction: string | null;
   onMessageChange: (value: string) => void;
   onAttachmentsChange: (files: File[]) => void;
+  onExecutionModeChange: (value: TaskExecutionMode) => void;
   onSubmitMessage: () => void;
 }) {
   const messageActions = getMessageActions(flow);
   const canSubmitMessage = messageActions.some((action) => action.enabled);
   const hasDraft = Boolean(messageBody.trim()) || attachments.length > 0;
+  const submitAction =
+    messageActions.find((action) => action.enabled) || messageActions[0];
   return (
-    <form
+    <TaskComposerInput
+      attachments={attachments}
+      body={messageBody}
+      busy={busyAction === 'message'}
+      disabled={!canSubmitMessage}
+      executionMode={executionMode}
+      placeholder="补充反馈、继续提问或说明交付后的修改要求"
+      submitDisabled={!canSubmitMessage || !hasDraft || Boolean(busyAction)}
+      submitTitle={submitAction?.description || submitAction?.label || '发送'}
+      onAttachmentsChange={onAttachmentsChange}
+      onBodyChange={onMessageChange}
+      onExecutionModeChange={onExecutionModeChange}
       onSubmit={(event) => {
         event.preventDefault();
         onSubmitMessage();
       }}
-      className="flex flex-col gap-3"
-    >
-      <textarea
-        value={messageBody}
-        onChange={(event) => onMessageChange(event.target.value)}
-        placeholder="补充反馈、继续提问或说明交付后的修改要求"
-        rows={2}
-        disabled={!canSubmitMessage}
-        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
-      />
-      <ImageAttachmentPicker
-        attachments={attachments}
-        disabled={!canSubmitMessage}
-        onChange={onAttachmentsChange}
-      />
-      <MessageActionButtons
-        actions={messageActions}
-        busyAction={busyAction}
-        hasDraft={hasDraft}
-      />
-    </form>
+    />
   );
 }

--- a/packages/along-web/src/task-planning/TaskComposerInput.tsx
+++ b/packages/along-web/src/task-planning/TaskComposerInput.tsx
@@ -1,0 +1,279 @@
+import { type FormEvent, useState } from 'react';
+import type { TaskExecutionMode } from '../types-task';
+import {
+  ImageAttachmentPicker,
+  type ImageAttachmentPickerRenderProps,
+} from './TaskImageAttachments';
+
+interface TaskComposerInputProps {
+  attachments: File[];
+  body: string;
+  busy?: boolean;
+  disabled?: boolean;
+  executionMode: TaskExecutionMode;
+  placeholder: string;
+  rows?: number;
+  submitDisabled: boolean;
+  submitTitle?: string;
+  onAttachmentsChange: (files: File[]) => void;
+  onBodyChange: (value: string) => void;
+  onExecutionModeChange: (value: TaskExecutionMode) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+type ComposerDisplayProps = Omit<
+  TaskComposerInputProps,
+  'attachments' | 'onAttachmentsChange' | 'onSubmit'
+>;
+
+function PlusIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.8"
+    >
+      <path d="M10 4v12M4 10h12" />
+    </svg>
+  );
+}
+
+function ImageIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.7"
+    >
+      <rect x="3" y="4" width="14" height="12" rx="2" />
+      <path d="m6 13 3-3 2 2 2-3 3 4" />
+      <circle cx="8" cy="8" r="1" />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+    >
+      <path d="m3 10 14-7-4 14-3-6-7-1Z" />
+      <path d="m10 11 7-8" />
+    </svg>
+  );
+}
+
+function isTaskExecutionMode(value: string): value is TaskExecutionMode {
+  return value === 'manual' || value === 'autonomous';
+}
+
+function AttachmentPopover({
+  canAdd,
+  count,
+  disabled,
+  maxCount,
+  openPicker,
+}: {
+  canAdd: boolean;
+  count: number;
+  disabled?: boolean;
+  maxCount: number;
+  openPicker: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const isDisabled = disabled || !canAdd;
+  return (
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        aria-label="添加附件"
+        aria-expanded={isOpen}
+        disabled={isDisabled}
+        title={
+          count >= maxCount ? `单次最多上传 ${maxCount} 张图片` : '添加附件'
+        }
+        onClick={() => setIsOpen((value) => !value)}
+        className="flex h-9 w-9 items-center justify-center rounded-lg border border-border-color bg-black/25 text-text-secondary transition-colors hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-brand/70 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <PlusIcon />
+      </button>
+      {isOpen && (
+        <div className="absolute bottom-full left-0 z-20 mb-2 w-36 rounded-lg border border-border-color bg-bg-secondary p-1 shadow-xl">
+          <button
+            type="button"
+            disabled={isDisabled}
+            onClick={() => {
+              openPicker();
+              setIsOpen(false);
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-text-secondary transition-colors hover:bg-black/30 hover:text-text-primary focus:bg-black/30 focus:text-text-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <ImageIcon />
+            <span>图片</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ComposerTextarea({
+  body,
+  busy,
+  disabled,
+  placeholder,
+  rows,
+  onBodyChange,
+}: Pick<
+  TaskComposerInputProps,
+  'body' | 'busy' | 'disabled' | 'placeholder' | 'rows' | 'onBodyChange'
+>) {
+  return (
+    <textarea
+      value={body}
+      onChange={(event) => onBodyChange(event.target.value)}
+      placeholder={placeholder}
+      rows={rows}
+      disabled={disabled || busy}
+      className="min-w-0 resize-none rounded-lg border border-border-color bg-black/35 px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
+    />
+  );
+}
+
+function ExecutionModeSelect({
+  busy,
+  disabled,
+  executionMode,
+  onExecutionModeChange,
+}: Pick<
+  TaskComposerInputProps,
+  'busy' | 'disabled' | 'executionMode' | 'onExecutionModeChange'
+>) {
+  return (
+    <label className="min-w-0 shrink text-xs text-text-muted">
+      <span className="sr-only">执行模式</span>
+      <select
+        value={executionMode}
+        disabled={disabled || busy}
+        onChange={(event) => {
+          const value = event.target.value;
+          if (isTaskExecutionMode(value)) onExecutionModeChange(value);
+        }}
+        className="h-9 max-w-[132px] rounded-lg border border-border-color bg-black/25 px-3 text-sm text-text-primary outline-none focus:ring-1 focus:ring-brand/60 disabled:opacity-50"
+      >
+        <option value="manual">人工确认</option>
+        <option value="autonomous">全自动</option>
+      </select>
+    </label>
+  );
+}
+
+function SubmitIconButton({
+  busy,
+  submitDisabled,
+  submitTitle,
+}: Pick<TaskComposerInputProps, 'busy' | 'submitDisabled' | 'submitTitle'>) {
+  return (
+    <button
+      type="submit"
+      aria-label={busy ? '发送中' : '发送'}
+      title={busy ? '发送中' : submitTitle}
+      disabled={submitDisabled || busy}
+      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-brand bg-brand text-white transition-colors hover:bg-brand-hover focus:outline-none focus:ring-1 focus:ring-brand/70 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {busy ? (
+        <span aria-hidden="true" className="text-sm leading-none">
+          ...
+        </span>
+      ) : (
+        <SendIcon />
+      )}
+    </button>
+  );
+}
+
+function ComposerActionRow({
+  controls,
+  ...props
+}: ComposerDisplayProps & {
+  controls: ImageAttachmentPickerRenderProps;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <AttachmentPopover
+        canAdd={controls.canAdd}
+        count={controls.count}
+        disabled={props.disabled || props.busy}
+        maxCount={controls.maxCount}
+        openPicker={controls.openPicker}
+      />
+      <ExecutionModeSelect {...props} />
+      <div className="min-w-0 flex-1" />
+      <SubmitIconButton {...props} />
+    </div>
+  );
+}
+
+function ComposerContent({
+  controls,
+  ...props
+}: ComposerDisplayProps & {
+  controls: ImageAttachmentPickerRenderProps;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      {controls.previews}
+      <ComposerTextarea {...props} />
+      {controls.error}
+      <ComposerActionRow controls={controls} {...props} />
+    </div>
+  );
+}
+
+export function TaskComposerInput({
+  attachments,
+  busy,
+  disabled,
+  rows = 2,
+  submitTitle = '发送',
+  onAttachmentsChange,
+  onSubmit,
+  ...props
+}: TaskComposerInputProps) {
+  const composerProps: ComposerDisplayProps = {
+    ...props,
+    busy,
+    disabled,
+    rows,
+    submitTitle,
+  };
+  return (
+    <form onSubmit={onSubmit} className="min-w-0">
+      <ImageAttachmentPicker
+        attachments={attachments}
+        disabled={disabled || busy}
+        onChange={onAttachmentsChange}
+      >
+        {(controls) => (
+          <ComposerContent controls={controls} {...composerProps} />
+        )}
+      </ImageAttachmentPicker>
+    </form>
+  );
+}

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import type {
   TaskArtifactRecord,
+  TaskExecutionMode,
   TaskFlowAction,
   TaskPlanningSnapshot,
 } from '../types';
@@ -15,8 +16,8 @@ import { AgentStagesPanel } from './AgentStagesPanel';
 import type { DraftTaskInput, RepositoryOption } from './api';
 import { ExistingTaskComposer } from './ExistingTaskComposer';
 import { formatTime, getTaskStatusLabel, getThreadStatusLabel } from './format';
+import { TaskComposerInput } from './TaskComposerInput';
 import { FlowHistory, TaskFlowPanel } from './TaskFlowPanel';
-import { ImageAttachmentPicker } from './TaskImageAttachments';
 import { TaskProgressPanel } from './TaskProgressPanel';
 import { TaskRecordsPanel } from './TaskRecords';
 
@@ -125,50 +126,21 @@ function NewTaskComposer({
   onDraftAttachmentsChange: (files: File[]) => void;
   onCreateTask: (event: FormEvent) => void;
 }) {
+  const hasDraft = Boolean(draft.body.trim()) || draft.attachments.length > 0;
   return (
-    <form onSubmit={onCreateTask} className="flex flex-col gap-3">
-      <div className="text-sm font-semibold text-text-secondary">任务内容</div>
-      <textarea
-        value={draft.body}
-        onChange={(event) => onDraftChange('body', event.target.value)}
-        placeholder="输入任务目标或问题"
-        rows={2}
-        className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-brand/60"
-      />
-      <ImageAttachmentPicker
-        attachments={draft.attachments}
-        onChange={onDraftAttachmentsChange}
-      />
-      <label className="flex flex-col gap-1 text-xs text-text-muted">
-        执行模式
-        <select
-          value={draft.executionMode}
-          onChange={(event) =>
-            onDraftChange('executionMode', event.target.value)
-          }
-          className="bg-black/35 border border-border-color rounded-lg px-3 py-2 text-sm text-text-primary outline-none focus:ring-1 focus:ring-brand/60"
-        >
-          <option value="manual">人工确认</option>
-          <option value="autonomous">全自动</option>
-        </select>
-      </label>
-      <div className="flex items-center justify-between gap-3">
-        <span className="min-w-0 text-xs text-text-muted">
-          {selectedRepository ? '将创建到当前仓库。' : '请先选择仓库。'}
-        </span>
-        <button
-          type="submit"
-          disabled={
-            !selectedRepository ||
-            (!draft.body.trim() && draft.attachments.length === 0) ||
-            busyAction === 'create'
-          }
-          className="shrink-0 px-3 py-2 rounded-lg text-xs font-semibold bg-brand text-white border border-brand hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {busyAction === 'create' ? '发送中' : '发送'}
-        </button>
-      </div>
-    </form>
+    <TaskComposerInput
+      attachments={draft.attachments}
+      body={draft.body}
+      busy={busyAction === 'create'}
+      executionMode={draft.executionMode}
+      placeholder={selectedRepository ? '输入任务目标或问题' : '请先选择仓库'}
+      submitDisabled={!selectedRepository || !hasDraft || Boolean(busyAction)}
+      submitTitle="创建任务"
+      onAttachmentsChange={onDraftAttachmentsChange}
+      onBodyChange={(value) => onDraftChange('body', value)}
+      onExecutionModeChange={(value) => onDraftChange('executionMode', value)}
+      onSubmit={onCreateTask}
+    />
   );
 }
 
@@ -185,12 +157,14 @@ type TaskDetailProps = {
   sortedArtifacts: TaskArtifactRecord[];
   messageBody: string;
   messageAttachments: File[];
+  messageExecutionMode: TaskExecutionMode;
   busyAction: string | null;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
   onDraftAttachmentsChange: (files: File[]) => void;
   onCreateTask: (event: FormEvent) => void;
   onMessageChange: (value: string) => void;
   onMessageAttachmentsChange: (files: File[]) => void;
+  onMessageExecutionModeChange: (value: TaskExecutionMode) => void;
   onSubmitMessage: () => void;
   onAction: (action: TaskFlowAction) => void;
 };
@@ -317,9 +291,11 @@ function SelectedTaskDetail({
             flow={selected.flow}
             messageBody={detail.messageBody}
             attachments={detail.messageAttachments}
+            executionMode={detail.messageExecutionMode}
             busyAction={detail.busyAction}
             onMessageChange={detail.onMessageChange}
             onAttachmentsChange={detail.onMessageAttachmentsChange}
+            onExecutionModeChange={detail.onMessageExecutionModeChange}
             onSubmitMessage={detail.onSubmitMessage}
           />
         </div>

--- a/packages/along-web/src/task-planning/TaskImageAttachments.tsx
+++ b/packages/along-web/src/task-planning/TaskImageAttachments.tsx
@@ -1,6 +1,7 @@
 import {
   type ChangeEvent,
   type DragEvent,
+  type ReactNode,
   type RefObject,
   useEffect,
   useRef,
@@ -61,26 +62,23 @@ function ImageAttachmentThumb({
     return () => URL.revokeObjectURL(objectUrl);
   }, [file]);
   return (
-    <div className="flex h-16 min-w-0 items-center gap-2 rounded-lg border border-border-color bg-black/25 p-2">
+    <div className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-border-color bg-black/25">
       {url && (
         <img
           src={url}
-          alt={file.name}
-          className="h-12 w-12 shrink-0 rounded object-cover"
+          alt="待发送图片"
+          className="h-full w-full object-cover"
         />
       )}
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-xs text-text-secondary">{file.name}</div>
-        <div className="text-[11px] text-text-muted">
-          {formatFileSize(file.size)}
-        </div>
-      </div>
       <button
         type="button"
+        aria-label="删除图片"
         onClick={onRemove}
-        className="shrink-0 rounded border border-border-color px-2 py-1 text-[11px] text-text-muted hover:text-text-primary"
+        className="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-full border border-border-color bg-black/70 text-text-primary opacity-0 transition-opacity hover:bg-black focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-brand/70 group-hover:opacity-100 group-focus-within:opacity-100"
       >
-        删除
+        <span aria-hidden="true" className="text-base leading-none">
+          ×
+        </span>
       </button>
     </div>
   );
@@ -95,7 +93,7 @@ function ImageAttachmentList({
 }) {
   if (attachments.length === 0) return null;
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+    <div className="flex flex-wrap gap-2">
       {attachments.map((file) => (
         <ImageAttachmentThumb
           key={`${file.name}-${file.size}-${file.lastModified}`}
@@ -107,7 +105,7 @@ function ImageAttachmentList({
   );
 }
 
-function ImageAttachmentActions({
+function DefaultImageAttachmentActions({
   attachments,
   disabled,
   inputRef,
@@ -122,13 +120,22 @@ function ImageAttachmentActions({
         onClick={() => inputRef.current?.click()}
         className="rounded-lg border border-border-color bg-black/25 px-3 py-2 text-xs font-semibold text-text-secondary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
       >
-        添加图片
+        图片
       </button>
       <span className="text-[11px] text-text-muted">
         {attachments.length}/{MAX_IMAGE_COUNT}
       </span>
     </div>
   );
+}
+
+export interface ImageAttachmentPickerRenderProps {
+  canAdd: boolean;
+  count: number;
+  error: ReactNode;
+  maxCount: number;
+  openPicker: () => void;
+  previews: ReactNode;
 }
 
 function HiddenImageInput({
@@ -150,11 +157,10 @@ function HiddenImageInput({
   );
 }
 
-export function ImageAttachmentPicker({
+function useImageAttachmentInput({
   attachments,
-  disabled,
   onChange,
-}: ImageAttachmentPickerProps) {
+}: Pick<ImageAttachmentPickerProps, 'attachments' | 'onChange'>) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   const addFiles = (files: File[]) => {
@@ -166,11 +172,91 @@ export function ImageAttachmentPicker({
     addFiles(Array.from(event.target.files || []));
     event.target.value = '';
   };
-  const onDrop = (event: DragEvent<HTMLFieldSetElement>) => {
+  return { addFiles, error, inputRef, onFileChange };
+}
+
+function buildPickerRenderProps({
+  attachments,
+  canAdd,
+  error,
+  onChange,
+  openPicker,
+}: {
+  attachments: File[];
+  canAdd: boolean;
+  error: string | null;
+  onChange: (files: File[]) => void;
+  openPicker: () => void;
+}): ImageAttachmentPickerRenderProps {
+  return {
+    canAdd,
+    count: attachments.length,
+    error: error ? (
+      <div className="text-xs text-status-error">{error}</div>
+    ) : null,
+    maxCount: MAX_IMAGE_COUNT,
+    openPicker,
+    previews: (
+      <ImageAttachmentList attachments={attachments} onChange={onChange} />
+    ),
+  };
+}
+
+function DefaultImageAttachmentPickerContent({
+  attachments,
+  disabled,
+  inputRef,
+  renderProps,
+}: Pick<ImageAttachmentPickerProps, 'attachments' | 'disabled'> & {
+  inputRef: RefObject<HTMLInputElement | null>;
+  renderProps: ImageAttachmentPickerRenderProps;
+}) {
+  return (
+    <>
+      <DefaultImageAttachmentActions
+        attachments={attachments}
+        disabled={disabled}
+        inputRef={inputRef}
+      />
+      {renderProps.previews}
+      {renderProps.error}
+    </>
+  );
+}
+
+function useImageAttachmentDrop(
+  disabled: boolean | undefined,
+  addFiles: (files: File[]) => void,
+) {
+  return (event: DragEvent<HTMLFieldSetElement>) => {
     event.preventDefault();
     if (disabled) return;
     addFiles(Array.from(event.dataTransfer.files));
   };
+}
+
+export function ImageAttachmentPicker({
+  attachments,
+  children,
+  disabled,
+  onChange,
+}: ImageAttachmentPickerProps) {
+  const { addFiles, error, inputRef, onFileChange } = useImageAttachmentInput({
+    attachments,
+    onChange,
+  });
+  const onDrop = useImageAttachmentDrop(disabled, addFiles);
+  const canAdd = !disabled && attachments.length < MAX_IMAGE_COUNT;
+  const openPicker = () => {
+    if (canAdd) inputRef.current?.click();
+  };
+  const renderProps = buildPickerRenderProps({
+    attachments,
+    canAdd,
+    error,
+    onChange,
+    openPicker,
+  });
   return (
     <fieldset
       onDragOver={(event) => event.preventDefault()}
@@ -179,18 +265,22 @@ export function ImageAttachmentPicker({
     >
       <HiddenImageInput inputRef={inputRef} onFileChange={onFileChange} />
       <legend className="sr-only">图片附件</legend>
-      <ImageAttachmentActions
-        attachments={attachments}
-        disabled={disabled}
-        inputRef={inputRef}
-      />
-      <ImageAttachmentList attachments={attachments} onChange={onChange} />
-      {error && <div className="text-xs text-status-error">{error}</div>}
+      {children ? (
+        children(renderProps)
+      ) : (
+        <DefaultImageAttachmentPickerContent
+          attachments={attachments}
+          disabled={disabled}
+          inputRef={inputRef}
+          renderProps={renderProps}
+        />
+      )}
     </fieldset>
   );
 }
 interface ImageAttachmentPickerProps {
   attachments: File[];
+  children?: (props: ImageAttachmentPickerRenderProps) => ReactNode;
   disabled?: boolean;
   onChange: (files: File[]) => void;
 }

--- a/packages/along-web/src/task-planning/actionTypes.ts
+++ b/packages/along-web/src/task-planning/actionTypes.ts
@@ -1,4 +1,4 @@
-import type { TaskPlanningSnapshot } from '../types';
+import type { TaskExecutionMode, TaskPlanningSnapshot } from '../types';
 import type {
   ApproveTaskPlanResponse,
   CloseTaskResponse,
@@ -24,6 +24,7 @@ export interface UseTaskPlanningActionsInput {
   draft: DraftTaskInput;
   messageBody: string;
   messageAttachments: File[];
+  messageExecutionMode: TaskExecutionMode;
   busyAction: string | null;
   repositoriesRefreshing: boolean;
   canApprove: boolean;
@@ -38,6 +39,9 @@ export interface UseTaskPlanningActionsInput {
   >;
   setMessageBody: React.Dispatch<React.SetStateAction<string>>;
   setMessageAttachments: React.Dispatch<React.SetStateAction<File[]>>;
+  setMessageExecutionMode: React.Dispatch<
+    React.SetStateAction<TaskExecutionMode>
+  >;
   setBusyAction: React.Dispatch<React.SetStateAction<string | null>>;
   setRepositoriesRefreshing: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;

--- a/packages/along-web/src/task-planning/useTaskDraftActions.ts
+++ b/packages/along-web/src/task-planning/useTaskDraftActions.ts
@@ -47,6 +47,7 @@ function clearSelectedTask(input: UseTaskPlanningActionsInput) {
   input.setSelectedSnapshot(null);
   input.setMessageBody('');
   input.setMessageAttachments([]);
+  input.setMessageExecutionMode('manual');
 }
 
 function resetDraft(input: UseTaskPlanningActionsInput) {

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -63,6 +63,7 @@ function useSelectionActions(input: UseTaskPlanningActionsInput) {
     input.setSelectedSnapshot(snapshot);
     input.setMessageBody('');
     input.setMessageAttachments([]);
+    input.setMessageExecutionMode(snapshot.task.executionMode);
   };
   return { selectTask };
 }
@@ -100,7 +101,11 @@ function useMessageActions(
     const attachments = input.messageAttachments;
     if (!input.selected || input.busyAction) return;
     await runBusy(input, 'message', async () => {
-      const payload = { body, autoRun: true };
+      const payload = {
+        body,
+        autoRun: true,
+        executionMode: input.messageExecutionMode,
+      };
       const result =
         attachments.length > 0
           ? await postSelectedMultipart<SubmitTaskMessageResponse>(

--- a/packages/along-web/src/task-planning/useTaskPlanningController.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningController.ts
@@ -1,5 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
-import type { TaskFlowActionId, TaskPlanningSnapshot } from '../types';
+import type {
+  TaskExecutionMode,
+  TaskFlowActionId,
+  TaskPlanningSnapshot,
+} from '../types';
 import type { RepositoryOption } from './api';
 import { useTaskPlanningActions } from './useTaskPlanningActions';
 import {
@@ -27,6 +31,8 @@ function usePlanningBaseState() {
   const repositoryState = useRepositories();
   const [messageBody, setMessageBody] = useState('');
   const [messageAttachments, setMessageAttachments] = useState<File[]>([]);
+  const [messageExecutionMode, setMessageExecutionMode] =
+    useState<TaskExecutionMode>('manual');
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [repositoriesRefreshing, setRepositoriesRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,6 +43,8 @@ function usePlanningBaseState() {
     setMessageBody,
     messageAttachments,
     setMessageAttachments,
+    messageExecutionMode,
+    setMessageExecutionMode,
     busyAction,
     setBusyAction,
     repositoriesRefreshing,
@@ -127,6 +135,7 @@ function usePlanningActions(
     draft: base.repositoryState.draft,
     messageBody: base.messageBody,
     messageAttachments: base.messageAttachments,
+    messageExecutionMode: base.messageExecutionMode,
     busyAction: base.busyAction,
     repositoriesRefreshing: base.repositoriesRefreshing,
     ...flowFlags,
@@ -137,6 +146,7 @@ function usePlanningActions(
     setSelectedSnapshot: base.taskState.setSelectedSnapshot,
     setMessageBody: base.setMessageBody,
     setMessageAttachments: base.setMessageAttachments,
+    setMessageExecutionMode: base.setMessageExecutionMode,
     setBusyAction: base.setBusyAction,
     setRepositoriesRefreshing: base.setRepositoriesRefreshing,
     setError: base.setError,
@@ -157,12 +167,14 @@ export function useTaskPlanningController() {
     ...derived,
     messageBody: base.messageBody,
     messageAttachments: base.messageAttachments,
+    messageExecutionMode: base.messageExecutionMode,
     loading: loadState.loading,
     busyAction: base.busyAction,
     repositoriesRefreshing: base.repositoriesRefreshing,
     error: base.error,
     setMessageBody: base.setMessageBody,
     setMessageAttachments: base.setMessageAttachments,
+    setMessageExecutionMode: base.setMessageExecutionMode,
     ...actions,
   };
 }


### PR DESCRIPTION
along-task: #23

## 修改内容
- `packages/along-web/src/TaskPlanningView.tsx`
- `packages/along-web/src/task-planning/ExistingTaskComposer.tsx`
- `packages/along-web/src/task-planning/TaskComposerInput.tsx`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskImageAttachments.tsx`
- `packages/along-web/src/task-planning/actionTypes.ts`
- `packages/along-web/src/task-planning/useTaskDraftActions.ts`
- `packages/along-web/src/task-planning/useTaskPlanningActions.ts`
- `packages/along-web/src/task-planning/useTaskPlanningController.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-23`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
## Assessment
该需求成立，目标是统一新建任务聊天框与已有会话聊天窗口的输入区交互，降低视觉噪音并为后续附件类型扩展预留入口。改动属于前端交互与布局优化，不应改变消息发送、图片上传、执行模式含义和会话数据结构的核心业务语义。

## Summary
将图片上传入口收纳进输入区左侧加号 Popover；将执行模式放到加号右侧的下拉控件，默认显示“人工确认”，可切换“全自动”；将发送按钮改为图标按钮并与附件入口、模式选择保持同一操作行；移除“任务内容”标题、图片文件名/大小展示和“创建到当前仓库”按钮；新建任务输入框与已有会话输入框保持一致体验。

```mermaid
flowchart TD
  U[用户输入区] --> A[顶部附件预览区]
  U --> B[文本输入区]
  U --> C[底部操作行]
  C --> P[加号 Popover]
  P --> I[图片上传项]
  C --> M[执行模式下拉]
  M --> H[人工确认]
  M --> F[全自动]
  C --> S[图标发送按钮]
  I --> A
  A --> D[悬停显示删除图标]
  S --> E[沿用现有发送流程]
```

## Implementation Changes
1. 统一抽象或复用聊天输入区组件，使新建任务场景和已有会话场景共享同一套附件入口、附件预览、执行模式选择和发送按钮布局；若当前已有公共组件，则在公共组件内完成改造，避免两处逻辑分叉。
2. 将原图片上传按钮移动到左侧加号 Popover 内，Popover 项包含图片图标和“图片”文案；点击该项触发现有图片选择/上传逻辑。Popover 结构需保留可扩展性，后续可继续加入文件、链接等附件类型，但本次只实现图片项。
3. 图片添加成功后在文本输入框上方展示缩略图预览；移除“任务内容”标题、图片名称和图片大小展示。图片预览默认只展示图片本身，鼠标悬停或键盘聚焦时显示删除图标，点击后移除该图片并同步更新待发送附件状态。
4. 将执行模式控件放在加号按钮右侧，以下拉框形式展示当前模式；默认值为“人工确认”，可切换为“全自动”。切换后必须继续写入现有发送参数/任务创建参数中的执行模式字段，不新增与现有语义冲突的状态。
5. 将发送按钮改为图标按钮，放在底部操作行右侧，并与加号按钮、执行模式下拉保持同一行。按钮可用/禁用、加载态和提交行为沿用现有规则。
6. 删除输入区中的“创建到当前仓库”按钮及其直接入口，不再作为聊天框主操作出现；如该能力仍有业务价值，应保留底层能力但从本次输入区 UI 中移除。
7. 在已有会话聊天窗口应用同样改动，确保附件预览、删除、模式切换和发送行为与新建任务场景一致。
8. 响应式布局需保证操作行在常见桌面和窄屏宽度下不重叠：加号与发送为图标按钮，执行模式下拉在空间不足时可压缩但文案不可溢出遮挡。

## Contracts / Interfaces
- 图片上传、附件状态和消息发送沿用现有数据结构；本次不引入新的后端接口。
- 执行模式只允许在现有支持的模式值之间切换：人工确认与全自动；默认值为人工确认。
- 删除图片只影响当前输入框待发送附件，不影响已发送消息或历史会话附件。
- 新建任务输入区与已有会话输入区对外暴露的发送参数应保持一致，避免同一交互在不同场景产生不同 payload。

## Failure Handling
- 图片选择取消时不改变当前附件状态。
- 图片上传或读取失败时保留当前输入内容和已有附件，并展示现有错误提示机制中的用户可见错误。
- 发送中应禁用发送按钮或保持现有防重复提交策略，避免重复发送。
- 执行模式切换失败若只是本地状态异常，应回退到“人工确认”并避免提交不合法模式值。

## Test Plan
1. 手动验证新建任务输入区：打开加号 Popover、点击图片项、选择图片、预览展示、悬停显示删除图标、删除图片、发送消息。
2. 手动验证已有会话输入区执行同样流程，确认 UI 和 payload 行为一致。
3. 验证执行模式默认是“人工确认”，切换“全自动”后发送时参数正确；再次切回后参数恢复。
4. 验证无文本仅图片、有文本无图片、文本加图片三类发送场景。
5. 验证“创建到当前仓库”按钮不再出现在两个聊天输入场景。
6. 如项目已有前端测试，补充或更新聊天输入组件测试，覆盖附件入口、删除预览、模式切换和发送回调。
7. 运行项目现有 lint、typecheck 和相关测试脚本；若无法完整运行，需记录未验证项和风险。

## Assumptions
- “人工确认”和“全自动”对应项目中已有执行模式，不需要新增后端枚举或迁移历史数据。
- 参考图仅用于布局和交互方向，不要求像素级复刻。
- 本次目标是简化聊天框主流程，不处理除图片外的其他附件类型。

## 交付信息
- Commit: 03831044f65c36aed2925d26b0200eec0cfafb1b