### PR TITLE
Task #19: 任务状态显示逻辑优化

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -23,8 +23,8 @@ import { TaskRecordsPanel } from './TaskRecords';
 
 function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
   const [isExpanded, setIsExpanded] = useState(true);
-  const executionMode =
-    selected.task.executionMode === 'autonomous' ? '全自动' : '人工确认';
+  const statusLabel =
+    selected.display?.label || getTaskStatusLabel(selected.task.status);
   return (
     <aside className="min-w-0 rounded-lg border border-border-color bg-black/25">
       <button
@@ -40,8 +40,7 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
             </span>
             {!isExpanded && (
               <span className="truncate text-xs text-text-muted">
-                {getTaskStatusLabel(selected.task.status)} ·{' '}
-                {formatTime(selected.task.updatedAt)}
+                {statusLabel} · {formatTime(selected.task.updatedAt)}
               </span>
             )}
           </div>
@@ -51,63 +50,91 @@ function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
         </div>
       </button>
       {isExpanded && (
-        <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-4 pb-4 text-sm">
-          <span className="text-text-muted">ID</span>
-          <span className="truncate">{selected.task.taskId}</span>
-          {selected.task.seq != null && (
-            <>
-              <span className="text-text-muted">Seq</span>
-              <span>#{selected.task.seq}</span>
-            </>
-          )}
-          {selected.task.type && (
-            <>
-              <span className="text-text-muted">Type</span>
-              <span>{selected.task.type}</span>
-            </>
-          )}
-          <span className="text-text-muted">Thread</span>
-          <span className="truncate">{selected.thread.threadId}</span>
-          <span className="text-text-muted">Plan Status</span>
-          <span>{getThreadStatusLabel(selected.thread.status)}</span>
-          <span className="text-text-muted">Source</span>
-          <span>{selected.task.source}</span>
-          <span className="text-text-muted">Mode</span>
-          <span>{executionMode}</span>
-          <span className="text-text-muted">Status</span>
-          <span>{getTaskStatusLabel(selected.task.status)}</span>
-          {selected.task.branchName && (
-            <>
-              <span className="text-text-muted">Branch</span>
-              <span className="truncate">{selected.task.branchName}</span>
-            </>
-          )}
-          {selected.task.worktreePath && (
-            <>
-              <span className="text-text-muted">Worktree</span>
-              <span className="truncate" title={selected.task.worktreePath}>
-                {selected.task.worktreePath}
-              </span>
-            </>
-          )}
-          {selected.task.prUrl && (
-            <>
-              <span className="text-text-muted">PR</span>
-              <a
-                href={selected.task.prUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="truncate text-brand hover:text-brand-hover"
-              >
-                #{selected.task.prNumber || selected.task.prUrl}
-              </a>
-            </>
-          )}
-          <span className="text-text-muted">Updated</span>
-          <span>{formatTime(selected.task.updatedAt)}</span>
-        </div>
+        <TaskInfoRows selected={selected} statusLabel={statusLabel} />
       )}
     </aside>
+  );
+}
+
+function TaskInfoRows({
+  selected,
+  statusLabel,
+}: {
+  selected: TaskPlanningSnapshot;
+  statusLabel: string;
+}) {
+  const executionMode =
+    selected.task.executionMode === 'autonomous' ? '全自动' : '人工确认';
+  return (
+    <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-4 pb-4 text-sm">
+      <span className="text-text-muted">ID</span>
+      <span className="truncate">{selected.task.taskId}</span>
+      {selected.task.seq != null && (
+        <>
+          <span className="text-text-muted">Seq</span>
+          <span>#{selected.task.seq}</span>
+        </>
+      )}
+      {selected.task.type && (
+        <>
+          <span className="text-text-muted">Type</span>
+          <span>{selected.task.type}</span>
+        </>
+      )}
+      <span className="text-text-muted">Thread</span>
+      <span className="truncate">{selected.thread.threadId}</span>
+      <span className="text-text-muted">Plan Status</span>
+      <span>{getThreadStatusLabel(selected.thread.status)}</span>
+      <span className="text-text-muted">Workflow</span>
+      <span>{selected.task.currentWorkflowKind}</span>
+      <span className="text-text-muted">Source</span>
+      <span>{selected.task.source}</span>
+      <span className="text-text-muted">Mode</span>
+      <span>{executionMode}</span>
+      <span className="text-text-muted">Status</span>
+      <span>{statusLabel}</span>
+      <TaskInfoOptionalRows selected={selected} />
+      <span className="text-text-muted">Updated</span>
+      <span>{formatTime(selected.task.updatedAt)}</span>
+    </div>
+  );
+}
+
+function TaskInfoOptionalRows({
+  selected,
+}: {
+  selected: TaskPlanningSnapshot;
+}) {
+  return (
+    <>
+      {selected.task.branchName && (
+        <>
+          <span className="text-text-muted">Branch</span>
+          <span className="truncate">{selected.task.branchName}</span>
+        </>
+      )}
+      {selected.task.worktreePath && (
+        <>
+          <span className="text-text-muted">Worktree</span>
+          <span className="truncate" title={selected.task.worktreePath}>
+            {selected.task.worktreePath}
+          </span>
+        </>
+      )}
+      {selected.task.prUrl && (
+        <>
+          <span className="text-text-muted">PR</span>
+          <a
+            href={selected.task.prUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="truncate text-brand hover:text-brand-hover"
+          >
+            #{selected.task.prNumber || selected.task.prUrl}
+          </a>
+        </>
+      )}
+    </>
   );
 }
 

--- a/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowStageCard.tsx
@@ -3,7 +3,7 @@ import type {
   TaskFlowStage,
   TaskPlanRevisionRecord,
 } from '../types';
-import { getFlowActionClass, getFlowStageDotClass } from './format';
+import { getFlowActionClass, getFlowStageDotClass } from './flowFormat';
 
 export function getStageActionScope(
   actions: TaskFlowAction[],

--- a/packages/along-web/src/task-planning/TaskStatusBadge.tsx
+++ b/packages/along-web/src/task-planning/TaskStatusBadge.tsx
@@ -1,4 +1,5 @@
 import type { TaskPlanningSnapshot } from '../types';
+import { getTaskDisplayClass } from './displayFormat';
 import { getTaskStatusClass, getTaskStatusLabel } from './format';
 
 export function TaskStatusBadge({
@@ -8,11 +9,13 @@ export function TaskStatusBadge({
 }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${getTaskStatusClass(
-        snapshot.task.status,
-      )}`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${
+        snapshot.display
+          ? getTaskDisplayClass(snapshot.display.state)
+          : getTaskStatusClass(snapshot.task.status)
+      }`}
     >
-      {getTaskStatusLabel(snapshot.task.status)}
+      {snapshot.display?.label || getTaskStatusLabel(snapshot.task.status)}
     </span>
   );
 }

--- a/packages/along-web/src/task-planning/displayFormat.ts
+++ b/packages/along-web/src/task-planning/displayFormat.ts
@@ -1,0 +1,30 @@
+import type { TaskDisplayState } from '../types';
+
+export function getTaskDisplayClass(state: TaskDisplayState): string {
+  switch (state) {
+    case 'ask_active':
+      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
+    case 'ask_answered':
+      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
+    case 'waiting_user':
+    case 'planning_awaiting_approval':
+      return 'bg-amber-500/15 text-amber-300 border-amber-500/30';
+    case 'planning_drafting':
+      return 'bg-sky-500/15 text-sky-300 border-sky-500/30';
+    case 'planning_feedback':
+    case 'implementation_verifying':
+      return 'bg-violet-500/15 text-violet-300 border-violet-500/30';
+    case 'planning_planned':
+      return 'bg-blue-500/15 text-blue-300 border-blue-500/30';
+    case 'implementation_implementing':
+      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
+    case 'completed':
+      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
+    case 'failed':
+      return 'bg-rose-500/15 text-rose-300 border-rose-500/30';
+    case 'cancelled':
+      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
+    default:
+      return 'bg-white/10 text-text-secondary border-border-color';
+  }
+}

--- a/packages/along-web/src/task-planning/flowActionRouter.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.ts
@@ -59,6 +59,7 @@ function runStageAction(
 ) {
   if (id === 'approve_plan')
     runSimpleAction('approve', 'approve', input.canApprove);
+  if (id === 'request_plan') runSimpleAction('planner', 'planner', true);
   if (id === 'rerun_planner') runSimpleAction('planner', 'planner', true);
   if (id === 'start_implementation') {
     runSimpleAction('implementation', 'implementation', input.canImplement);

--- a/packages/along-web/src/task-planning/flowFormat.ts
+++ b/packages/along-web/src/task-planning/flowFormat.ts
@@ -1,0 +1,42 @@
+import type { TaskFlowAction, TaskFlowStageState } from '../types';
+
+export function getFlowStageStateClass(state: TaskFlowStageState): string {
+  switch (state) {
+    case 'completed':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200';
+    case 'current':
+      return 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100';
+    case 'blocked':
+      return 'border-rose-500/40 bg-rose-500/10 text-rose-100';
+    case 'attention':
+      return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+    default:
+      return 'border-border-color bg-black/20 text-text-muted';
+  }
+}
+
+export function getFlowStageDotClass(state: TaskFlowStageState): string {
+  switch (state) {
+    case 'completed':
+      return 'bg-emerald-400';
+    case 'current':
+      return 'bg-cyan-300 shadow-[0_0_0_4px_rgba(34,211,238,0.12)]';
+    case 'blocked':
+      return 'bg-rose-300 shadow-[0_0_0_4px_rgba(251,113,133,0.12)]';
+    case 'attention':
+      return 'bg-amber-300 shadow-[0_0_0_4px_rgba(251,191,36,0.12)]';
+    default:
+      return 'bg-zinc-600';
+  }
+}
+
+export function getFlowActionClass(action: TaskFlowAction): string {
+  if (!action.enabled) return 'border-border-color text-text-muted bg-black/20';
+  if (action.variant === 'danger') {
+    return 'border-rose-500/40 text-rose-100 bg-rose-500/10 hover:bg-rose-500/20';
+  }
+  if (action.variant === 'primary') {
+    return 'border-brand bg-brand text-white hover:bg-brand-hover';
+  }
+  return 'border-border-color text-text-secondary hover:bg-white/5';
+}

--- a/packages/along-web/src/task-planning/format.ts
+++ b/packages/along-web/src/task-planning/format.ts
@@ -3,9 +3,7 @@ import type {
   TaskAgentStageRecord,
   TaskAgentStageStatus,
   TaskArtifactType,
-  TaskFlowAction,
   TaskFlowSnapshot,
-  TaskFlowStageState,
   TaskPlanningSnapshot,
   TaskStatus,
   TaskThreadStatus,
@@ -37,6 +35,12 @@ export function formatDuration(startedAt: string, endedAt?: string): string {
 
 export function getThreadStatusLabel(status: TaskThreadStatus): string {
   switch (status) {
+    case 'active':
+      return '进行中';
+    case 'waiting_user':
+      return '待补充';
+    case 'answered':
+      return '已回答';
     case 'drafting':
       return '起草中';
     case 'awaiting_approval':
@@ -45,6 +49,16 @@ export function getThreadStatusLabel(status: TaskThreadStatus): string {
       return '讨论中';
     case 'approved':
       return '已批准';
+    case 'planned':
+      return '已规划';
+    case 'implementing':
+      return '实现中';
+    case 'verifying':
+      return '验证中';
+    case 'completed':
+      return '已完成';
+    case 'failed':
+      return '失败';
     default:
       return status;
   }
@@ -239,36 +253,6 @@ export function getArtifactClass(type: TaskArtifactType): string {
   }
 }
 
-export function getFlowStageStateClass(state: TaskFlowStageState): string {
-  switch (state) {
-    case 'completed':
-      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200';
-    case 'current':
-      return 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100';
-    case 'blocked':
-      return 'border-rose-500/40 bg-rose-500/10 text-rose-100';
-    case 'attention':
-      return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
-    default:
-      return 'border-border-color bg-black/20 text-text-muted';
-  }
-}
-
-export function getFlowStageDotClass(state: TaskFlowStageState): string {
-  switch (state) {
-    case 'completed':
-      return 'bg-emerald-400';
-    case 'current':
-      return 'bg-cyan-400';
-    case 'blocked':
-      return 'bg-rose-400';
-    case 'attention':
-      return 'bg-amber-400';
-    default:
-      return 'bg-text-muted';
-  }
-}
-
 export function getFlowSeverityClass(
   severity: TaskFlowSnapshot['severity'],
 ): string {
@@ -282,14 +266,4 @@ export function getFlowSeverityClass(
     default:
       return 'border-cyan-500/25 bg-cyan-500/10 text-cyan-100';
   }
-}
-
-export function getFlowActionClass(action: TaskFlowAction): string {
-  if (action.variant === 'danger') {
-    return 'border-rose-500/30 bg-rose-500/15 text-rose-200 hover:bg-rose-500/25';
-  }
-  if (action.variant === 'primary') {
-    return 'border-brand bg-brand text-white hover:bg-brand-hover';
-  }
-  return 'border-border-color text-text-secondary hover:bg-white/5';
 }

--- a/packages/along-web/src/types-flow.ts
+++ b/packages/along-web/src/types-flow.ts
@@ -1,0 +1,86 @@
+export type TaskFlowStageId =
+  | 'ask'
+  | 'requirements'
+  | 'plan_discussion'
+  | 'plan_confirmation'
+  | 'implementation'
+  | 'delivery'
+  | 'completed';
+
+export type TaskFlowStageState =
+  | 'pending'
+  | 'current'
+  | 'completed'
+  | 'blocked'
+  | 'attention';
+
+export type TaskFlowActionId =
+  | 'submit_feedback'
+  | 'request_plan'
+  | 'approve_plan'
+  | 'request_revision'
+  | 'rerun_planner'
+  | 'start_implementation'
+  | 'confirm_implementation_steps'
+  | 'resume_failed_stage'
+  | 'copy_resume_command'
+  | 'manual_complete'
+  | 'start_delivery'
+  | 'accept_delivery'
+  | 'request_changes'
+  | 'close_task';
+
+export type TaskFlowEventType =
+  | 'task_created'
+  | 'user_feedback'
+  | 'plan_revision'
+  | 'plan_approved'
+  | 'implementation_steps_approved'
+  | 'feedback_round'
+  | 'agent_run_started'
+  | 'agent_run_succeeded'
+  | 'agent_run_failed'
+  | 'agent_run_cancelled'
+  | 'delivery_updated'
+  | 'task_completed'
+  | 'task_closed';
+
+export interface TaskFlowAction {
+  id: TaskFlowActionId;
+  label: string;
+  description: string;
+  enabled: boolean;
+  disabledReason?: string;
+  stage: TaskFlowStageId;
+  variant: 'primary' | 'secondary' | 'danger';
+}
+
+export interface TaskFlowStage {
+  id: TaskFlowStageId;
+  label: string;
+  summary: string;
+  state: TaskFlowStageState;
+  blocker?: string;
+  details: string[];
+  startedAt?: string;
+  endedAt?: string;
+}
+
+export interface TaskFlowEvent {
+  eventId: string;
+  type: TaskFlowEventType;
+  stage: TaskFlowStageId;
+  title: string;
+  summary?: string;
+  occurredAt: string;
+}
+
+export interface TaskFlowSnapshot {
+  currentStageId: TaskFlowStageId;
+  conclusion: string;
+  severity: 'normal' | 'warning' | 'blocked' | 'success';
+  stages: TaskFlowStage[];
+  actions: TaskFlowAction[];
+  blockers: string[];
+  events: TaskFlowEvent[];
+}

--- a/packages/along-web/src/types-task.ts
+++ b/packages/along-web/src/types-task.ts
@@ -1,3 +1,27 @@
+import type { TaskFlowSnapshot } from './types-flow';
+import type {
+  TaskDisplay,
+  TaskLifecycle,
+  WorkflowKind,
+} from './types-workflow';
+
+export type {
+  TaskFlowAction,
+  TaskFlowActionId,
+  TaskFlowEvent,
+  TaskFlowEventType,
+  TaskFlowSnapshot,
+  TaskFlowStage,
+  TaskFlowStageId,
+  TaskFlowStageState,
+} from './types-flow';
+export type {
+  TaskDisplay,
+  TaskDisplayState,
+  TaskLifecycle,
+  WorkflowKind,
+} from './types-workflow';
+
 export type TaskStatus =
   | 'planning'
   | 'planning_approved'
@@ -11,10 +35,18 @@ export type TaskStatus =
 export type TaskExecutionMode = 'manual' | 'autonomous';
 
 export type TaskThreadStatus =
+  | 'active'
+  | 'waiting_user'
+  | 'answered'
   | 'drafting'
   | 'awaiting_approval'
   | 'discussing'
-  | 'approved';
+  | 'approved'
+  | 'planned'
+  | 'implementing'
+  | 'verifying'
+  | 'completed'
+  | 'failed';
 
 export type TaskArtifactType =
   | 'user_message'
@@ -45,6 +77,8 @@ export interface TaskItemRecord {
   body: string;
   source: string;
   status: TaskStatus;
+  lifecycle?: TaskLifecycle;
+  currentWorkflowKind?: WorkflowKind;
   activeThreadId?: string;
   repoOwner?: string;
   repoName?: string;
@@ -64,7 +98,7 @@ export interface TaskItemRecord {
 export interface TaskThreadRecord {
   threadId: string;
   taskId: string;
-  purpose: 'planning';
+  purpose: WorkflowKind;
   status: TaskThreadStatus;
   currentPlanId?: string;
   openRoundId?: string;
@@ -204,94 +238,10 @@ export interface TaskAgentStageRecord {
   manualResume?: TaskAgentManualResume;
 }
 
-export type TaskFlowStageId =
-  | 'requirements'
-  | 'plan_discussion'
-  | 'plan_confirmation'
-  | 'implementation'
-  | 'delivery'
-  | 'completed';
-
-export type TaskFlowStageState =
-  | 'pending'
-  | 'current'
-  | 'completed'
-  | 'blocked'
-  | 'attention';
-
-export type TaskFlowActionId =
-  | 'submit_feedback'
-  | 'approve_plan'
-  | 'request_revision'
-  | 'rerun_planner'
-  | 'start_implementation'
-  | 'confirm_implementation_steps'
-  | 'resume_failed_stage'
-  | 'copy_resume_command'
-  | 'manual_complete'
-  | 'start_delivery'
-  | 'accept_delivery'
-  | 'request_changes'
-  | 'close_task';
-
-export type TaskFlowEventType =
-  | 'task_created'
-  | 'user_feedback'
-  | 'plan_revision'
-  | 'plan_approved'
-  | 'implementation_steps_approved'
-  | 'feedback_round'
-  | 'agent_run_started'
-  | 'agent_run_succeeded'
-  | 'agent_run_failed'
-  | 'agent_run_cancelled'
-  | 'delivery_updated'
-  | 'task_completed'
-  | 'task_closed';
-
-export interface TaskFlowAction {
-  id: TaskFlowActionId;
-  label: string;
-  description: string;
-  enabled: boolean;
-  disabledReason?: string;
-  stage: TaskFlowStageId;
-  variant: 'primary' | 'secondary' | 'danger';
-}
-
-export interface TaskFlowStage {
-  id: TaskFlowStageId;
-  label: string;
-  summary: string;
-  state: TaskFlowStageState;
-  blocker?: string;
-  details: string[];
-  startedAt?: string;
-  endedAt?: string;
-}
-
-export interface TaskFlowEvent {
-  eventId: string;
-  type: TaskFlowEventType;
-  stage: TaskFlowStageId;
-  title: string;
-  summary?: string;
-  occurredAt: string;
-}
-
-export interface TaskFlowSnapshot {
-  currentStageId: TaskFlowStageId;
-  conclusion: string;
-  severity: 'normal' | 'warning' | 'blocked' | 'success';
-  stages: TaskFlowStage[];
-  actions: TaskFlowAction[];
-  blockers: string[];
-  events: TaskFlowEvent[];
-}
-
 export interface TaskPlanningSnapshot {
   task: TaskItemRecord;
   thread: TaskThreadRecord;
+  display?: TaskDisplay;
   currentPlan: TaskPlanRevisionRecord | null;
   openRound: TaskFeedbackRoundRecord | null;
   artifacts: TaskArtifactRecord[];

--- a/packages/along-web/src/types-workflow.ts
+++ b/packages/along-web/src/types-workflow.ts
@@ -1,0 +1,30 @@
+export type TaskLifecycle =
+  | 'open'
+  | 'waiting_user'
+  | 'ready'
+  | 'running'
+  | 'completed'
+  | 'cancelled'
+  | 'failed';
+
+export type WorkflowKind = 'ask' | 'planning' | 'implementation';
+
+export type TaskDisplayState =
+  | 'ask_active'
+  | 'waiting_user'
+  | 'ask_answered'
+  | 'planning_drafting'
+  | 'planning_awaiting_approval'
+  | 'planning_feedback'
+  | 'planning_planned'
+  | 'implementation_implementing'
+  | 'implementation_verifying'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'processing';
+
+export interface TaskDisplay {
+  state: TaskDisplayState;
+  label: string;
+}

--- a/packages/along/src/agents/task-planning.ts
+++ b/packages/along/src/agents/task-planning.ts
@@ -115,20 +115,27 @@ function buildSnapshotSummary(snapshot: TaskPlanningSnapshot): string {
   return JSON.stringify(summary, null, 2);
 }
 
-export function buildPlannerPrompt(snapshot: TaskPlanningSnapshot): string {
-  const hasCurrentPlan = Boolean(snapshot.currentPlan);
-  const hasOpenRound = Boolean(snapshot.openRound);
-
+function buildPlannerPromptIntro(isAsk: boolean): string[] {
   return [
-    '你是 Along 的 Planning Agent，只负责输出一个可直接落库的任务规划结果。',
-    '你的目标是帮助用户把一个 Task 讨论到足够清晰，然后给出正式 Plan，或在必要时先提出澄清。',
+    isAsk
+      ? '你是 Along 的 Ask Agent，负责回答咨询、解释代码、探索方案，但不默认创建正式计划。'
+      : '你是 Along 的 Planning Agent，只负责输出一个可直接落库的任务规划结果。',
+    isAsk
+      ? '你的目标是直接回答用户问题；只有用户明确要求制定计划、修复、实现或改代码时，才输出正式 Plan。'
+      : '你的目标是帮助用户把一个 Task 讨论到足够清晰，然后给出正式 Plan，或在必要时先提出澄清。',
     '',
+  ];
+}
+
+function buildPlannerPromptRules(): string[] {
+  return [
     '要求：',
     '1. 只输出 JSON，不要输出 Markdown、代码块、解释或前后缀文本。',
     '2. JSON 结构必须是：{"action":"plan_revision"|"planning_update","body":"...","type":"feat"|"fix"|...}',
     '3. body 必须是中文，且是最终要落库的正文。',
     '4. action = "plan_revision" 表示你已经给出了正式计划或计划修订。',
     '5. action = "planning_update" 表示你是在回答问题、澄清约束或补充上下文，但还不是正式计划。',
+    '5a. 当前 workflow=ask 时，默认使用 planning_update 回答咨询；不要因为能想到实现方式就自动升级为 plan_revision。',
     '6. 如果信息仍然不足以形成正式计划，优先输出 planning_update，明确指出还缺什么。',
     '7. 如果当前已经有 Plan 且存在 open feedback round，优先结合反馈决定是 answer_only 还是 revise_plan 的语义，但输出仍然只用上面的两个 action。',
     '8. type 字段必须提供 conventional commit 类型（feat/fix/docs/style/refactor/perf/test/chore/ci），planning_update 可使用 chore。',
@@ -141,6 +148,17 @@ export function buildPlannerPrompt(snapshot: TaskPlanningSnapshot): string {
     '15. 对涉及多个模块、状态流转、数据流、跨端交互或多阶段 agent 编排的大计划，正文必须包含 Mermaid 图表，从整体上展示结构、流程或状态机；小型单点修改不强制加图。',
     '16. 正式计划推荐包含 Assessment、Summary、Implementation Changes、Test Plan、Assumptions；涉及跨模块契约、API、类型、状态、持久化或外部调用方时，再补充 Contracts / Interfaces。',
     '',
+  ];
+}
+
+export function buildPlannerPrompt(snapshot: TaskPlanningSnapshot): string {
+  const hasCurrentPlan = Boolean(snapshot.currentPlan);
+  const hasOpenRound = Boolean(snapshot.openRound);
+  const isAsk = snapshot.task.currentWorkflowKind === 'ask';
+
+  return [
+    ...buildPlannerPromptIntro(isAsk),
+    ...buildPlannerPromptRules(),
     `当前状态: hasCurrentPlan=${hasCurrentPlan}, hasOpenRound=${hasOpenRound}`,
     '',
     '任务快照：',

--- a/packages/along/src/agents/task-planning.ts
+++ b/packages/along/src/agents/task-planning.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { TaskPlanningSnapshot } from '../domain/task-planning';
+import { WORKFLOW_KIND } from '../domain/task-workflow-state';
 
 export const PLANNER_OUTPUT_SCHEMA = z.object({
   action: z.enum(['plan_revision', 'planning_update']),
@@ -89,7 +90,9 @@ function buildSnapshotSummary(snapshot: TaskPlanningSnapshot): string {
       title: snapshot.task.title,
       body: truncateText(snapshot.task.body, 4000),
       source: snapshot.task.source,
-      status: snapshot.task.status,
+      lifecycle: snapshot.task.lifecycle,
+      currentWorkflowKind: snapshot.task.currentWorkflowKind,
+      display: snapshot.display,
     },
     thread: {
       threadId: snapshot.thread.threadId,
@@ -154,7 +157,7 @@ function buildPlannerPromptRules(): string[] {
 export function buildPlannerPrompt(snapshot: TaskPlanningSnapshot): string {
   const hasCurrentPlan = Boolean(snapshot.currentPlan);
   const hasOpenRound = Boolean(snapshot.openRound);
-  const isAsk = snapshot.task.currentWorkflowKind === 'ask';
+  const isAsk = snapshot.task.currentWorkflowKind === WORKFLOW_KIND.ASK;
 
   return [
     ...buildPlannerPromptIntro(isAsk),

--- a/packages/along/src/core/db-schema.ts
+++ b/packages/along/src/core/db-schema.ts
@@ -51,6 +51,8 @@ const TABLES = [
     task_id TEXT PRIMARY KEY,
     title TEXT NOT NULL, body TEXT NOT NULL, source TEXT NOT NULL,
     status TEXT NOT NULL, active_thread_id TEXT, repo_owner TEXT, repo_name TEXT,
+    lifecycle TEXT NOT NULL DEFAULT 'open',
+    current_workflow_kind TEXT NOT NULL DEFAULT 'ask',
     cwd TEXT, worktree_path TEXT, branch_name TEXT, commit_shas TEXT DEFAULT '[]',
     pr_url TEXT, pr_number INTEGER, seq INTEGER, type TEXT,
     execution_mode TEXT NOT NULL DEFAULT 'manual',
@@ -182,6 +184,8 @@ const COLUMN_MIGRATIONS = [
   'ALTER TABLE task_items ADD COLUMN seq INTEGER',
   'ALTER TABLE task_items ADD COLUMN type TEXT',
   "ALTER TABLE task_items ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'manual'",
+  "ALTER TABLE task_items ADD COLUMN lifecycle TEXT NOT NULL DEFAULT 'open'",
+  "ALTER TABLE task_items ADD COLUMN current_workflow_kind TEXT NOT NULL DEFAULT 'ask'",
 ];
 
 function execRequired(db: Database, statements: string[]) {

--- a/packages/along/src/core/db-schema.ts
+++ b/packages/along/src/core/db-schema.ts
@@ -50,7 +50,7 @@ const TABLES = [
   `CREATE TABLE IF NOT EXISTS task_items (
     task_id TEXT PRIMARY KEY,
     title TEXT NOT NULL, body TEXT NOT NULL, source TEXT NOT NULL,
-    status TEXT NOT NULL, active_thread_id TEXT, repo_owner TEXT, repo_name TEXT,
+    active_thread_id TEXT, repo_owner TEXT, repo_name TEXT,
     lifecycle TEXT NOT NULL DEFAULT 'open',
     current_workflow_kind TEXT NOT NULL DEFAULT 'ask',
     cwd TEXT, worktree_path TEXT, branch_name TEXT, commit_shas TEXT DEFAULT '[]',
@@ -149,7 +149,6 @@ const INDEXES = [
   'CREATE INDEX IF NOT EXISTS idx_comment_mirror_issue ON comment_mirror(owner, repo, issue_number, comment_id)',
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_plan_revisions_active_issue ON plan_revisions(owner, repo, issue_number) WHERE status = 'active'",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_discussion_rounds_open_issue ON discussion_rounds(owner, repo, issue_number) WHERE status IN ('open','processing','stale_partial')",
-  'CREATE INDEX IF NOT EXISTS idx_task_items_status ON task_items(status, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_task_threads_task ON task_threads(task_id, purpose, status)',
   'CREATE INDEX IF NOT EXISTS idx_task_artifacts_thread ON task_artifacts(thread_id, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_task_attachments_artifact ON task_attachments(artifact_id, created_at)',

--- a/packages/along/src/domain/task-auto-commit.test.ts
+++ b/packages/along/src/domain/task-auto-commit.test.ts
@@ -4,14 +4,34 @@ import type { Result } from '../core/result';
 const planningMocks = vi.hoisted(() => ({
   recordTaskAgentResult: vi.fn(),
   updateTaskDelivery: vi.fn(),
+  updateTaskWorkflowState: vi.fn(),
+}));
+const mockTaskConstants = vi.hoisted(() => ({
+  TASK_LIFECYCLE: {
+    READY: 'ready',
+  },
+  TASK_STATUS: {
+    IMPLEMENTING: 'implementing',
+  },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+    COMPLETED: 'completed',
+  },
+  THREAD_PURPOSE: {
+    PLANNING: 'planning',
+  },
+  WORKFLOW_KIND: {
+    IMPLEMENTATION: 'implementation',
+  },
 }));
 
 vi.mock('./task-planning', () => ({
-  TASK_STATUS: {
-    IMPLEMENTED: 'implemented',
-  },
+  TASK_LIFECYCLE: mockTaskConstants.TASK_LIFECYCLE,
+  THREAD_STATUS: mockTaskConstants.THREAD_STATUS,
+  WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
   updateTaskDelivery: planningMocks.updateTaskDelivery,
+  updateTaskWorkflowState: planningMocks.updateTaskWorkflowState,
 }));
 
 import { runTaskAutoCommit } from './task-auto-commit';
@@ -23,7 +43,7 @@ const snapshot = {
     title: '移动演示数据按钮',
     body: '删除下方的演示数据按钮应该位于礼薄列表上方。',
     source: 'web',
-    status: 'implementing',
+    status: mockTaskConstants.TASK_STATUS.IMPLEMENTING,
     activeThreadId: 'thread-1',
     repoOwner: 'ranwawa',
     repoName: 'along',
@@ -36,8 +56,8 @@ const snapshot = {
   thread: {
     threadId: 'thread-1',
     taskId: 'task-1',
-    purpose: 'planning',
-    status: 'approved',
+    purpose: mockTaskConstants.THREAD_PURPOSE.PLANNING,
+    status: mockTaskConstants.THREAD_STATUS.APPROVED,
     currentPlanId: 'plan-1',
     approvedPlanId: 'plan-1',
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -61,6 +81,10 @@ describe('task-auto-commit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     planningMocks.updateTaskDelivery.mockReturnValue({
+      success: true,
+      data: undefined,
+    });
+    planningMocks.updateTaskWorkflowState.mockReturnValue({
       success: true,
       data: undefined,
     });
@@ -108,10 +132,15 @@ describe('task-auto-commit', () => {
     expect(calls).toContain('git commit -m fix(task): 完成移动演示数据按钮');
     expect(planningMocks.updateTaskDelivery).toHaveBeenCalledWith({
       taskId: 'task-1',
-      status: 'implemented',
       worktreePath: '/tmp/worktree',
       branchName: 'fix/demo-1',
       commitShas: ['abc123'],
+    });
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: mockTaskConstants.THREAD_STATUS.COMPLETED,
     });
   });
 

--- a/packages/along/src/domain/task-auto-commit.ts
+++ b/packages/along/src/domain/task-auto-commit.ts
@@ -14,8 +14,11 @@ import {
 } from './task-auto-commit-utils';
 import {
   recordTaskAgentResult,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
+  THREAD_STATUS,
   updateTaskDelivery,
+  updateTaskWorkflowState,
+  WORKFLOW_KIND,
 } from './task-planning';
 import type { TaskWorktreeCommandRunner } from './task-worktree';
 
@@ -92,12 +95,18 @@ function updateCommitMetadata(
   input: RunTaskAutoCommitInput,
   commitShas: string[],
 ) {
-  return updateTaskDelivery({
+  const deliveryRes = updateTaskDelivery({
     taskId: input.snapshot.task.taskId,
-    status: TASK_STATUS.IMPLEMENTED,
     worktreePath: input.worktreePath,
     branchName: input.branchName,
     commitShas,
+  });
+  if (!deliveryRes.success) return deliveryRes;
+  return updateTaskWorkflowState({
+    taskId: input.snapshot.task.taskId,
+    lifecycle: TASK_LIFECYCLE.READY,
+    currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+    threadStatus: THREAD_STATUS.COMPLETED,
   });
 }
 

--- a/packages/along/src/domain/task-delivery.test.ts
+++ b/packages/along/src/domain/task-delivery.test.ts
@@ -9,26 +9,48 @@ const planningMocks = vi.hoisted(() => ({
   recordTaskAgentResult: vi.fn(),
   updateTaskDelivery: vi.fn(),
   updateTaskRepository: vi.fn(),
+  updateTaskWorkflowState: vi.fn(),
 }));
-
-vi.mock('./task-planning', () => ({
+const mockTaskConstants = vi.hoisted(() => ({
   AGENT_RUN_STATUS: {
     RUNNING: 'running',
     SUCCEEDED: 'succeeded',
     FAILED: 'failed',
     CANCELLED: 'cancelled',
   },
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
+    READY: 'ready',
+    RUNNING: 'running',
+  },
   TASK_STATUS: {
     IMPLEMENTED: 'implemented',
-    DELIVERING: 'delivering',
-    DELIVERED: 'delivered',
   },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+    COMPLETED: 'completed',
+    VERIFYING: 'verifying',
+  },
+  THREAD_PURPOSE: {
+    PLANNING: 'planning',
+  },
+  WORKFLOW_KIND: {
+    IMPLEMENTATION: 'implementation',
+  },
+}));
+
+vi.mock('./task-planning', () => ({
+  AGENT_RUN_STATUS: mockTaskConstants.AGENT_RUN_STATUS,
+  TASK_LIFECYCLE: mockTaskConstants.TASK_LIFECYCLE,
+  THREAD_STATUS: mockTaskConstants.THREAD_STATUS,
+  WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
   updateTaskDelivery: planningMocks.updateTaskDelivery,
   updateTaskRepository: planningMocks.updateTaskRepository,
+  updateTaskWorkflowState: planningMocks.updateTaskWorkflowState,
 }));
 
 vi.mock('../integration/github-client', () => ({
@@ -50,7 +72,9 @@ const snapshot = {
     title: '移动演示数据按钮',
     body: '删除下方的演示数据按钮应该位于礼薄列表上方。',
     source: 'web',
-    status: 'implemented',
+    status: mockTaskConstants.TASK_STATUS.IMPLEMENTED,
+    lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+    currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
     activeThreadId: 'thread-1',
     repoOwner: 'ranwawa',
     repoName: 'kinkeeper',
@@ -64,8 +88,8 @@ const snapshot = {
   thread: {
     threadId: 'thread-1',
     taskId: 'task_123456789abc',
-    purpose: 'planning',
-    status: 'approved',
+    purpose: mockTaskConstants.THREAD_PURPOSE.PLANNING,
+    status: mockTaskConstants.THREAD_STATUS.APPROVED,
     currentPlanId: 'plan-1',
     approvedPlanId: 'plan-1',
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -80,7 +104,7 @@ const snapshot = {
       taskId: 'task_123456789abc',
       threadId: 'thread-1',
       version: 1,
-      status: 'approved',
+      status: mockTaskConstants.THREAD_STATUS.APPROVED,
       artifactId: 'art-plan',
       body: '## 方案\n\n移动按钮。',
       createdAt: '2026-01-01T00:00:01.000Z',
@@ -111,6 +135,10 @@ describe('task-delivery', () => {
       success: true,
       data: undefined,
     });
+    planningMocks.updateTaskWorkflowState.mockReturnValue({
+      success: true,
+      data: undefined,
+    });
     planningMocks.createTaskAgentRun.mockReturnValue({
       success: true,
       data: {
@@ -119,7 +147,7 @@ describe('task-delivery', () => {
         threadId: 'thread-1',
         agentId: 'delivery',
         provider: 'system',
-        status: 'running',
+        status: mockTaskConstants.AGENT_RUN_STATUS.RUNNING,
         inputArtifactIds: ['art-plan'],
         outputArtifactIds: [],
         startedAt: '2026-01-01T00:00:01.000Z',
@@ -202,7 +230,6 @@ describe('task-delivery', () => {
     expect(result.data.prNumber).toBe(42);
     expect(planningMocks.updateTaskDelivery).toHaveBeenNthCalledWith(1, {
       taskId: 'task_123456789abc',
-      status: 'implemented',
       branchName: expect.stringMatching(/^fix\/.*-42/),
       worktreePath: expect.stringContaining(
         '/ranwawa/kinkeeper/tasks/42/worktree',
@@ -210,7 +237,6 @@ describe('task-delivery', () => {
     });
     expect(planningMocks.updateTaskDelivery).toHaveBeenNthCalledWith(2, {
       taskId: 'task_123456789abc',
-      status: 'delivering',
       branchName: expect.stringMatching(/^fix\/.*-42/),
       worktreePath: expect.stringContaining(
         '/ranwawa/kinkeeper/tasks/42/worktree',
@@ -218,11 +244,22 @@ describe('task-delivery', () => {
     });
     expect(planningMocks.updateTaskDelivery).toHaveBeenLastCalledWith({
       taskId: 'task_123456789abc',
-      status: 'delivered',
       branchName: expect.stringMatching(/^fix\/.*-42/),
       commitShas: ['abc123'],
       prUrl: 'https://github.com/ranwawa/kinkeeper/pull/42',
       prNumber: 42,
+    });
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenCalledWith({
+      taskId: 'task_123456789abc',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.RUNNING,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: mockTaskConstants.THREAD_STATUS.VERIFYING,
+    });
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenLastCalledWith({
+      taskId: 'task_123456789abc',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: mockTaskConstants.THREAD_STATUS.COMPLETED,
     });
     expect(calls.map((call) => `${call.command} ${call.args[0]}`)).toContain(
       'gh pr',
@@ -258,9 +295,11 @@ describe('task-delivery', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(planningMocks.updateTaskDelivery).toHaveBeenLastCalledWith({
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenLastCalledWith({
       taskId: 'task_123456789abc',
-      status: 'implemented',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: mockTaskConstants.THREAD_STATUS.COMPLETED,
     });
   });
 

--- a/packages/along/src/domain/task-delivery.ts
+++ b/packages/along/src/domain/task-delivery.ts
@@ -12,10 +12,13 @@ import {
   finishTaskAgentRun,
   readTaskPlanningSnapshot,
   recordTaskAgentResult,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
   type TaskAgentRunRecord,
   type TaskPlanningSnapshot,
+  THREAD_STATUS,
   updateTaskDelivery,
+  updateTaskWorkflowState,
+  WORKFLOW_KIND,
 } from './task-planning';
 import {
   defaultTaskWorktreeCommandRunner,
@@ -130,7 +133,12 @@ function failDeliveryRun(
   threadId: string,
   message: string,
 ): Result<never> {
-  updateTaskDelivery({ taskId, status: TASK_STATUS.IMPLEMENTED });
+  updateTaskWorkflowState({
+    taskId,
+    lifecycle: TASK_LIFECYCLE.READY,
+    currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+    threadStatus: THREAD_STATUS.COMPLETED,
+  });
   recordTaskAgentResult({
     taskId,
     threadId,
@@ -167,11 +175,17 @@ export async function runTaskDelivery(
     });
   }
 
-  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return failure('Task 已关闭，不能交付');
   }
-  if (snapshot.task.status !== TASK_STATUS.IMPLEMENTED) {
-    return failure(`当前 Task 状态不能交付: ${snapshot.task.status}`);
+  if (
+    snapshot.task.currentWorkflowKind !== WORKFLOW_KIND.IMPLEMENTATION ||
+    snapshot.task.lifecycle !== TASK_LIFECYCLE.READY ||
+    snapshot.task.prUrl
+  ) {
+    return failure(
+      `当前 Task 工作流不能交付: ${snapshot.task.currentWorkflowKind}/${snapshot.task.lifecycle}`,
+    );
   }
 
   const repositoryRes = await ensureTaskRepository(snapshot, input.cwd, runner);
@@ -224,7 +238,6 @@ export async function runTaskDelivery(
 
   const startedRes = updateTaskDelivery({
     taskId: input.taskId,
-    status: TASK_STATUS.DELIVERING,
     worktreePath,
     branchName,
   });
@@ -234,6 +247,20 @@ export async function runTaskDelivery(
       input.taskId,
       snapshot.thread.threadId,
       startedRes.error,
+    );
+  }
+  const workflowStartedRes = updateTaskWorkflowState({
+    taskId: input.taskId,
+    lifecycle: TASK_LIFECYCLE.RUNNING,
+    currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+    threadStatus: THREAD_STATUS.VERIFYING,
+  });
+  if (!workflowStartedRes.success) {
+    return failDeliveryRun(
+      run,
+      input.taskId,
+      snapshot.thread.threadId,
+      workflowStartedRes.error,
     );
   }
 
@@ -289,7 +316,6 @@ export async function runTaskDelivery(
     commitShas = [existingCommit];
     const commitMetaRes = updateTaskDelivery({
       taskId: input.taskId,
-      status: TASK_STATUS.DELIVERING,
       branchName,
       commitShas,
     });
@@ -418,7 +444,6 @@ export async function runTaskDelivery(
     const prNumber = parsePrNumber(prUrl);
     const deliveryRes = updateTaskDelivery({
       taskId: input.taskId,
-      status: TASK_STATUS.DELIVERED,
       branchName,
       commitShas,
       prUrl,
@@ -430,6 +455,20 @@ export async function runTaskDelivery(
         input.taskId,
         snapshot.thread.threadId,
         deliveryRes.error,
+      );
+    }
+    const workflowDeliveredRes = updateTaskWorkflowState({
+      taskId: input.taskId,
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.COMPLETED,
+    });
+    if (!workflowDeliveredRes.success) {
+      return failDeliveryRun(
+        run,
+        input.taskId,
+        snapshot.thread.threadId,
+        workflowDeliveredRes.error,
       );
     }
 

--- a/packages/along/src/domain/task-display-state.ts
+++ b/packages/along/src/domain/task-display-state.ts
@@ -1,0 +1,78 @@
+import {
+  TASK_LIFECYCLE,
+  WORKFLOW_KIND,
+  type WorkflowRuntimeState,
+} from './task-workflow-state';
+
+export type TaskDisplayState =
+  | 'ask_active'
+  | 'waiting_user'
+  | 'ask_answered'
+  | 'planning_drafting'
+  | 'planning_awaiting_approval'
+  | 'planning_feedback'
+  | 'planning_planned'
+  | 'implementation_implementing'
+  | 'implementation_verifying'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'processing';
+
+export interface TaskDisplay {
+  state: TaskDisplayState;
+  label: string;
+}
+
+export function deriveTaskDisplay(state: WorkflowRuntimeState): TaskDisplay {
+  if (state.lifecycle === TASK_LIFECYCLE.CANCELLED) {
+    return { state: 'cancelled', label: '已取消' };
+  }
+  if (state.lifecycle === TASK_LIFECYCLE.FAILED) {
+    return { state: 'failed', label: '失败' };
+  }
+  if (state.lifecycle === TASK_LIFECYCLE.COMPLETED) {
+    return { state: 'completed', label: '已完成' };
+  }
+  if (state.workflowState === 'waiting_user') {
+    return { state: 'waiting_user', label: '待补充' };
+  }
+  if (state.currentWorkflowKind === WORKFLOW_KIND.ASK) {
+    return state.workflowState === 'answered'
+      ? { state: 'ask_answered', label: '已回答' }
+      : { state: 'ask_active', label: '咨询中' };
+  }
+  if (state.currentWorkflowKind === WORKFLOW_KIND.PLANNING) {
+    return derivePlanningDisplay(state);
+  }
+  if (state.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION) {
+    return deriveImplementationDisplay(state);
+  }
+  return { state: 'processing', label: '处理中' };
+}
+
+function derivePlanningDisplay(state: WorkflowRuntimeState): TaskDisplay {
+  if (state.workflowState === 'awaiting_approval') {
+    return { state: 'planning_awaiting_approval', label: '待批准' };
+  }
+  if (state.workflowState === 'feedback') {
+    return { state: 'planning_feedback', label: '计划反馈中' };
+  }
+  if (state.workflowState === 'planned') {
+    return { state: 'planning_planned', label: '已规划' };
+  }
+  return { state: 'planning_drafting', label: '规划中' };
+}
+
+function deriveImplementationDisplay(state: WorkflowRuntimeState): TaskDisplay {
+  if (state.workflowState === 'verifying') {
+    return { state: 'implementation_verifying', label: '验证中' };
+  }
+  if (state.workflowState === 'completed') {
+    return { state: 'planning_planned', label: '已规划' };
+  }
+  if (state.workflowState === 'failed') {
+    return { state: 'failed', label: '失败' };
+  }
+  return { state: 'implementation_implementing', label: '实现中' };
+}

--- a/packages/along/src/domain/task-implementation-agent.test.ts
+++ b/packages/along/src/domain/task-implementation-agent.test.ts
@@ -2,23 +2,43 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const planningMocks = vi.hoisted(() => ({
   readTaskPlanningSnapshot: vi.fn(),
-  updateTaskStatus: vi.fn(),
+  updateTaskWorkflowState: vi.fn(),
 }));
 const runnerMock = vi.hoisted(() => vi.fn());
 const worktreeMock = vi.hoisted(() => vi.fn());
 const autoCommitMock = vi.hoisted(() => vi.fn());
-
-vi.mock('./task-planning', () => ({
+const mockTaskConstants = vi.hoisted(() => ({
   PLAN_STATUS: {
     APPROVED: 'approved',
   },
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
+    READY: 'ready',
+    RUNNING: 'running',
+  },
   TASK_STATUS: {
     PLANNING_APPROVED: 'planning_approved',
-    IMPLEMENTING: 'implementing',
-    IMPLEMENTED: 'implemented',
   },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+    IMPLEMENTING: 'implementing',
+  },
+  THREAD_PURPOSE: {
+    PLANNING: 'planning',
+  },
+  WORKFLOW_KIND: {
+    PLANNING: 'planning',
+    IMPLEMENTATION: 'implementation',
+  },
+}));
+
+vi.mock('./task-planning', () => ({
+  PLAN_STATUS: mockTaskConstants.PLAN_STATUS,
+  TASK_LIFECYCLE: mockTaskConstants.TASK_LIFECYCLE,
+  THREAD_STATUS: mockTaskConstants.THREAD_STATUS,
+  WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
-  updateTaskStatus: planningMocks.updateTaskStatus,
+  updateTaskWorkflowState: planningMocks.updateTaskWorkflowState,
 }));
 
 vi.mock('./task-agent-runtime', () => ({
@@ -42,7 +62,9 @@ const approvedSnapshot = {
     title: '移动演示数据按钮',
     body: '删除下方的演示数据按钮应该位于礼薄列表上方。',
     source: 'web',
-    status: 'planning_approved',
+    status: mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
+    lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+    currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.PLANNING,
     activeThreadId: 'thread-1',
     repoOwner: 'ranwawa',
     repoName: 'kinkeeper',
@@ -53,8 +75,8 @@ const approvedSnapshot = {
   thread: {
     threadId: 'thread-1',
     taskId: 'task-1',
-    purpose: 'planning',
-    status: 'approved',
+    purpose: mockTaskConstants.THREAD_PURPOSE.PLANNING,
+    status: mockTaskConstants.THREAD_STATUS.APPROVED,
     currentPlanId: 'plan-1',
     approvedPlanId: 'plan-1',
     createdAt: '2026-01-01T00:00:00.000Z',
@@ -65,7 +87,7 @@ const approvedSnapshot = {
     taskId: 'task-1',
     threadId: 'thread-1',
     version: 1,
-    status: 'approved',
+    status: mockTaskConstants.PLAN_STATUS.APPROVED,
     artifactId: 'art-plan',
     body: '## 方案\n\n移动按钮。',
     createdAt: '2026-01-01T00:00:01.000Z',
@@ -89,7 +111,7 @@ const approvedSnapshot = {
       taskId: 'task-1',
       threadId: 'thread-1',
       version: 1,
-      status: 'approved',
+      status: mockTaskConstants.PLAN_STATUS.APPROVED,
       artifactId: 'art-plan',
       body: '## 方案\n\n移动按钮。',
       createdAt: '2026-01-01T00:00:01.000Z',
@@ -148,7 +170,7 @@ describe('task-implementation-agent', () => {
       success: true,
       data: approvedSnapshot,
     });
-    planningMocks.updateTaskStatus.mockReturnValue({
+    planningMocks.updateTaskWorkflowState.mockReturnValue({
       success: true,
       data: undefined,
     });
@@ -199,7 +221,7 @@ describe('task-implementation-agent', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error(result.error);
-    expect(planningMocks.updateTaskStatus).not.toHaveBeenCalled();
+    expect(planningMocks.updateTaskWorkflowState).not.toHaveBeenCalled();
     expect(worktreeMock).not.toHaveBeenCalled();
     expect(autoCommitMock).not.toHaveBeenCalled();
     expect(result.data.commitShas).toEqual([]);
@@ -236,7 +258,7 @@ describe('task-implementation-agent', () => {
     expect(runnerMock).not.toHaveBeenCalled();
     expect(worktreeMock).not.toHaveBeenCalled();
     expect(autoCommitMock).not.toHaveBeenCalled();
-    expect(planningMocks.updateTaskStatus).not.toHaveBeenCalled();
+    expect(planningMocks.updateTaskWorkflowState).not.toHaveBeenCalled();
   });
 
   it('当实施步骤已人工确认时，期望启动实现 Agent 并在完成后自动提交', async () => {
@@ -252,12 +274,13 @@ describe('task-implementation-agent', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error(result.error);
-    expect(planningMocks.updateTaskStatus).toHaveBeenNthCalledWith(
-      1,
-      'task-1',
-      'implementing',
-    );
-    expect(planningMocks.updateTaskStatus).toHaveBeenCalledTimes(1);
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenNthCalledWith(1, {
+      taskId: 'task-1',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.RUNNING,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: mockTaskConstants.THREAD_STATUS.IMPLEMENTING,
+    });
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenCalledTimes(1);
     expect(result.data.commitShas).toEqual(['abc123']);
     expect(runnerMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -296,11 +319,12 @@ describe('task-implementation-agent', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(planningMocks.updateTaskStatus).toHaveBeenNthCalledWith(
-      2,
-      'task-1',
-      'planning_approved',
-    );
+    expect(planningMocks.updateTaskWorkflowState).toHaveBeenNthCalledWith(2, {
+      taskId: 'task-1',
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.PLANNING,
+      threadStatus: mockTaskConstants.THREAD_STATUS.APPROVED,
+    });
   });
 
   it('当 auto-commit 失败后，期望反馈错误给实现 Agent 修复并重试提交', async () => {
@@ -363,6 +387,6 @@ describe('task-implementation-agent', () => {
 
     expect(result.success).toBe(false);
     expect(runnerMock).not.toHaveBeenCalled();
-    expect(planningMocks.updateTaskStatus).not.toHaveBeenCalled();
+    expect(planningMocks.updateTaskWorkflowState).not.toHaveBeenCalled();
   });
 });

--- a/packages/along/src/domain/task-implementation-agent.ts
+++ b/packages/along/src/domain/task-implementation-agent.ts
@@ -11,10 +11,12 @@ import {
 import {
   PLAN_STATUS,
   readTaskPlanningSnapshot,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
   type TaskPlanningSnapshot,
   type TaskPlanRevisionRecord,
-  updateTaskStatus,
+  THREAD_STATUS,
+  updateTaskWorkflowState,
+  WORKFLOW_KIND,
 } from './task-planning';
 import {
   defaultTaskWorktreeCommandRunner,
@@ -76,7 +78,12 @@ async function readRequiredSnapshot(
 }
 
 function rollbackToPlanningApproved<T>(taskId: string, result: Result<T>) {
-  const rollbackRes = updateTaskStatus(taskId, TASK_STATUS.PLANNING_APPROVED);
+  const rollbackRes = updateTaskWorkflowState({
+    taskId,
+    lifecycle: TASK_LIFECYCLE.READY,
+    currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+    threadStatus: THREAD_STATUS.APPROVED,
+  });
   return rollbackRes.success ? result : failure<T>(rollbackRes.error);
 }
 
@@ -137,7 +144,12 @@ async function prepareImplementationRun(
   });
   if (!worktreeRes.success) return failure(worktreeRes.error);
 
-  const startedRes = updateTaskStatus(input.taskId, TASK_STATUS.IMPLEMENTING);
+  const startedRes = updateTaskWorkflowState({
+    taskId: input.taskId,
+    lifecycle: TASK_LIFECYCLE.RUNNING,
+    currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+    threadStatus: THREAD_STATUS.IMPLEMENTING,
+  });
   if (!startedRes.success) return failure(startedRes.error);
 
   return success({ snapshot, approvedPlan, worktree: worktreeRes.data });
@@ -150,17 +162,17 @@ function readApprovedImplementationContext(
   if (!snapshotRes.success) return failure(snapshotRes.error);
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
-  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return failure('Task 已关闭，不能开始实现');
   }
 
   const approvedPlan = findApprovedPlan(snapshot);
   if (!approvedPlan) return failure('当前 Task 没有已批准方案，不能开始实现');
   if (
-    snapshot.task.status !== TASK_STATUS.PLANNING_APPROVED &&
-    snapshot.task.status !== TASK_STATUS.IMPLEMENTING
+    snapshot.task.currentWorkflowKind !== WORKFLOW_KIND.PLANNING &&
+    snapshot.task.currentWorkflowKind !== WORKFLOW_KIND.IMPLEMENTATION
   ) {
-    return failure(`当前 Task 状态不能开始实现: ${snapshot.task.status}`);
+    return failure('当前 Task 工作流不能开始实现');
   }
 
   return success({ snapshot, approvedPlan });

--- a/packages/along/src/domain/task-implementation-auto-commit-loop.ts
+++ b/packages/along/src/domain/task-implementation-auto-commit-loop.ts
@@ -10,10 +10,12 @@ import type {
 } from './task-implementation-agent';
 import {
   readTaskPlanningSnapshot,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
   type TaskPlanningSnapshot,
   type TaskPlanRevisionRecord,
-  updateTaskStatus,
+  THREAD_STATUS,
+  updateTaskWorkflowState,
+  WORKFLOW_KIND,
 } from './task-planning';
 import type {
   PrepareTaskWorktreeOutput,
@@ -40,7 +42,12 @@ async function readRequiredSnapshot(
 }
 
 function rollbackToPlanningApproved<T>(taskId: string, result: Result<T>) {
-  const rollbackRes = updateTaskStatus(taskId, TASK_STATUS.PLANNING_APPROVED);
+  const rollbackRes = updateTaskWorkflowState({
+    taskId,
+    lifecycle: TASK_LIFECYCLE.READY,
+    currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+    threadStatus: THREAD_STATUS.APPROVED,
+  });
   return rollbackRes.success ? result : failure<T>(rollbackRes.error);
 }
 

--- a/packages/along/src/domain/task-planning-agent.test.ts
+++ b/packages/along/src/domain/task-planning-agent.test.ts
@@ -8,8 +8,8 @@ const planningMocks = vi.hoisted(() => ({
 const runnerMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./task-planning', () => ({
-  TASK_STATUS: {
-    CLOSED: 'closed',
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
   },
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
   publishTaskPlanRevision: planningMocks.publishTaskPlanRevision,
@@ -32,6 +32,8 @@ const baseSnapshot = {
     body: '需要不依赖 GitHub Issue 完成 planning。',
     source: 'test',
     status: 'planning',
+    lifecycle: 'open',
+    currentWorkflowKind: 'planning',
     activeThreadId: 'thread-1',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/along/src/domain/task-planning-agent.ts
+++ b/packages/along/src/domain/task-planning-agent.ts
@@ -15,7 +15,7 @@ import {
   publishPlanningUpdate,
   publishTaskPlanRevision,
   readTaskPlanningSnapshot,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
   type TaskPlanningSnapshot,
 } from './task-planning';
 
@@ -149,7 +149,7 @@ export async function runTaskPlanningAgent(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
-  if (snapshot.task.status === TASK_STATUS.CLOSED) {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return failure('Task 已关闭，不能运行 Planner');
   }
 

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -862,7 +862,7 @@ describe('task-planning', () => {
     expect(snapshot.data.task.executionMode).toBe('autonomous');
   });
 
-  it('当首版计划前需要澄清时，期望记录 Planning Update 并保持可继续讨论', () => {
+  it('当纯咨询得到回答时，期望记录 Planning Update 并保持 ask 展示', () => {
     const created = createPlanningTask({
       title: '实现 Task API',
       body: '希望通过网页创建 planning task。',
@@ -885,8 +885,18 @@ describe('task-planning', () => {
       throw new Error('missing snapshot');
     expect(snapshot.data.currentPlan).toBeNull();
     expect(snapshot.data.openRound).toBeNull();
-    expect(snapshot.data.thread.status).toBe(THREAD_STATUS.DISCUSSING);
-    expect(snapshot.data.flow.currentStageId).toBe('plan_discussion');
+    expect(snapshot.data.task.currentWorkflowKind).toBe('ask');
+    expect(snapshot.data.display).toMatchObject({
+      state: 'ask_answered',
+      label: '已回答',
+    });
+    expect(snapshot.data.thread.status).toBe(THREAD_STATUS.ANSWERED);
+    expect(snapshot.data.flow.currentStageId).toBe('ask');
+    expect(
+      snapshot.data.flow.stages.some(
+        (stage) => stage.id === 'plan_confirmation',
+      ),
+    ).toBe(false);
     expect(snapshot.data.artifacts.map((item) => item.type)).toEqual([
       'user_message',
       'planning_update',
@@ -933,7 +943,11 @@ describe('task-planning', () => {
     if (!snapshot.success || !snapshot.data)
       throw new Error('missing snapshot');
     expect(snapshot.data.task.status).toBe(TASK_STATUS.PLANNING_APPROVED);
-    expect(snapshot.data.thread.status).toBe(THREAD_STATUS.APPROVED);
+    expect(snapshot.data.thread.status).toBe(THREAD_STATUS.PLANNED);
+    expect(snapshot.data.display).toMatchObject({
+      state: 'planning_planned',
+      label: '已规划',
+    });
   });
 
   it('当已交付任务验收完成时，期望流程进入任务完成阶段', () => {

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -220,13 +220,14 @@ const mockDbState = vi.hoisted(() => {
             title,
             body,
             source,
-            status,
             activeThreadId,
             repoOwner,
             repoName,
             cwd,
             seq,
             executionMode,
+            lifecycle,
+            currentWorkflowKind,
             createdAt,
             updatedAt,
           ] = args;
@@ -235,7 +236,6 @@ const mockDbState = vi.hoisted(() => {
             title,
             body,
             source,
-            status,
             active_thread_id: activeThreadId,
             repo_owner: repoOwner,
             repo_name: repoName,
@@ -248,6 +248,8 @@ const mockDbState = vi.hoisted(() => {
             seq,
             type: null,
             execution_mode: executionMode,
+            lifecycle,
+            current_workflow_kind: currentWorkflowKind,
             created_at: createdAt,
             updated_at: updatedAt,
           });
@@ -316,6 +318,76 @@ const mockDbState = vi.hoisted(() => {
         }
 
         if (
+          normalized.includes(
+            'UPDATE task_items SET lifecycle = ?, current_workflow_kind = ?, updated_at = ?',
+          )
+        ) {
+          const [lifecycle, currentWorkflowKind, updatedAt, taskId] = args;
+          const row = findTask(String(taskId));
+          if (row) {
+            row.lifecycle = lifecycle;
+            row.current_workflow_kind = currentWorkflowKind;
+            row.updated_at = updatedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
+          normalized.includes(
+            'UPDATE task_items SET current_workflow_kind = ?, lifecycle = ?, updated_at = ?',
+          )
+        ) {
+          const [currentWorkflowKind, lifecycle, updatedAt, taskId] = args;
+          const row = findTask(String(taskId));
+          if (row) {
+            row.current_workflow_kind = currentWorkflowKind;
+            row.lifecycle = lifecycle;
+            row.updated_at = updatedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
+          normalized.includes(
+            'UPDATE task_items SET lifecycle = ?, updated_at = ?',
+          )
+        ) {
+          const [lifecycle, updatedAt, taskId] = args;
+          const row = findTask(String(taskId));
+          if (row) {
+            row.lifecycle = lifecycle;
+            row.updated_at = updatedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
+          normalized.includes(
+            'UPDATE task_items SET branch_name = COALESCE(?, branch_name)',
+          )
+        ) {
+          const [
+            branchName,
+            worktreePath,
+            commitShas,
+            prUrl,
+            prNumber,
+            updatedAt,
+            taskId,
+          ] = args;
+          const row = findTask(String(taskId));
+          if (row) {
+            row.branch_name = branchName || row.branch_name;
+            row.worktree_path = worktreePath || row.worktree_path;
+            row.commit_shas = commitShas || row.commit_shas;
+            row.pr_url = prUrl || row.pr_url;
+            row.pr_number = prNumber || row.pr_number;
+            row.updated_at = updatedAt;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
           normalized ===
           'UPDATE task_threads SET open_round_id = NULL, updated_at = ? WHERE thread_id = ?'
         ) {
@@ -378,6 +450,20 @@ const mockDbState = vi.hoisted(() => {
           if (row) {
             row.feedback_artifact_ids = ids;
             row.status = status;
+          }
+          return { changes: row ? 1 : 0 };
+        }
+
+        if (
+          normalized.includes(
+            'UPDATE task_threads SET status = ?, updated_at = ? WHERE task_id = ?',
+          )
+        ) {
+          const [status, updatedAt, taskId] = args;
+          const row = activeThread(String(taskId));
+          if (row) {
+            row.status = status;
+            row.updated_at = updatedAt;
           }
           return { changes: row ? 1 : 0 };
         }
@@ -532,20 +618,6 @@ const mockDbState = vi.hoisted(() => {
           if (row) {
             row.status = status;
             row.approved_plan_id = planId;
-            row.updated_at = updatedAt;
-          }
-          return { changes: row ? 1 : 0 };
-        }
-
-        if (
-          normalized.includes(
-            'UPDATE task_items SET status = ?, updated_at = ?',
-          )
-        ) {
-          const [status, updatedAt, taskId] = args;
-          const row = findTask(String(taskId));
-          if (row) {
-            row.status = status;
             row.updated_at = updatedAt;
           }
           return { changes: row ? 1 : 0 };
@@ -778,10 +850,15 @@ import {
   recoverInterruptedTaskAgentRuns,
   submitTaskMessage,
   TASK_AGENT_PROGRESS_PHASE,
+  TASK_LIFECYCLE,
   TASK_STATUS,
+  type TaskStatus,
   THREAD_STATUS,
   updateTaskAgentProviderSession,
+  updateTaskDelivery,
   updateTaskStatus,
+  updateTaskWorkflowState,
+  WORKFLOW_KIND,
 } from './task-planning';
 
 function createTaskWithPlan() {
@@ -801,6 +878,72 @@ function createTaskWithPlan() {
   if (!plan.success) throw new Error(plan.error);
 
   return { taskId: created.data.task.taskId, plan: plan.data };
+}
+
+function moveTaskToCompatStatus(taskId: string, status: TaskStatus) {
+  if (status === TASK_STATUS.PLANNING) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.OPEN,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      threadStatus: THREAD_STATUS.DRAFTING,
+    });
+  }
+  if (status === TASK_STATUS.PLANNING_APPROVED) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      threadStatus: THREAD_STATUS.APPROVED,
+    });
+  }
+  if (status === TASK_STATUS.IMPLEMENTING) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.RUNNING,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.IMPLEMENTING,
+    });
+  }
+  if (status === TASK_STATUS.IMPLEMENTED) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.COMPLETED,
+    });
+  }
+  if (status === TASK_STATUS.DELIVERING) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.RUNNING,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.VERIFYING,
+    });
+  }
+  if (status === TASK_STATUS.DELIVERED) {
+    const delivery = updateTaskDelivery({
+      taskId,
+      prUrl: 'https://github.com/ranwawa/along/pull/1',
+      prNumber: 1,
+    });
+    if (!delivery.success) return delivery;
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.COMPLETED,
+    });
+  }
+  if (status === TASK_STATUS.COMPLETED) {
+    return updateTaskWorkflowState({
+      taskId,
+      lifecycle: TASK_LIFECYCLE.COMPLETED,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      threadStatus: THREAD_STATUS.COMPLETED,
+    });
+  }
+  throw new Error(`unsupported compat status in test: ${status}`);
 }
 
 describe('task-planning', () => {
@@ -955,7 +1098,7 @@ describe('task-planning', () => {
     const approve = approveCurrentTaskPlan(taskId);
     expect(approve.success).toBe(true);
 
-    const delivered = updateTaskStatus(taskId, TASK_STATUS.DELIVERED);
+    const delivered = moveTaskToCompatStatus(taskId, TASK_STATUS.DELIVERED);
     expect(delivered.success).toBe(true);
     if (!delivered.success) throw new Error(delivered.error);
     const deliveredSnapshot = readTaskPlanningSnapshot(taskId);
@@ -990,9 +1133,11 @@ describe('task-planning', () => {
     TASK_STATUS.DELIVERED,
   ])('当 %s 状态关闭任务时，期望进入 closed 并记录关闭事件', (status) => {
     const { taskId } = createTaskWithPlan();
-    const approve = approveCurrentTaskPlan(taskId);
-    expect(approve.success).toBe(true);
-    const statusRes = updateTaskStatus(taskId, status);
+    if (status !== TASK_STATUS.PLANNING) {
+      const approve = approveCurrentTaskPlan(taskId);
+      expect(approve.success).toBe(true);
+    }
+    const statusRes = moveTaskToCompatStatus(taskId, status);
     expect(statusRes.success).toBe(true);
 
     const closed = closeTask(taskId, '无需继续');
@@ -1007,7 +1152,9 @@ describe('task-planning', () => {
       type: 'task_closed',
       role: 'system',
       metadata: expect.objectContaining({
-        previousStatus: status,
+        previousLifecycle: expect.any(String),
+        previousWorkflowKind: expect.any(String),
+        previousThreadStatus: expect.any(String),
         reason: '无需继续',
       }),
     });
@@ -1015,7 +1162,7 @@ describe('task-planning', () => {
       closed.data.flow.events.find((event) => event.type === 'task_closed'),
     ).toMatchObject({
       title: '任务已关闭',
-      summary: expect.stringContaining(`关闭前状态：${status}`),
+      summary: expect.stringContaining('关闭前生命周期：'),
     });
   });
 
@@ -1023,7 +1170,7 @@ describe('task-planning', () => {
     const { taskId } = createTaskWithPlan();
     const approve = approveCurrentTaskPlan(taskId);
     expect(approve.success).toBe(true);
-    const delivered = updateTaskStatus(taskId, TASK_STATUS.DELIVERED);
+    const delivered = moveTaskToCompatStatus(taskId, TASK_STATUS.DELIVERED);
     expect(delivered.success).toBe(true);
     const completed = completeDeliveredTask(taskId);
     expect(completed.success).toBe(true);
@@ -1410,7 +1557,10 @@ describe('task-planning', () => {
     const approved = approveCurrentTaskPlan(taskId);
     expect(approved.success).toBe(true);
 
-    const implementing = updateTaskStatus(taskId, TASK_STATUS.IMPLEMENTING);
+    const implementing = moveTaskToCompatStatus(
+      taskId,
+      TASK_STATUS.IMPLEMENTING,
+    );
     expect(implementing.success).toBe(true);
 
     const snapshot = readTaskPlanningSnapshot(taskId);

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -14,12 +14,21 @@ import {
   type TaskAttachmentRow,
   type TaskAttachmentUploadInput,
 } from './task-attachments';
+import { deriveTaskDisplay, type TaskDisplay } from './task-display-state';
 import {
   areImplementationStepsApproved,
   findImplementationStepsApprovalArtifact,
   findImplementationStepsArtifact,
   IMPLEMENTATION_STEPS_APPROVAL_KIND,
 } from './task-implementation-steps';
+import {
+  reduceWorkflowEvent,
+  TASK_LIFECYCLE,
+  type TaskLifecycle,
+  WORKFLOW_KIND,
+  type WorkflowKind,
+  type WorkflowRuntimeState,
+} from './task-workflow-state';
 
 export const TASK_STATUS = {
   PLANNING: 'planning',
@@ -43,17 +52,27 @@ export type TaskExecutionMode =
   (typeof TASK_EXECUTION_MODE)[keyof typeof TASK_EXECUTION_MODE];
 
 export const THREAD_PURPOSE = {
+  ASK: 'ask',
   PLANNING: 'planning',
+  IMPLEMENTATION: 'implementation',
 } as const;
 
 export type ThreadPurpose =
   (typeof THREAD_PURPOSE)[keyof typeof THREAD_PURPOSE];
 
 export const THREAD_STATUS = {
+  ACTIVE: 'active',
+  WAITING_USER: 'waiting_user',
+  ANSWERED: 'answered',
   DRAFTING: 'drafting',
   AWAITING_APPROVAL: 'awaiting_approval',
   DISCUSSING: 'discussing',
   APPROVED: 'approved',
+  PLANNED: 'planned',
+  IMPLEMENTING: 'implementing',
+  VERIFYING: 'verifying',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
 } as const;
 
 export type ThreadStatus = (typeof THREAD_STATUS)[keyof typeof THREAD_STATUS];
@@ -154,6 +173,8 @@ export interface TaskItemRecord {
   body: string;
   source: string;
   status: TaskStatus;
+  lifecycle: TaskLifecycle;
+  currentWorkflowKind: WorkflowKind;
   activeThreadId?: string;
   repoOwner?: string;
   repoName?: string;
@@ -296,6 +317,7 @@ export interface TaskAgentStageRecord {
 }
 
 export type TaskFlowStageId =
+  | 'ask'
   | 'requirements'
   | 'plan_discussion'
   | 'plan_confirmation'
@@ -312,6 +334,7 @@ export type TaskFlowStageState =
 
 export type TaskFlowActionId =
   | 'submit_feedback'
+  | 'request_plan'
   | 'approve_plan'
   | 'request_revision'
   | 'rerun_planner'
@@ -383,6 +406,7 @@ export interface TaskFlowSnapshot {
 export interface TaskPlanningSnapshot {
   task: TaskItemRecord;
   thread: TaskThreadRecord;
+  display: TaskDisplay;
   currentPlan: TaskPlanRevisionRecord | null;
   openRound: TaskFeedbackRoundRecord | null;
   artifacts: TaskArtifactRecord[];
@@ -406,6 +430,7 @@ export interface CreatePlanningTaskInput {
   repoName?: string;
   cwd?: string;
   executionMode?: TaskExecutionMode;
+  workflowKind?: WorkflowKind;
   attachments?: TaskAttachmentUploadInput[];
 }
 
@@ -552,6 +577,8 @@ interface TaskItemRow {
   body: string;
   source: string;
   status: TaskStatus;
+  lifecycle?: TaskLifecycle | null;
+  current_workflow_kind?: WorkflowKind | null;
   active_thread_id: string | null;
   repo_owner: string | null;
   repo_name: string | null;
@@ -679,6 +706,46 @@ function normalizeTaskExecutionMode(
     : TASK_EXECUTION_MODE.MANUAL;
 }
 
+function normalizeWorkflowKind(value: string | null | undefined): WorkflowKind {
+  if (value === WORKFLOW_KIND.PLANNING) return WORKFLOW_KIND.PLANNING;
+  if (value === WORKFLOW_KIND.IMPLEMENTATION)
+    return WORKFLOW_KIND.IMPLEMENTATION;
+  return WORKFLOW_KIND.ASK;
+}
+
+function normalizeTaskLifecycle(
+  value: string | null | undefined,
+  status: TaskStatus,
+): TaskLifecycle {
+  if (
+    value === TASK_LIFECYCLE.OPEN ||
+    value === TASK_LIFECYCLE.WAITING_USER ||
+    value === TASK_LIFECYCLE.READY ||
+    value === TASK_LIFECYCLE.RUNNING ||
+    value === TASK_LIFECYCLE.COMPLETED ||
+    value === TASK_LIFECYCLE.CANCELLED ||
+    value === TASK_LIFECYCLE.FAILED
+  ) {
+    return value;
+  }
+  if (status === TASK_STATUS.CLOSED) return TASK_LIFECYCLE.CANCELLED;
+  if (status === TASK_STATUS.COMPLETED) return TASK_LIFECYCLE.COMPLETED;
+  if (
+    status === TASK_STATUS.IMPLEMENTING ||
+    status === TASK_STATUS.DELIVERING
+  ) {
+    return TASK_LIFECYCLE.RUNNING;
+  }
+  if (
+    status === TASK_STATUS.PLANNING_APPROVED ||
+    status === TASK_STATUS.IMPLEMENTED ||
+    status === TASK_STATUS.DELIVERED
+  ) {
+    return TASK_LIFECYCLE.READY;
+  }
+  return TASK_LIFECYCLE.OPEN;
+}
+
 function parseMetadata(
   value: string | null | undefined,
 ): Record<string, unknown> {
@@ -772,6 +839,8 @@ function mapTask(row: TaskItemRow): TaskItemRecord {
     body: row.body,
     source: row.source,
     status: row.status,
+    lifecycle: normalizeTaskLifecycle(row.lifecycle, row.status),
+    currentWorkflowKind: normalizeWorkflowKind(row.current_workflow_kind),
     activeThreadId: row.active_thread_id || undefined,
     repoOwner: row.repo_owner || undefined,
     repoName: row.repo_name || undefined,
@@ -935,6 +1004,7 @@ function buildTaskAgentStages(
 }
 
 const TASK_FLOW_STAGE_ORDER: TaskFlowStageId[] = [
+  'ask',
   'requirements',
   'plan_discussion',
   'plan_confirmation',
@@ -944,6 +1014,7 @@ const TASK_FLOW_STAGE_ORDER: TaskFlowStageId[] = [
 ];
 
 const TASK_FLOW_STAGE_LABELS: Record<TaskFlowStageId, string> = {
+  ask: '咨询问答',
   requirements: '需求接收',
   plan_discussion: '计划讨论',
   plan_confirmation: '计划确认',
@@ -951,6 +1022,164 @@ const TASK_FLOW_STAGE_LABELS: Record<TaskFlowStageId, string> = {
   delivery: '结果交付',
   completed: '已完成',
 };
+
+function inferWorkflowState(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+  currentPlan: TaskPlanRevisionRecord | null;
+  openRound: TaskFeedbackRoundRecord | null;
+  agentStages: TaskAgentStageRecord[];
+}): WorkflowRuntimeState {
+  if (input.task.status === TASK_STATUS.CLOSED) {
+    return {
+      lifecycle: TASK_LIFECYCLE.CANCELLED,
+      currentWorkflowKind: input.task.currentWorkflowKind,
+      workflowState:
+        input.task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION
+          ? 'failed'
+          : input.task.currentWorkflowKind === WORKFLOW_KIND.PLANNING
+            ? 'planned'
+            : 'answered',
+    };
+  }
+  if (input.task.status === TASK_STATUS.COMPLETED) {
+    return {
+      lifecycle: TASK_LIFECYCLE.COMPLETED,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      workflowState: 'completed',
+    };
+  }
+  if (
+    input.task.status === TASK_STATUS.IMPLEMENTING ||
+    input.task.status === TASK_STATUS.IMPLEMENTED ||
+    input.task.status === TASK_STATUS.DELIVERING ||
+    input.task.status === TASK_STATUS.DELIVERED
+  ) {
+    const runningStage = input.agentStages.find(
+      (stage) =>
+        stage.stage === TASK_AGENT_STAGE.IMPLEMENTATION &&
+        stage.status === AGENT_RUN_STATUS.RUNNING,
+    );
+    const failedStage = input.agentStages.find(
+      (stage) =>
+        stage.stage === TASK_AGENT_STAGE.IMPLEMENTATION &&
+        stage.status === AGENT_RUN_STATUS.FAILED,
+    );
+    if (failedStage) {
+      return {
+        lifecycle: TASK_LIFECYCLE.FAILED,
+        currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+        workflowState: 'failed',
+      };
+    }
+    if (runningStage || input.task.status === TASK_STATUS.IMPLEMENTING) {
+      return reduceWorkflowEvent(
+        {
+          lifecycle: TASK_LIFECYCLE.READY,
+          currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+          workflowState: 'planned',
+        },
+        { type: 'implementation.started' },
+      );
+    }
+    return {
+      lifecycle:
+        input.task.status === TASK_STATUS.DELIVERING
+          ? TASK_LIFECYCLE.RUNNING
+          : TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      workflowState:
+        input.task.status === TASK_STATUS.DELIVERING
+          ? 'verifying'
+          : 'completed',
+    };
+  }
+  if (
+    input.task.currentWorkflowKind === WORKFLOW_KIND.ASK &&
+    input.thread.purpose === THREAD_PURPOSE.ASK &&
+    !input.currentPlan
+  ) {
+    return {
+      lifecycle: input.task.lifecycle,
+      currentWorkflowKind: WORKFLOW_KIND.ASK,
+      workflowState:
+        input.thread.status === THREAD_STATUS.WAITING_USER
+          ? 'waiting_user'
+          : input.thread.status === THREAD_STATUS.ANSWERED
+            ? 'answered'
+            : 'active',
+    };
+  }
+  if (input.openRound) {
+    return {
+      lifecycle: TASK_LIFECYCLE.OPEN,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      workflowState: 'feedback',
+    };
+  }
+  if (
+    input.thread.approvedPlanId ||
+    input.task.status === TASK_STATUS.PLANNING_APPROVED
+  ) {
+    return {
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      workflowState: 'planned',
+    };
+  }
+  if (
+    input.currentPlan ||
+    input.thread.status === THREAD_STATUS.AWAITING_APPROVAL
+  ) {
+    return {
+      lifecycle: TASK_LIFECYCLE.WAITING_USER,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      workflowState: 'awaiting_approval',
+    };
+  }
+  return {
+    lifecycle: input.task.lifecycle,
+    currentWorkflowKind:
+      input.thread.purpose === THREAD_PURPOSE.PLANNING
+        ? WORKFLOW_KIND.PLANNING
+        : WORKFLOW_KIND.ASK,
+    workflowState:
+      input.thread.status === THREAD_STATUS.WAITING_USER
+        ? 'waiting_user'
+        : input.thread.purpose === THREAD_PURPOSE.PLANNING
+          ? 'drafting'
+          : 'active',
+  };
+}
+
+function applyWorkflowView(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+  currentPlan: TaskPlanRevisionRecord | null;
+  openRound: TaskFeedbackRoundRecord | null;
+  agentStages: TaskAgentStageRecord[];
+}): {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+  display: TaskDisplay;
+  workflow: WorkflowRuntimeState;
+} {
+  const workflow = inferWorkflowState(input);
+  return {
+    task: {
+      ...input.task,
+      lifecycle: workflow.lifecycle,
+      currentWorkflowKind: workflow.currentWorkflowKind,
+    },
+    thread: {
+      ...input.thread,
+      purpose: workflow.currentWorkflowKind,
+      status: workflow.workflowState as ThreadStatus,
+    },
+    display: deriveTaskDisplay(workflow),
+    workflow,
+  };
+}
 
 function isLongRunning(run: TaskAgentRunRecord): boolean {
   const startedAt = new Date(run.startedAt).getTime();
@@ -990,6 +1219,7 @@ function getCurrentTaskFlowStageId(input: {
 }): TaskFlowStageId {
   if (input.task.status === TASK_STATUS.CLOSED) return 'completed';
   if (input.task.status === TASK_STATUS.COMPLETED) return 'completed';
+  if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) return 'ask';
   if (input.task.status === TASK_STATUS.DELIVERED) return 'delivery';
   if (input.openRound) return 'plan_discussion';
 
@@ -1070,6 +1300,18 @@ function buildTaskFlowConclusion(input: {
   }
   if (input.task.status === TASK_STATUS.COMPLETED) {
     return { conclusion: '任务已完成，关键产物已归档。', severity: 'success' };
+  }
+  if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
+    if (input.thread.status === THREAD_STATUS.ANSWERED) {
+      return {
+        conclusion: '咨询已回答，可以继续追问或转为计划。',
+        severity: 'success',
+      };
+    }
+    if (input.thread.status === THREAD_STATUS.WAITING_USER) {
+      return { conclusion: '当前咨询需要补充信息。', severity: 'warning' };
+    }
+    return { conclusion: '咨询正在处理中。', severity: 'normal' };
   }
   if (input.task.status === TASK_STATUS.DELIVERED) {
     return {
@@ -1172,6 +1414,34 @@ function buildTaskFlowActions(input: {
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowAction[] {
   if (input.task.status === TASK_STATUS.CLOSED) return [];
+  if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
+    return [
+      buildTaskFlowAction({
+        id: 'submit_feedback',
+        label: '继续提问',
+        description: '补充问题或继续当前咨询',
+        enabled: true,
+        stage: 'ask',
+        variant: 'secondary',
+      }),
+      buildTaskFlowAction({
+        id: 'request_plan',
+        label: '转为计划',
+        description: '把当前咨询切换为正式计划流程',
+        enabled: true,
+        stage: 'ask',
+        variant: 'primary',
+      }),
+      buildTaskFlowAction({
+        id: 'close_task',
+        label: '关闭任务',
+        description: '结束当前咨询并保留历史记录',
+        enabled: true,
+        stage: 'ask',
+        variant: 'danger',
+      }),
+    ];
+  }
 
   const failedStage = getLatestFailedAgentStage(input.agentStages);
   const implementationStage = getStageByAgentStage(
@@ -1404,6 +1674,10 @@ function getTaskFlowStageSummary(input: {
   }
 
   switch (input.stageId) {
+    case 'ask':
+      if (input.thread.status === THREAD_STATUS.ANSWERED) return '已回答';
+      if (input.thread.status === THREAD_STATUS.WAITING_USER) return '待补充';
+      return '咨询中';
     case 'requirements':
       return '任务目标和上下文已记录';
     case 'plan_discussion':
@@ -1465,6 +1739,10 @@ function buildTaskFlowStageDetails(input: {
       details.push(`仓库：${input.task.repoOwner}/${input.task.repoName}`);
     }
   }
+  if (input.stageId === 'ask') {
+    details.push(`来源：${input.task.source}`);
+    details.push(`消息数：${input.artifacts.length}`);
+  }
   if (input.stageId === 'plan_discussion') {
     details.push(`计划版本数：${input.plans.length}`);
     if (input.openRound) {
@@ -1518,6 +1796,24 @@ function buildTaskFlowStages(input: {
   artifacts: TaskArtifactRecord[];
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowStage[] {
+  if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
+    const state: TaskFlowStageState =
+      input.thread.status === THREAD_STATUS.ANSWERED ? 'completed' : 'current';
+    return [
+      {
+        id: 'ask',
+        label: TASK_FLOW_STAGE_LABELS.ask,
+        summary: getTaskFlowStageSummary({ stageId: 'ask', ...input }),
+        state,
+        details: buildTaskFlowStageDetails({ stageId: 'ask', ...input }),
+        startedAt: input.task.createdAt,
+        endedAt:
+          input.thread.status === THREAD_STATUS.ANSWERED
+            ? input.task.updatedAt
+            : undefined,
+      },
+    ];
+  }
   const currentIndex = TASK_FLOW_STAGE_ORDER.indexOf(input.currentStageId);
   const failedStage =
     input.task.status === TASK_STATUS.CLOSED
@@ -1614,7 +1910,10 @@ function buildTaskFlowEvents(input: {
       events.push({
         eventId: artifact.artifactId,
         type: 'user_feedback',
-        stage: 'plan_discussion',
+        stage:
+          input.thread.purpose === THREAD_PURPOSE.ASK
+            ? 'ask'
+            : 'plan_discussion',
         title: '用户补充反馈',
         summary: artifact.body.slice(0, 120),
         occurredAt: artifact.createdAt,
@@ -2089,6 +2388,7 @@ export function createPlanningTask(
   const db = dbRes.data;
   const taskId = generateId('task');
   const threadId = generateId('thread');
+  const workflowKind = input.workflowKind || WORKFLOW_KIND.ASK;
   const preparedAttachmentsRes = prepareTaskImageAttachments({
     task: {
       taskId,
@@ -2148,8 +2448,12 @@ export function createPlanningTask(
       ).run(
         threadId,
         taskId,
-        THREAD_PURPOSE.PLANNING,
-        THREAD_STATUS.DRAFTING,
+        workflowKind === WORKFLOW_KIND.PLANNING
+          ? THREAD_PURPOSE.PLANNING
+          : THREAD_PURPOSE.ASK,
+        workflowKind === WORKFLOW_KIND.PLANNING
+          ? THREAD_STATUS.DRAFTING
+          : THREAD_STATUS.ACTIVE,
         now,
         now,
       );
@@ -2293,8 +2597,8 @@ export function readTaskPlanningSnapshot(
               `,
             )
             .all(threadRow.thread_id) as TaskAgentSessionEventRow[]);
-    const task = mapTask(taskRow);
-    const thread = mapThread(threadRow);
+    const mappedTask = mapTask(taskRow);
+    const mappedThread = mapThread(threadRow);
     const currentPlan = currentPlanRow ? mapPlan(currentPlanRow) : null;
     const openRound = openRoundRow ? mapRound(openRoundRow) : null;
     const attachmentRows = db
@@ -2304,7 +2608,7 @@ export function readTaskPlanningSnapshot(
       .all(threadRow.thread_id) as TaskAttachmentRow[];
     const attachmentsByArtifact = groupAttachmentsByArtifact(
       attachmentRows,
-      task,
+      mappedTask,
     );
     const artifacts = artifactRows.map((row) => ({
       ...mapArtifact(row),
@@ -2315,11 +2619,25 @@ export function readTaskPlanningSnapshot(
     const agentRuns = runRows.map(mapRun);
     const agentProgressEvents = progressRows.map(mapProgressEvent);
     const agentSessionEvents = sessionEventRows.map(mapSessionEvent);
-    const agentStages = buildTaskAgentStages(agentRuns, agentBindings, task);
+    const agentStages = buildTaskAgentStages(
+      agentRuns,
+      agentBindings,
+      mappedTask,
+    );
+    const workflowView = applyWorkflowView({
+      task: mappedTask,
+      thread: mappedThread,
+      currentPlan,
+      openRound,
+      agentStages,
+    });
+    const task = workflowView.task;
+    const thread = workflowView.thread;
 
     return success({
       task,
       thread,
+      display: workflowView.display,
       currentPlan,
       openRound,
       artifacts,
@@ -2477,9 +2795,15 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
       });
 
       if (!thread.current_plan_id || !createdArtifact) {
-        db.prepare(
-          'UPDATE task_threads SET updated_at = ? WHERE thread_id = ?',
-        ).run(now, thread.thread_id);
+        if (thread.purpose === THREAD_PURPOSE.ASK) {
+          db.prepare(
+            'UPDATE task_threads SET status = ?, updated_at = ? WHERE thread_id = ?',
+          ).run(THREAD_STATUS.ACTIVE, now, thread.thread_id);
+        } else {
+          db.prepare(
+            'UPDATE task_threads SET updated_at = ? WHERE thread_id = ?',
+          ).run(now, thread.thread_id);
+        }
         db.prepare(
           'UPDATE task_items SET updated_at = ? WHERE task_id = ?',
         ).run(now, thread.task_id);
@@ -2773,6 +3097,14 @@ export function publishPlanningUpdate(
             WHERE thread_id = ?
           `,
         ).run(THREAD_STATUS.AWAITING_APPROVAL, now, snapshot.thread.threadId);
+      } else if (snapshot.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
+        db.prepare(
+          `
+            UPDATE task_threads
+            SET status = ?, updated_at = ?
+            WHERE thread_id = ?
+          `,
+        ).run(THREAD_STATUS.ANSWERED, now, snapshot.thread.threadId);
       } else {
         db.prepare(
           `
@@ -2794,6 +3126,55 @@ export function publishPlanningUpdate(
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return failure(`发布 Planning Update 失败: ${message}`);
+  }
+}
+
+export function requestTaskPlan(taskId: string): Result<void> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return snapshotRes;
+  const snapshot = snapshotRes.data;
+  if (!snapshot) return failure(`Task 不存在: ${taskId}`);
+  const openRes = ensureTaskIsOpen(snapshot, '转为计划');
+  if (!openRes.success) return openRes;
+  if (snapshot.task.currentWorkflowKind !== WORKFLOW_KIND.ASK) {
+    return success(undefined);
+  }
+
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+
+  try {
+    const now = iso_timestamp();
+    const txn = dbRes.data.transaction(() => {
+      dbRes.data
+        .prepare(
+          `
+            UPDATE task_items
+            SET current_workflow_kind = ?, lifecycle = ?, updated_at = ?
+            WHERE task_id = ?
+          `,
+        )
+        .run(WORKFLOW_KIND.PLANNING, TASK_LIFECYCLE.OPEN, now, taskId);
+      dbRes.data
+        .prepare(
+          `
+            UPDATE task_threads
+            SET purpose = ?, status = ?, updated_at = ?
+            WHERE thread_id = ?
+          `,
+        )
+        .run(
+          THREAD_PURPOSE.PLANNING,
+          THREAD_STATUS.DRAFTING,
+          now,
+          snapshot.thread.threadId,
+        );
+    });
+    txn();
+    return success(undefined);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`转为计划失败: ${message}`);
   }
 }
 

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -30,6 +30,9 @@ import {
   type WorkflowRuntimeState,
 } from './task-workflow-state';
 
+export type { TaskLifecycle, WorkflowKind };
+export { TASK_LIFECYCLE, WORKFLOW_KIND };
+
 export const TASK_STATUS = {
   PLANNING: 'planning',
   PLANNING_APPROVED: 'planning_approved',
@@ -533,7 +536,6 @@ export interface RecordTaskAgentResultInput {
 
 export interface UpdateTaskDeliveryInput {
   taskId: string;
-  status: TaskStatus;
   worktreePath?: string;
   branchName?: string;
   commitShas?: string[];
@@ -576,7 +578,6 @@ interface TaskItemRow {
   title: string;
   body: string;
   source: string;
-  status: TaskStatus;
   lifecycle?: TaskLifecycle | null;
   current_workflow_kind?: WorkflowKind | null;
   active_thread_id: string | null;
@@ -715,7 +716,6 @@ function normalizeWorkflowKind(value: string | null | undefined): WorkflowKind {
 
 function normalizeTaskLifecycle(
   value: string | null | undefined,
-  status: TaskStatus,
 ): TaskLifecycle {
   if (
     value === TASK_LIFECYCLE.OPEN ||
@@ -727,21 +727,6 @@ function normalizeTaskLifecycle(
     value === TASK_LIFECYCLE.FAILED
   ) {
     return value;
-  }
-  if (status === TASK_STATUS.CLOSED) return TASK_LIFECYCLE.CANCELLED;
-  if (status === TASK_STATUS.COMPLETED) return TASK_LIFECYCLE.COMPLETED;
-  if (
-    status === TASK_STATUS.IMPLEMENTING ||
-    status === TASK_STATUS.DELIVERING
-  ) {
-    return TASK_LIFECYCLE.RUNNING;
-  }
-  if (
-    status === TASK_STATUS.PLANNING_APPROVED ||
-    status === TASK_STATUS.IMPLEMENTED ||
-    status === TASK_STATUS.DELIVERED
-  ) {
-    return TASK_LIFECYCLE.READY;
   }
   return TASK_LIFECYCLE.OPEN;
 }
@@ -833,14 +818,24 @@ function mapPlan(row: TaskPlanRevisionRow): TaskPlanRevisionRecord {
 }
 
 function mapTask(row: TaskItemRow): TaskItemRecord {
+  const lifecycle = normalizeTaskLifecycle(row.lifecycle);
+  const currentWorkflowKind = normalizeWorkflowKind(row.current_workflow_kind);
   return {
     taskId: row.task_id,
     title: row.title,
     body: row.body,
     source: row.source,
-    status: row.status,
-    lifecycle: normalizeTaskLifecycle(row.lifecycle, row.status),
-    currentWorkflowKind: normalizeWorkflowKind(row.current_workflow_kind),
+    status: deriveTaskStatusFromWorkflow(
+      {
+        lifecycle,
+        currentWorkflowKind,
+        workflowState:
+          currentWorkflowKind === WORKFLOW_KIND.ASK ? 'active' : 'drafting',
+      },
+      { prUrl: row.pr_url || undefined },
+    ),
+    lifecycle,
+    currentWorkflowKind,
     activeThreadId: row.active_thread_id || undefined,
     repoOwner: row.repo_owner || undefined,
     repoName: row.repo_name || undefined,
@@ -1023,6 +1018,101 @@ const TASK_FLOW_STAGE_LABELS: Record<TaskFlowStageId, string> = {
   completed: '已完成',
 };
 
+function isTaskCancelled(task: TaskItemRecord): boolean {
+  return task.lifecycle === TASK_LIFECYCLE.CANCELLED;
+}
+
+function isTaskCompleted(task: TaskItemRecord): boolean {
+  return task.lifecycle === TASK_LIFECYCLE.COMPLETED;
+}
+
+function isTaskDelivered(task: TaskItemRecord): boolean {
+  return (
+    task.lifecycle === TASK_LIFECYCLE.READY &&
+    task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION &&
+    Boolean(task.prUrl)
+  );
+}
+
+function isTaskImplemented(task: TaskItemRecord): boolean {
+  return (
+    task.lifecycle === TASK_LIFECYCLE.READY &&
+    task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION &&
+    !task.prUrl
+  );
+}
+
+function isTaskDelivering(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+}): boolean {
+  return (
+    input.task.lifecycle === TASK_LIFECYCLE.RUNNING &&
+    input.task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION &&
+    input.thread.status === THREAD_STATUS.VERIFYING
+  );
+}
+
+function isTaskImplementing(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+}): boolean {
+  return (
+    input.task.lifecycle === TASK_LIFECYCLE.RUNNING &&
+    input.task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION &&
+    input.thread.status !== THREAD_STATUS.VERIFYING
+  );
+}
+
+function isPlanningApproved(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+}): boolean {
+  return (
+    input.task.lifecycle === TASK_LIFECYCLE.READY &&
+    input.task.currentWorkflowKind === WORKFLOW_KIND.PLANNING &&
+    Boolean(input.thread.approvedPlanId)
+  );
+}
+
+function isPlanningActive(input: {
+  task: TaskItemRecord;
+  thread: TaskThreadRecord;
+}): boolean {
+  return (
+    input.task.currentWorkflowKind === WORKFLOW_KIND.PLANNING &&
+    !isPlanningApproved(input)
+  );
+}
+
+function deriveTaskStatusFromWorkflow(
+  workflow: WorkflowRuntimeState,
+  task?: Pick<TaskItemRecord, 'prUrl'>,
+): TaskStatus {
+  if (workflow.lifecycle === TASK_LIFECYCLE.CANCELLED) {
+    return TASK_STATUS.CLOSED;
+  }
+  if (workflow.lifecycle === TASK_LIFECYCLE.COMPLETED) {
+    return TASK_STATUS.COMPLETED;
+  }
+  if (workflow.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION) {
+    if (workflow.workflowState === 'verifying') {
+      return TASK_STATUS.DELIVERING;
+    }
+    if (workflow.workflowState === 'completed') {
+      return task?.prUrl ? TASK_STATUS.DELIVERED : TASK_STATUS.IMPLEMENTED;
+    }
+    return TASK_STATUS.IMPLEMENTING;
+  }
+  if (
+    workflow.currentWorkflowKind === WORKFLOW_KIND.PLANNING &&
+    workflow.workflowState === 'planned'
+  ) {
+    return TASK_STATUS.PLANNING_APPROVED;
+  }
+  return TASK_STATUS.PLANNING;
+}
+
 function inferWorkflowState(input: {
   task: TaskItemRecord;
   thread: TaskThreadRecord;
@@ -1030,7 +1120,7 @@ function inferWorkflowState(input: {
   openRound: TaskFeedbackRoundRecord | null;
   agentStages: TaskAgentStageRecord[];
 }): WorkflowRuntimeState {
-  if (input.task.status === TASK_STATUS.CLOSED) {
+  if (isTaskCancelled(input.task)) {
     return {
       lifecycle: TASK_LIFECYCLE.CANCELLED,
       currentWorkflowKind: input.task.currentWorkflowKind,
@@ -1042,19 +1132,14 @@ function inferWorkflowState(input: {
             : 'answered',
     };
   }
-  if (input.task.status === TASK_STATUS.COMPLETED) {
+  if (isTaskCompleted(input.task)) {
     return {
       lifecycle: TASK_LIFECYCLE.COMPLETED,
       currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
       workflowState: 'completed',
     };
   }
-  if (
-    input.task.status === TASK_STATUS.IMPLEMENTING ||
-    input.task.status === TASK_STATUS.IMPLEMENTED ||
-    input.task.status === TASK_STATUS.DELIVERING ||
-    input.task.status === TASK_STATUS.DELIVERED
-  ) {
+  if (input.task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION) {
     const runningStage = input.agentStages.find(
       (stage) =>
         stage.stage === TASK_AGENT_STAGE.IMPLEMENTATION &&
@@ -1072,7 +1157,21 @@ function inferWorkflowState(input: {
         workflowState: 'failed',
       };
     }
-    if (runningStage || input.task.status === TASK_STATUS.IMPLEMENTING) {
+    if (
+      input.thread.status === THREAD_STATUS.VERIFYING ||
+      input.agentStages.some(
+        (stage) =>
+          stage.stage === TASK_AGENT_STAGE.DELIVERY &&
+          stage.status === AGENT_RUN_STATUS.RUNNING,
+      )
+    ) {
+      return {
+        lifecycle: TASK_LIFECYCLE.RUNNING,
+        currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+        workflowState: 'verifying',
+      };
+    }
+    if (runningStage || input.task.lifecycle === TASK_LIFECYCLE.RUNNING) {
       return reduceWorkflowEvent(
         {
           lifecycle: TASK_LIFECYCLE.READY,
@@ -1083,15 +1182,10 @@ function inferWorkflowState(input: {
       );
     }
     return {
-      lifecycle:
-        input.task.status === TASK_STATUS.DELIVERING
-          ? TASK_LIFECYCLE.RUNNING
-          : TASK_LIFECYCLE.READY,
+      lifecycle: input.task.lifecycle,
       currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
       workflowState:
-        input.task.status === TASK_STATUS.DELIVERING
-          ? 'verifying'
-          : 'completed',
+        input.thread.status === THREAD_STATUS.FAILED ? 'failed' : 'completed',
     };
   }
   if (
@@ -1119,7 +1213,8 @@ function inferWorkflowState(input: {
   }
   if (
     input.thread.approvedPlanId ||
-    input.task.status === TASK_STATUS.PLANNING_APPROVED
+    input.thread.status === THREAD_STATUS.APPROVED ||
+    input.thread.status === THREAD_STATUS.PLANNED
   ) {
     return {
       lifecycle: TASK_LIFECYCLE.READY,
@@ -1168,6 +1263,7 @@ function applyWorkflowView(input: {
   return {
     task: {
       ...input.task,
+      status: deriveTaskStatusFromWorkflow(workflow, input.task),
       lifecycle: workflow.lifecycle,
       currentWorkflowKind: workflow.currentWorkflowKind,
     },
@@ -1217,10 +1313,10 @@ function getCurrentTaskFlowStageId(input: {
   openRound: TaskFeedbackRoundRecord | null;
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowStageId {
-  if (input.task.status === TASK_STATUS.CLOSED) return 'completed';
-  if (input.task.status === TASK_STATUS.COMPLETED) return 'completed';
+  if (isTaskCancelled(input.task)) return 'completed';
+  if (isTaskCompleted(input.task)) return 'completed';
   if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) return 'ask';
-  if (input.task.status === TASK_STATUS.DELIVERED) return 'delivery';
+  if (isTaskDelivered(input.task)) return 'delivery';
   if (input.openRound) return 'plan_discussion';
 
   const failedStage = getLatestFailedAgentStage(input.agentStages);
@@ -1250,7 +1346,7 @@ function getCurrentTaskFlowStageId(input: {
   if (input.thread.status === THREAD_STATUS.AWAITING_APPROVAL) {
     return 'plan_confirmation';
   }
-  if (input.task.status === TASK_STATUS.IMPLEMENTING) return 'implementation';
+  if (isTaskImplementing(input)) return 'implementation';
 
   const implementationStage = getStageByAgentStage(
     input.agentStages,
@@ -1259,15 +1355,15 @@ function getCurrentTaskFlowStageId(input: {
   if (implementationStage?.status === AGENT_RUN_STATUS.RUNNING) {
     return 'implementation';
   }
-  if (input.task.status === TASK_STATUS.IMPLEMENTED) return 'delivery';
-  if (input.task.status === TASK_STATUS.DELIVERING) return 'delivery';
+  if (isTaskImplemented(input.task)) return 'delivery';
+  if (isTaskDelivering(input)) return 'delivery';
 
   const deliveryStage = getStageByAgentStage(
     input.agentStages,
     TASK_AGENT_STAGE.DELIVERY,
   );
   if (deliveryStage?.status === AGENT_RUN_STATUS.RUNNING) return 'delivery';
-  if (input.task.status === TASK_STATUS.PLANNING_APPROVED) {
+  if (isPlanningApproved(input)) {
     return 'implementation';
   }
   return input.currentPlan ? 'plan_confirmation' : 'plan_discussion';
@@ -1292,13 +1388,13 @@ function buildTaskFlowConclusion(input: {
   failedStage?: TaskAgentStageRecord;
   runningStage?: TaskAgentStageRecord;
 }): Pick<TaskFlowSnapshot, 'conclusion' | 'severity'> {
-  if (input.task.status === TASK_STATUS.CLOSED) {
+  if (isTaskCancelled(input.task)) {
     return {
       conclusion: '任务已关闭，不再继续推进。',
       severity: 'blocked',
     };
   }
-  if (input.task.status === TASK_STATUS.COMPLETED) {
+  if (isTaskCompleted(input.task)) {
     return { conclusion: '任务已完成，关键产物已归档。', severity: 'success' };
   }
   if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
@@ -1313,7 +1409,7 @@ function buildTaskFlowConclusion(input: {
     }
     return { conclusion: '咨询正在处理中。', severity: 'normal' };
   }
-  if (input.task.status === TASK_STATUS.DELIVERED) {
+  if (isTaskDelivered(input.task)) {
     return {
       conclusion: '结果已交付，等待验收或继续修改。',
       severity: 'success',
@@ -1346,7 +1442,7 @@ function buildTaskFlowConclusion(input: {
   ) {
     return { conclusion: '等待你确认计划。', severity: 'normal' };
   }
-  if (input.task.status === TASK_STATUS.PLANNING_APPROVED) {
+  if (isPlanningApproved(input)) {
     const approvedPlan =
       input.currentPlan?.planId === input.thread.approvedPlanId
         ? input.currentPlan
@@ -1370,13 +1466,13 @@ function buildTaskFlowConclusion(input: {
       severity: 'normal',
     };
   }
-  if (input.task.status === TASK_STATUS.IMPLEMENTED) {
+  if (isTaskImplemented(input.task)) {
     return {
       conclusion: '实现已完成，可以提交并创建 PR。',
       severity: 'normal',
     };
   }
-  if (input.task.status === TASK_STATUS.DELIVERING) {
+  if (isTaskDelivering(input)) {
     return { conclusion: '交付流程正在处理。', severity: 'normal' };
   }
   if (!input.currentPlan) {
@@ -1413,7 +1509,7 @@ function buildTaskFlowActions(input: {
   artifacts: TaskArtifactRecord[];
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowAction[] {
-  if (input.task.status === TASK_STATUS.CLOSED) return [];
+  if (isTaskCancelled(input.task)) return [];
   if (input.task.currentWorkflowKind === WORKFLOW_KIND.ASK) {
     return [
       buildTaskFlowAction({
@@ -1454,8 +1550,8 @@ function buildTaskFlowActions(input: {
   );
   const canSubmitFeedback =
     input.thread.status !== THREAD_STATUS.APPROVED ||
-    input.task.status === TASK_STATUS.DELIVERED ||
-    input.task.status === TASK_STATUS.COMPLETED;
+    isTaskDelivered(input.task) ||
+    isTaskCompleted(input.task);
   const canApprove = Boolean(
     input.currentPlan &&
       !input.openRound &&
@@ -1463,7 +1559,7 @@ function buildTaskFlowActions(input: {
   );
   const canImplement = Boolean(
     input.thread.approvedPlanId &&
-      input.task.status === TASK_STATUS.PLANNING_APPROVED &&
+      isPlanningApproved(input) &&
       implementationStage?.status !== AGENT_RUN_STATUS.RUNNING,
   );
   const approvedPlan =
@@ -1480,10 +1576,10 @@ function buildTaskFlowActions(input: {
     implementationSteps && !implementationStepsApproved,
   );
   const canDeliver = Boolean(
-    input.task.status === TASK_STATUS.IMPLEMENTED &&
+    isTaskImplemented(input.task) &&
       deliveryStage?.status !== AGENT_RUN_STATUS.RUNNING,
   );
-  const canAcceptDelivery = input.task.status === TASK_STATUS.DELIVERED;
+  const canAcceptDelivery = isTaskDelivered(input.task);
   const failedResumeReason = failedStage?.manualResume?.command
     ? undefined
     : failedStage?.manualResume?.reason || '当前没有失败阶段可接管';
@@ -1536,7 +1632,7 @@ function buildTaskFlowActions(input: {
       id: 'rerun_planner',
       label: '重新规划',
       description: '重新调度 Planner 处理当前上下文',
-      enabled: input.task.status === TASK_STATUS.PLANNING,
+      enabled: isPlanningActive(input),
       disabledReason: '当前不处于计划阶段',
       stage: 'plan_discussion',
       variant:
@@ -1560,7 +1656,7 @@ function buildTaskFlowActions(input: {
           : '先让 Implementation Agent 产出详细实施步骤',
       enabled: canImplement,
       disabledReason: input.thread.approvedPlanId
-        ? input.task.status === TASK_STATUS.IMPLEMENTING
+        ? isTaskImplementing(input)
           ? '实现 Agent 正在执行'
           : '当前 Task 状态不能开始实现'
         : '当前没有已批准计划',
@@ -1601,10 +1697,9 @@ function buildTaskFlowActions(input: {
       label: '提交并创建 PR',
       description: '将已实现结果提交到分支并创建 PR',
       enabled: canDeliver,
-      disabledReason:
-        input.task.status === TASK_STATUS.IMPLEMENTED
-          ? 'Delivery Agent 正在执行'
-          : '只有实现完成后才能交付',
+      disabledReason: isTaskImplemented(input.task)
+        ? 'Delivery Agent 正在执行'
+        : '只有实现完成后才能交付',
       stage: 'delivery',
       variant: 'primary',
     }),
@@ -1621,14 +1716,12 @@ function buildTaskFlowActions(input: {
       id: 'request_changes',
       label: '继续修改',
       description: '基于交付结果重新打开讨论',
-      enabled:
-        input.task.status === TASK_STATUS.DELIVERED ||
-        input.task.status === TASK_STATUS.COMPLETED,
+      enabled: isTaskDelivered(input.task) || isTaskCompleted(input.task),
       disabledReason: '只有交付后才能发起继续修改',
       stage: 'delivery',
       variant: 'secondary',
     }),
-    ...(input.task.status === TASK_STATUS.COMPLETED
+    ...(isTaskCompleted(input.task)
       ? []
       : [
           buildTaskFlowAction({
@@ -1690,8 +1783,8 @@ function getTaskFlowStageSummary(input: {
           ? '计划已确认'
           : '尚未进入确认';
     case 'implementation':
-      if (input.task.status === TASK_STATUS.IMPLEMENTED) return '实现已完成';
-      if (input.task.status === TASK_STATUS.PLANNING_APPROVED) {
+      if (isTaskImplemented(input.task)) return '实现已完成';
+      if (isPlanningApproved(input)) {
         const approvedPlan =
           input.currentPlan?.planId === input.thread.approvedPlanId
             ? input.currentPlan
@@ -1708,15 +1801,13 @@ function getTaskFlowStageSummary(input: {
       }
       return '等待计划批准';
     case 'delivery':
-      if (input.task.status === TASK_STATUS.DELIVERED) return '结果已交付';
-      if (input.task.status === TASK_STATUS.IMPLEMENTED) return '等待交付';
-      if (input.task.status === TASK_STATUS.DELIVERING) return '交付中';
+      if (isTaskDelivered(input.task)) return '结果已交付';
+      if (isTaskImplemented(input.task)) return '等待交付';
+      if (isTaskDelivering(input)) return '交付中';
       return '等待实现完成';
     case 'completed':
-      if (input.task.status === TASK_STATUS.CLOSED) return '任务已关闭';
-      return input.task.status === TASK_STATUS.COMPLETED
-        ? '任务已完成'
-        : '等待验收';
+      if (isTaskCancelled(input.task)) return '任务已关闭';
+      return isTaskCompleted(input.task) ? '任务已完成' : '等待验收';
     default:
       return TASK_FLOW_STAGE_LABELS[input.stageId];
   }
@@ -1815,10 +1906,9 @@ function buildTaskFlowStages(input: {
     ];
   }
   const currentIndex = TASK_FLOW_STAGE_ORDER.indexOf(input.currentStageId);
-  const failedStage =
-    input.task.status === TASK_STATUS.CLOSED
-      ? undefined
-      : getLatestFailedAgentStage(input.agentStages);
+  const failedStage = isTaskCancelled(input.task)
+    ? undefined
+    : getLatestFailedAgentStage(input.agentStages);
 
   return TASK_FLOW_STAGE_ORDER.map((stageId, index) => {
     let state: TaskFlowStageState =
@@ -1941,9 +2031,17 @@ function buildTaskFlowEvents(input: {
       });
     }
     if (artifact.type === ARTIFACT_TYPE.TASK_CLOSED) {
-      const previousStatus =
-        typeof artifact.metadata.previousStatus === 'string'
-          ? artifact.metadata.previousStatus
+      const previousLifecycle =
+        typeof artifact.metadata.previousLifecycle === 'string'
+          ? artifact.metadata.previousLifecycle
+          : undefined;
+      const previousWorkflowKind =
+        typeof artifact.metadata.previousWorkflowKind === 'string'
+          ? artifact.metadata.previousWorkflowKind
+          : undefined;
+      const previousThreadStatus =
+        typeof artifact.metadata.previousThreadStatus === 'string'
+          ? artifact.metadata.previousThreadStatus
           : undefined;
       const reason =
         typeof artifact.metadata.reason === 'string'
@@ -1954,7 +2052,12 @@ function buildTaskFlowEvents(input: {
         type: 'task_closed',
         stage: 'completed',
         title: '任务已关闭',
-        summary: [previousStatus ? `关闭前状态：${previousStatus}` : '', reason]
+        summary: [
+          previousLifecycle ? `关闭前生命周期：${previousLifecycle}` : '',
+          previousWorkflowKind ? `工作流：${previousWorkflowKind}` : '',
+          previousThreadStatus ? `线程：${previousThreadStatus}` : '',
+          reason,
+        ]
           .filter(Boolean)
           .join('；'),
         occurredAt: artifact.createdAt,
@@ -2015,7 +2118,7 @@ function buildTaskFlowEvents(input: {
       occurredAt: input.task.updatedAt,
     });
   }
-  if (input.task.status === TASK_STATUS.COMPLETED) {
+  if (isTaskCompleted(input.task)) {
     events.push({
       eventId: `completed:${input.task.taskId}`,
       type: 'task_completed',
@@ -2060,7 +2163,7 @@ function buildTaskFlowSnapshot(input: {
   agentStages: TaskAgentStageRecord[];
 }): TaskFlowSnapshot {
   const currentStageId = getCurrentTaskFlowStageId(input);
-  const isClosed = input.task.status === TASK_STATUS.CLOSED;
+  const isClosed = isTaskCancelled(input.task);
   const failedStage = isClosed
     ? undefined
     : getLatestFailedAgentStage(input.agentStages);
@@ -2257,12 +2360,12 @@ function ensureTaskIsOpen(
   snapshot: TaskPlanningSnapshot,
   action: string,
 ): Result<void> {
-  return snapshot.task.status === TASK_STATUS.CLOSED
+  return snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED
     ? failure(`Task 已关闭，不能${action}`)
     : success(undefined);
 }
 
-function readTaskStatus(taskId: string): Result<TaskStatus | null> {
+function ensureTaskCanRecordAgentResult(taskId: string): Result<void> {
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
 
@@ -2270,10 +2373,14 @@ function readTaskStatus(taskId: string): Result<TaskStatus | null> {
     const row = dbRes.data
       .prepare('SELECT * FROM task_items WHERE task_id = ?')
       .get(taskId) as TaskItemRow | null;
-    return success(row ? row.status : null);
+    if (!row) return failure(`Task 不存在: ${taskId}`);
+    if (normalizeTaskLifecycle(row.lifecycle) === TASK_LIFECYCLE.CANCELLED) {
+      return failure('Task 已关闭，不能记录 Agent Result');
+    }
+    return success(undefined);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    return failure(`读取 Task 状态失败: ${message}`);
+    return failure(`检查 Task 状态失败: ${message}`);
   }
 }
 
@@ -2285,10 +2392,11 @@ export function closeTask(
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
-  if (snapshot.task.status === TASK_STATUS.COMPLETED) {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.COMPLETED) {
     return failure('已完成 Task 不能关闭');
   }
-  if (snapshot.task.status === TASK_STATUS.CLOSED) return success(snapshot);
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED)
+    return success(snapshot);
 
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
@@ -2311,7 +2419,9 @@ export function closeTask(
           ? `任务已关闭：${closeReason}`
           : '任务已关闭，不再继续推进。',
         metadata: {
-          previousStatus: snapshot.task.status,
+          previousLifecycle: snapshot.task.lifecycle,
+          previousWorkflowKind: snapshot.task.currentWorkflowKind,
+          previousThreadStatus: snapshot.thread.status,
           reason: closeReason || null,
           closedAt: now,
         },
@@ -2357,8 +2467,12 @@ export function closeTask(
       }
 
       db.prepare(
-        'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
-      ).run(TASK_STATUS.CLOSED, now, snapshot.task.taskId);
+        `
+          UPDATE task_items
+          SET lifecycle = ?, updated_at = ?
+          WHERE task_id = ?
+        `,
+      ).run(TASK_LIFECYCLE.CANCELLED, now, snapshot.task.taskId);
     });
 
     txn();
@@ -2419,22 +2533,24 @@ export function createPlanningTask(
       db.prepare(
         `
           INSERT INTO task_items (
-            task_id, title, body, source, status, active_thread_id,
-            repo_owner, repo_name, cwd, seq, execution_mode, created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            task_id, title, body, source, active_thread_id,
+            repo_owner, repo_name, cwd, seq, execution_mode, lifecycle,
+            current_workflow_kind, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
       ).run(
         taskId,
         title,
         body,
         input.source || 'web',
-        TASK_STATUS.PLANNING,
         threadId,
         input.repoOwner || null,
         input.repoName || null,
         input.cwd || null,
         seq,
         input.executionMode || TASK_EXECUTION_MODE.MANUAL,
+        TASK_LIFECYCLE.OPEN,
+        workflowKind,
         now,
         now,
       );
@@ -2740,14 +2856,12 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
     .prepare('SELECT * FROM task_items WHERE task_id = ?')
     .get(input.taskId) as TaskItemRow | null;
   if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
-  if (taskRow.status === TASK_STATUS.CLOSED) {
+  const task = mapTask(taskRow);
+  if (task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return failure('Task 已关闭，不能继续讨论');
   }
   if (thread.status === THREAD_STATUS.APPROVED) {
-    if (
-      taskRow?.status !== TASK_STATUS.DELIVERED &&
-      taskRow?.status !== TASK_STATUS.COMPLETED
-    ) {
+    if (!task.prUrl && task.lifecycle !== TASK_LIFECYCLE.COMPLETED) {
       return failure('当前 Planning 已批准，不能继续提交反馈');
     }
   }
@@ -2889,8 +3003,12 @@ export function submitTaskMessage(input: SubmitTaskMessageInput): Result<{
       );
       if (thread.status === THREAD_STATUS.APPROVED) {
         db.prepare(
-          'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
-        ).run(TASK_STATUS.PLANNING, now, thread.task_id);
+          `
+            UPDATE task_items
+            SET lifecycle = ?, current_workflow_kind = ?, updated_at = ?
+            WHERE task_id = ?
+          `,
+        ).run(TASK_LIFECYCLE.OPEN, WORKFLOW_KIND.PLANNING, now, thread.task_id);
       }
       roundResult = mapRound(roundRow);
     });
@@ -3183,11 +3301,8 @@ export function recordTaskAgentResult(
 ): Result<TaskArtifactRecord> {
   const body = input.body.trim();
   if (!body) return failure('Agent Result 内容不能为空');
-  const statusRes = readTaskStatus(input.taskId);
-  if (!statusRes.success) return statusRes;
-  if (statusRes.data === TASK_STATUS.CLOSED) {
-    return failure('Task 已关闭，不能记录 Agent Result');
-  }
+  const openRes = ensureTaskCanRecordAgentResult(input.taskId);
+  if (!openRes.success) return openRes;
 
   try {
     const artifact = insertArtifact({
@@ -3263,10 +3378,15 @@ export function approveCurrentTaskPlan(
       db.prepare(
         `
           UPDATE task_items
-          SET status = ?, updated_at = ?
+          SET lifecycle = ?, current_workflow_kind = ?, updated_at = ?
           WHERE task_id = ?
         `,
-      ).run(TASK_STATUS.PLANNING_APPROVED, now, snapshot.task.taskId);
+      ).run(
+        TASK_LIFECYCLE.READY,
+        WORKFLOW_KIND.PLANNING,
+        now,
+        snapshot.task.taskId,
+      );
     });
 
     txn();
@@ -3353,8 +3473,9 @@ export function completeDeliveredTask(
   if (!snapshot) return failure(`Task 不存在: ${taskId}`);
   const openRes = ensureTaskIsOpen(snapshot, '验收完成');
   if (!openRes.success) return openRes;
-  if (snapshot.task.status === TASK_STATUS.COMPLETED) return success(snapshot);
-  if (snapshot.task.status !== TASK_STATUS.DELIVERED) {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.COMPLETED)
+    return success(snapshot);
+  if (!snapshot.task.prUrl) {
     return failure('只有已交付 Task 可以验收完成');
   }
 
@@ -3379,9 +3500,18 @@ export function completeDeliveredTask(
       });
       dbRes.data
         .prepare(
-          'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
+          `
+            UPDATE task_items
+            SET lifecycle = ?, current_workflow_kind = ?, updated_at = ?
+            WHERE task_id = ?
+          `,
         )
-        .run(TASK_STATUS.COMPLETED, now, snapshot.task.taskId);
+        .run(
+          TASK_LIFECYCLE.COMPLETED,
+          WORKFLOW_KIND.IMPLEMENTATION,
+          now,
+          snapshot.task.taskId,
+        );
     });
 
     txn();
@@ -3521,31 +3651,61 @@ export function updateTaskStatus(
   taskId: string,
   status: TaskStatus,
 ): Result<void> {
+  void taskId;
+  void status;
+  return failure('旧 task.status 已禁止直接写入，请更新分层状态字段');
+}
+
+export function updateTaskWorkflowState(input: {
+  taskId: string;
+  lifecycle: TaskLifecycle;
+  currentWorkflowKind: WorkflowKind;
+  threadStatus?: ThreadStatus;
+}): Result<void> {
   const dbRes = getDb();
   if (!dbRes.success) return dbRes;
 
   try {
     const taskRow = dbRes.data
       .prepare('SELECT * FROM task_items WHERE task_id = ?')
-      .get(taskId) as TaskItemRow | null;
-    if (!taskRow) return failure(`Task 不存在: ${taskId}`);
+      .get(input.taskId) as TaskItemRow | null;
+    if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
     if (
-      taskRow.status === TASK_STATUS.CLOSED &&
-      status !== TASK_STATUS.CLOSED
+      normalizeTaskLifecycle(taskRow.lifecycle) === TASK_LIFECYCLE.CANCELLED &&
+      input.lifecycle !== TASK_LIFECYCLE.CANCELLED
     ) {
-      return failure('Task 已关闭，不能更新状态');
+      return failure('Task 已关闭，不能更新工作流状态');
     }
-    const result = dbRes.data
-      .prepare(
-        'UPDATE task_items SET status = ?, updated_at = ? WHERE task_id = ?',
-      )
-      .run(status, iso_timestamp(), taskId);
-    return result.changes > 0
-      ? success(undefined)
-      : failure(`Task 不存在: ${taskId}`);
+    const now = iso_timestamp();
+    const txn = dbRes.data.transaction(() => {
+      dbRes.data
+        .prepare(
+          `
+            UPDATE task_items
+            SET lifecycle = ?, current_workflow_kind = ?, updated_at = ?
+            WHERE task_id = ?
+          `,
+        )
+        .run(input.lifecycle, input.currentWorkflowKind, now, input.taskId);
+      if (input.threadStatus) {
+        dbRes.data
+          .prepare(
+            `
+              UPDATE task_threads
+              SET status = ?, updated_at = ?
+              WHERE task_id = ? AND thread_id = (
+                SELECT active_thread_id FROM task_items WHERE task_id = ?
+              )
+            `,
+          )
+          .run(input.threadStatus, now, input.taskId, input.taskId);
+      }
+    });
+    txn();
+    return success(undefined);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    return failure(`更新 Task 状态失败: ${message}`);
+    return failure(`更新 Task 工作流状态失败: ${message}`);
   }
 }
 
@@ -3561,8 +3721,7 @@ export function updateTaskDelivery(
       .get(input.taskId) as TaskItemRow | null;
     if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
     if (
-      taskRow.status === TASK_STATUS.CLOSED &&
-      input.status !== TASK_STATUS.CLOSED
+      normalizeTaskLifecycle(taskRow.lifecycle) === TASK_LIFECYCLE.CANCELLED
     ) {
       return failure('Task 已关闭，不能更新交付信息');
     }
@@ -3570,8 +3729,7 @@ export function updateTaskDelivery(
       .prepare(
         `
           UPDATE task_items
-          SET status = ?,
-              branch_name = COALESCE(?, branch_name),
+          SET branch_name = COALESCE(?, branch_name),
               worktree_path = COALESCE(?, worktree_path),
               commit_shas = COALESCE(?, commit_shas),
               pr_url = COALESCE(?, pr_url),
@@ -3581,7 +3739,6 @@ export function updateTaskDelivery(
         `,
       )
       .run(
-        input.status,
         input.branchName || null,
         input.worktreePath || null,
         input.commitShas ? JSON.stringify(input.commitShas) : null,
@@ -3681,19 +3838,31 @@ export function completeTaskAgentStageManually(
   let statusRes: Result<void> = success(undefined);
   if (input.stage === TASK_AGENT_STAGE.IMPLEMENTATION) {
     statusRes =
-      snapshot.task.status === TASK_STATUS.DELIVERING ||
-      snapshot.task.status === TASK_STATUS.DELIVERED
-        ? updateTaskStatus(input.taskId, snapshot.task.status)
-        : updateTaskStatus(input.taskId, TASK_STATUS.IMPLEMENTED);
+      isTaskDelivering({ task: snapshot.task, thread: snapshot.thread }) ||
+      isTaskDelivered(snapshot.task)
+        ? success(undefined)
+        : updateTaskWorkflowState({
+            taskId: input.taskId,
+            lifecycle: TASK_LIFECYCLE.READY,
+            currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+            threadStatus: THREAD_STATUS.COMPLETED,
+          });
   } else if (input.stage === TASK_AGENT_STAGE.DELIVERY && input.prUrl) {
-    statusRes = updateTaskDelivery({
+    const deliveryRes = updateTaskDelivery({
       taskId: input.taskId,
-      status: TASK_STATUS.DELIVERED,
       prUrl: input.prUrl,
       prNumber: input.prNumber || parseTaskPrNumber(input.prUrl),
     });
+    statusRes = deliveryRes.success
+      ? updateTaskWorkflowState({
+          taskId: input.taskId,
+          lifecycle: TASK_LIFECYCLE.READY,
+          currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+          threadStatus: THREAD_STATUS.COMPLETED,
+        })
+      : deliveryRes;
   } else {
-    statusRes = updateTaskStatus(input.taskId, snapshot.task.status);
+    statusRes = success(undefined);
   }
   if (!statusRes.success) {
     return failManualStageRun(run.runId, statusRes.error);
@@ -3901,7 +4070,9 @@ export function createTaskAgentRun(
       .prepare('SELECT * FROM task_items WHERE task_id = ?')
       .get(input.taskId) as TaskItemRow | null;
     if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
-    if (taskRow.status === TASK_STATUS.CLOSED) {
+    if (
+      normalizeTaskLifecycle(taskRow.lifecycle) === TASK_LIFECYCLE.CANCELLED
+    ) {
       return failure('Task 已关闭，不能创建 Agent Run');
     }
     dbRes.data
@@ -4023,31 +4194,25 @@ export function recoverInterruptedTaskAgentRuns(
       recoveredRuns.push(finishRes.data);
 
       if (row.agent_id === 'implementer') {
-        const task = dbRes.data
-          .prepare('SELECT * FROM task_items WHERE task_id = ?')
-          .get(row.task_id) as TaskItemRow | null;
-        if (task?.status === TASK_STATUS.IMPLEMENTING) {
-          const resetRes = updateTaskStatus(
-            String(row.task_id),
-            TASK_STATUS.PLANNING_APPROVED,
-          );
-          if (!resetRes.success) return resetRes;
-          resetTaskIds.add(String(row.task_id));
-        }
+        const resetRes = updateTaskWorkflowState({
+          taskId: String(row.task_id),
+          lifecycle: TASK_LIFECYCLE.READY,
+          currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+          threadStatus: THREAD_STATUS.APPROVED,
+        });
+        if (!resetRes.success) return resetRes;
+        resetTaskIds.add(String(row.task_id));
       }
 
       if (row.agent_id === 'delivery') {
-        const task = dbRes.data
-          .prepare('SELECT * FROM task_items WHERE task_id = ?')
-          .get(row.task_id) as TaskItemRow | null;
-        if (task?.status === TASK_STATUS.DELIVERING) {
-          const resetRes = updateTaskStatus(
-            String(row.task_id),
-            TASK_STATUS.IMPLEMENTED,
-          );
-          if (!resetRes.success) return resetRes;
-          resetTaskIds.add(String(row.task_id));
-        }
+        const resetRes = updateTaskWorkflowState({
+          taskId: String(row.task_id),
+          lifecycle: TASK_LIFECYCLE.READY,
+          currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+          threadStatus: THREAD_STATUS.COMPLETED,
+        });
+        if (!resetRes.success) return resetRes;
+        resetTaskIds.add(String(row.task_id));
       }
     }
 

--- a/packages/along/src/domain/task-workflow-state.test.ts
+++ b/packages/along/src/domain/task-workflow-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTaskDisplay } from './task-display-state';
+import {
+  reduceWorkflowEvent,
+  TASK_LIFECYCLE,
+  WORKFLOW_KIND,
+  type WorkflowRuntimeState,
+} from './task-workflow-state';
+
+describe('task-workflow-state', () => {
+  it('创建任务默认进入 ask workflow', () => {
+    const state = reduceWorkflowEvent(
+      {
+        lifecycle: TASK_LIFECYCLE.OPEN,
+        currentWorkflowKind: WORKFLOW_KIND.ASK,
+        workflowState: 'active',
+      },
+      { type: 'task.created' },
+    );
+
+    expect(state).toEqual({
+      lifecycle: 'open',
+      currentWorkflowKind: 'ask',
+      workflowState: 'active',
+    });
+    expect(deriveTaskDisplay(state)).toEqual({
+      state: 'ask_active',
+      label: '咨询中',
+    });
+  });
+
+  it('user.message.received 不直接改变状态', () => {
+    const state: WorkflowRuntimeState = {
+      lifecycle: TASK_LIFECYCLE.READY,
+      currentWorkflowKind: WORKFLOW_KIND.ASK,
+      workflowState: 'answered',
+    };
+
+    expect(reduceWorkflowEvent(state, { type: 'user.message.received' })).toBe(
+      state,
+    );
+  });
+
+  it('ask 可以通过 plan.requested 切换到 planning', () => {
+    const state = reduceWorkflowEvent(
+      {
+        lifecycle: TASK_LIFECYCLE.READY,
+        currentWorkflowKind: WORKFLOW_KIND.ASK,
+        workflowState: 'answered',
+      },
+      { type: 'plan.requested' },
+    );
+
+    expect(state).toEqual({
+      lifecycle: 'open',
+      currentWorkflowKind: 'planning',
+      workflowState: 'drafting',
+    });
+  });
+
+  it('planning 审批后进入 ready/planned', () => {
+    const drafted = reduceWorkflowEvent(
+      {
+        lifecycle: TASK_LIFECYCLE.OPEN,
+        currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+        workflowState: 'drafting',
+      },
+      { type: 'plan.revision.created' },
+    );
+    const approved = reduceWorkflowEvent(drafted, { type: 'plan.approved' });
+
+    expect(approved).toEqual({
+      lifecycle: 'ready',
+      currentWorkflowKind: 'planning',
+      workflowState: 'planned',
+    });
+    expect(deriveTaskDisplay(approved).label).toBe('已规划');
+  });
+
+  it('拒绝 workflow 不匹配的非法事件', () => {
+    expect(() =>
+      reduceWorkflowEvent(
+        {
+          lifecycle: TASK_LIFECYCLE.OPEN,
+          currentWorkflowKind: WORKFLOW_KIND.ASK,
+          workflowState: 'active',
+        },
+        { type: 'plan.revision.created' },
+      ),
+    ).toThrow('非法任务状态事件');
+  });
+});

--- a/packages/along/src/domain/task-workflow-state.ts
+++ b/packages/along/src/domain/task-workflow-state.ts
@@ -1,0 +1,244 @@
+export const TASK_LIFECYCLE = {
+  OPEN: 'open',
+  WAITING_USER: 'waiting_user',
+  READY: 'ready',
+  RUNNING: 'running',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+  FAILED: 'failed',
+} as const;
+
+export type TaskLifecycle =
+  (typeof TASK_LIFECYCLE)[keyof typeof TASK_LIFECYCLE];
+
+export const WORKFLOW_KIND = {
+  ASK: 'ask',
+  PLANNING: 'planning',
+  IMPLEMENTATION: 'implementation',
+} as const;
+
+export type WorkflowKind = (typeof WORKFLOW_KIND)[keyof typeof WORKFLOW_KIND];
+
+export type AskWorkflowState = 'active' | 'waiting_user' | 'answered';
+export type PlanningWorkflowState =
+  | 'drafting'
+  | 'waiting_user'
+  | 'awaiting_approval'
+  | 'feedback'
+  | 'planned';
+export type ImplementationWorkflowState =
+  | 'implementing'
+  | 'waiting_user'
+  | 'verifying'
+  | 'completed'
+  | 'failed';
+export type WorkflowState =
+  | AskWorkflowState
+  | PlanningWorkflowState
+  | ImplementationWorkflowState;
+
+export type DomainEventType =
+  | 'task.created'
+  | 'user.message.received'
+  | 'ask.started'
+  | 'ask.needs_user_input'
+  | 'ask.answer.completed'
+  | 'plan.requested'
+  | 'plan.needs_user_input'
+  | 'plan.revision.created'
+  | 'feedback.round.opened'
+  | 'feedback.round.resolved'
+  | 'plan.approved'
+  | 'implementation.started'
+  | 'implementation.completed'
+  | 'verification.started'
+  | 'verification.passed'
+  | 'implementation.failed'
+  | 'task.closed';
+
+export interface DomainEvent {
+  type: DomainEventType;
+  workflowKind?: WorkflowKind;
+}
+
+export interface WorkflowRuntimeState {
+  lifecycle: TaskLifecycle;
+  currentWorkflowKind: WorkflowKind;
+  workflowState: WorkflowState;
+}
+
+type WorkflowPatch = Pick<WorkflowRuntimeState, 'lifecycle' | 'workflowState'>;
+
+const TERMINAL_LIFECYCLES = new Set<TaskLifecycle>([
+  TASK_LIFECYCLE.COMPLETED,
+  TASK_LIFECYCLE.CANCELLED,
+]);
+
+function assertTransition(
+  condition: boolean,
+  event: DomainEventType,
+): asserts condition {
+  if (!condition) {
+    throw new Error(`非法任务状态事件: ${event}`);
+  }
+}
+
+export function reduceWorkflowEvent(
+  state: WorkflowRuntimeState,
+  event: DomainEvent,
+): WorkflowRuntimeState {
+  assertTransition(
+    !TERMINAL_LIFECYCLES.has(state.lifecycle) || event.type === 'task.created',
+    event.type,
+  );
+  if (event.type === 'task.created') return createInitialState(event);
+  if (event.type === 'user.message.received') return state;
+  if (event.type.startsWith('ask.')) return reduceAskEvent(state, event);
+  if (event.type.startsWith('plan.') || event.type.startsWith('feedback.')) {
+    return reducePlanningEvent(state, event);
+  }
+  if (
+    event.type.startsWith('implementation.') ||
+    event.type.startsWith('verification.')
+  ) {
+    return reduceImplementationEvent(state, event);
+  }
+  if (event.type === 'task.closed') {
+    return { ...state, lifecycle: TASK_LIFECYCLE.CANCELLED };
+  }
+  return state;
+}
+
+function createInitialState(event: DomainEvent): WorkflowRuntimeState {
+  const workflowKind = event.workflowKind || WORKFLOW_KIND.ASK;
+  return workflowKind === WORKFLOW_KIND.PLANNING
+    ? {
+        lifecycle: TASK_LIFECYCLE.OPEN,
+        currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+        workflowState: 'drafting',
+      }
+    : {
+        lifecycle: TASK_LIFECYCLE.OPEN,
+        currentWorkflowKind: WORKFLOW_KIND.ASK,
+        workflowState: 'active',
+      };
+}
+
+function reduceAskEvent(
+  state: WorkflowRuntimeState,
+  event: DomainEvent,
+): WorkflowRuntimeState {
+  switch (event.type) {
+    case 'ask.started':
+      return {
+        lifecycle: TASK_LIFECYCLE.OPEN,
+        currentWorkflowKind: WORKFLOW_KIND.ASK,
+        workflowState: 'active',
+      };
+    case 'ask.needs_user_input':
+      assertTransition(
+        state.currentWorkflowKind === WORKFLOW_KIND.ASK,
+        event.type,
+      );
+      return {
+        ...state,
+        lifecycle: TASK_LIFECYCLE.WAITING_USER,
+        workflowState: 'waiting_user',
+      };
+    case 'ask.answer.completed':
+      assertTransition(
+        state.currentWorkflowKind === WORKFLOW_KIND.ASK,
+        event.type,
+      );
+      return {
+        ...state,
+        lifecycle: TASK_LIFECYCLE.READY,
+        workflowState: 'answered',
+      };
+    default:
+      return state;
+  }
+}
+
+function reducePlanningEvent(
+  state: WorkflowRuntimeState,
+  event: DomainEvent,
+): WorkflowRuntimeState {
+  if (event.type === 'plan.requested') {
+    return {
+      lifecycle: TASK_LIFECYCLE.OPEN,
+      currentWorkflowKind: WORKFLOW_KIND.PLANNING,
+      workflowState: 'drafting',
+    };
+  }
+  assertTransition(
+    state.currentWorkflowKind === WORKFLOW_KIND.PLANNING,
+    event.type,
+  );
+  const patch = PLANNING_EVENT_PATCHES[event.type];
+  return patch ? { ...state, ...patch } : state;
+}
+
+function reduceImplementationEvent(
+  state: WorkflowRuntimeState,
+  event: DomainEvent,
+): WorkflowRuntimeState {
+  if (event.type === 'implementation.started') {
+    return {
+      lifecycle: TASK_LIFECYCLE.RUNNING,
+      currentWorkflowKind: WORKFLOW_KIND.IMPLEMENTATION,
+      workflowState: 'implementing',
+    };
+  }
+  assertTransition(
+    state.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION,
+    event.type,
+  );
+  const patch = IMPLEMENTATION_EVENT_PATCHES[event.type];
+  return patch ? { ...state, ...patch } : state;
+}
+
+const PLANNING_EVENT_PATCHES: Partial<Record<DomainEventType, WorkflowPatch>> =
+  {
+    'plan.needs_user_input': {
+      lifecycle: TASK_LIFECYCLE.WAITING_USER,
+      workflowState: 'waiting_user',
+    },
+    'plan.revision.created': {
+      lifecycle: TASK_LIFECYCLE.WAITING_USER,
+      workflowState: 'awaiting_approval',
+    },
+    'feedback.round.opened': {
+      lifecycle: TASK_LIFECYCLE.OPEN,
+      workflowState: 'feedback',
+    },
+    'feedback.round.resolved': {
+      lifecycle: TASK_LIFECYCLE.WAITING_USER,
+      workflowState: 'awaiting_approval',
+    },
+    'plan.approved': {
+      lifecycle: TASK_LIFECYCLE.READY,
+      workflowState: 'planned',
+    },
+  };
+
+const IMPLEMENTATION_EVENT_PATCHES: Partial<
+  Record<DomainEventType, WorkflowPatch>
+> = {
+  'implementation.completed': {
+    lifecycle: TASK_LIFECYCLE.READY,
+    workflowState: 'completed',
+  },
+  'verification.started': {
+    lifecycle: TASK_LIFECYCLE.RUNNING,
+    workflowState: 'verifying',
+  },
+  'verification.passed': {
+    lifecycle: TASK_LIFECYCLE.COMPLETED,
+    workflowState: 'completed',
+  },
+  'implementation.failed': {
+    lifecycle: TASK_LIFECYCLE.FAILED,
+    workflowState: 'failed',
+  },
+};

--- a/packages/along/src/domain/task-worktree.test.ts
+++ b/packages/along/src/domain/task-worktree.test.ts
@@ -7,6 +7,17 @@ const planningMocks = vi.hoisted(() => ({
   updateTaskDelivery: vi.fn(),
   updateTaskRepository: vi.fn(),
 }));
+const mockTaskConstants = vi.hoisted(() => ({
+  TASK_STATUS: {
+    PLANNING_APPROVED: 'planning_approved',
+  },
+  THREAD_PURPOSE: {
+    PLANNING: 'planning',
+  },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+  },
+}));
 
 vi.mock('./task-planning', () => ({
   updateTaskDelivery: planningMocks.updateTaskDelivery,
@@ -37,7 +48,7 @@ const snapshot = {
     title: '移动演示数据按钮',
     body: '删除下方的演示数据按钮应该位于礼薄列表上方。',
     source: 'web',
-    status: 'planning_approved',
+    status: mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
     activeThreadId: 'thread-1',
     repoOwner: 'ranwawa',
     repoName: 'kinkeeper',
@@ -51,8 +62,8 @@ const snapshot = {
   thread: {
     threadId: 'thread-1',
     taskId: 'task_123456789abc',
-    purpose: 'planning',
-    status: 'approved',
+    purpose: mockTaskConstants.THREAD_PURPOSE.PLANNING,
+    status: mockTaskConstants.THREAD_STATUS.APPROVED,
     approvedPlanId: 'plan-1',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
@@ -136,7 +147,6 @@ describe('task-worktree', () => {
     });
     expect(planningMocks.updateTaskDelivery).toHaveBeenCalledWith({
       taskId: 'task_123456789abc',
-      status: 'planning_approved',
       branchName: result.data.branchName,
       worktreePath,
     });

--- a/packages/along/src/domain/task-worktree.ts
+++ b/packages/along/src/domain/task-worktree.ts
@@ -305,7 +305,6 @@ async function ensureTaskWorktreeReady(context: TaskWorktreeContext) {
 function recordTaskWorktree(context: TaskWorktreeContext) {
   return updateTaskDelivery({
     taskId: context.snapshot.task.taskId,
-    status: context.snapshot.task.status,
     branchName: context.branchName,
     worktreePath: context.worktreePath,
   });

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -15,6 +15,7 @@ import {
   createPlanningTask,
   listTaskPlanningSnapshots,
   readTaskPlanningSnapshot,
+  requestTaskPlan,
   submitTaskMessage,
   type TaskPlanningSnapshot,
 } from '../domain/task-planning';
@@ -220,6 +221,8 @@ export async function handleTaskPlannerRequest(
   if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
   const snapshotError = readExistingTaskError(taskId);
   if (snapshotError) return snapshotError;
+  const requestPlanRes = requestTaskPlan(taskId);
+  if (!requestPlanRes.success) return errorResponse(requestPlanRes.error, 409);
 
   const scheduledRes = schedulePlannerIfNeeded(
     { ...bodyRes.data, autoRun: true },

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -17,7 +17,9 @@ import {
   readTaskPlanningSnapshot,
   requestTaskPlan,
   submitTaskMessage,
+  TASK_LIFECYCLE,
   type TaskPlanningSnapshot,
+  WORKFLOW_KIND,
 } from '../domain/task-planning';
 import type { TaskApiContext } from './task-api';
 import { readTaskAttachmentResponse } from './task-api-attachments';
@@ -245,7 +247,7 @@ export async function handleTaskImplementationRequest(
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-  if (snapshotRes.data.task.status === 'closed') {
+  if (snapshotRes.data.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return errorResponse('Task 已关闭，不能开始实现', 409);
   }
   if (!snapshotRes.data.thread.approvedPlanId) {
@@ -300,10 +302,15 @@ export async function handleTaskDeliveryRequest(
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-  if (snapshotRes.data.task.status === 'closed') {
+  if (snapshotRes.data.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return errorResponse('Task 已关闭，不能开始交付', 409);
   }
-  if (snapshotRes.data.task.status !== 'implemented') {
+  if (
+    snapshotRes.data.task.currentWorkflowKind !==
+      WORKFLOW_KIND.IMPLEMENTATION ||
+    snapshotRes.data.task.lifecycle !== TASK_LIFECYCLE.READY ||
+    snapshotRes.data.task.prUrl
+  ) {
     return errorResponse('当前 Task 只有在已实现后才能交付', 409);
   }
 
@@ -348,7 +355,7 @@ function readExistingTaskError(taskId: string): Response | null {
   const snapshotRes = readTaskPlanningSnapshot(taskId);
   if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
   if (!snapshotRes.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
-  if (snapshotRes.data.task.status === 'closed') {
+  if (snapshotRes.data.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
     return errorResponse('Task 已关闭，不能继续推进', 409);
   }
   return null;

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -19,6 +19,7 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
   listTaskPlanningSnapshots: vi.fn(),
   readTaskAgentBinding: vi.fn(),
   readTaskPlanningSnapshot: vi.fn(),
+  requestTaskPlan: vi.fn(),
   submitTaskMessage: vi.fn(),
 }));
 
@@ -41,6 +42,7 @@ vi.mock('../domain/task-planning', () => ({
   listTaskPlanningSnapshots: planningMocks.listTaskPlanningSnapshots,
   readTaskAgentBinding: planningMocks.readTaskAgentBinding,
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
+  requestTaskPlan: planningMocks.requestTaskPlan,
   submitTaskMessage: planningMocks.submitTaskMessage,
 }));
 

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -7,6 +7,11 @@ import {
   type PlanningMocks,
   resetPlanningMocks,
   snapshot,
+  TEST_PLAN_STATUS,
+  TEST_TASK_LIFECYCLE,
+  TEST_TASK_STATUS,
+  TEST_THREAD_STATUS,
+  TEST_WORKFLOW_KIND,
 } from './task-api.test-utils';
 
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
@@ -22,17 +27,38 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
   requestTaskPlan: vi.fn(),
   submitTaskMessage: vi.fn(),
 }));
-
-vi.mock('../domain/task-planning', () => ({
-  TASK_EXECUTION_MODE: {
-    MANUAL: 'manual',
-    AUTONOMOUS: 'autonomous',
-  },
+const mockTaskConstants = vi.hoisted(() => ({
   TASK_AGENT_STAGE: {
     PLANNING: 'planning',
     IMPLEMENTATION: 'implementation',
     DELIVERY: 'delivery',
   },
+  TASK_EXECUTION_MODE: {
+    MANUAL: 'manual',
+    AUTONOMOUS: 'autonomous',
+  },
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
+    READY: 'ready',
+  },
+  TASK_STATUS: {
+    IMPLEMENTED: 'implemented',
+    PLANNING_APPROVED: 'planning_approved',
+  },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+  },
+  WORKFLOW_KIND: {
+    IMPLEMENTATION: 'implementation',
+    PLANNING: 'planning',
+  },
+}));
+
+vi.mock('../domain/task-planning', () => ({
+  TASK_AGENT_STAGE: mockTaskConstants.TASK_AGENT_STAGE,
+  TASK_EXECUTION_MODE: mockTaskConstants.TASK_EXECUTION_MODE,
+  TASK_LIFECYCLE: mockTaskConstants.TASK_LIFECYCLE,
+  WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
   closeTask: planningMocks.closeTask,
@@ -101,7 +127,10 @@ it('当 Task 方案已批准时，期望可以调度 implementation', async () =
   const scheduled: unknown[] = [];
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
-    data: approvedSnapshot('/tmp/project', 'planning_approved'),
+    data: approvedSnapshot(
+      '/tmp/project',
+      mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
+    ),
   });
 
   const response = await handleTaskApiRequest(
@@ -121,9 +150,13 @@ it('当实施步骤已产出但未确认时，期望拒绝直接调度编码', a
   const scheduled: unknown[] = [];
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
-    data: approvedSnapshot('/tmp/project', 'planning_approved', {
-      withSteps: true,
-    }),
+    data: approvedSnapshot(
+      '/tmp/project',
+      mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
+      {
+        withSteps: true,
+      },
+    ),
   });
 
   const response = await handleTaskApiRequest(
@@ -145,9 +178,13 @@ it('当实施步骤已产出且请求显式确认时，期望记录确认并调�
   const scheduled: unknown[] = [];
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
-    data: approvedSnapshot('/tmp/project', 'planning_approved', {
-      withSteps: true,
-    }),
+    data: approvedSnapshot(
+      '/tmp/project',
+      mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
+      {
+        withSteps: true,
+      },
+    ),
   });
 
   const response = await handleTaskApiRequest(
@@ -172,7 +209,10 @@ it('当 Task 已实现时，期望可以调度 delivery', async () => {
   const scheduled: unknown[] = [];
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
-    data: approvedSnapshot('/tmp/project', 'implemented'),
+    data: approvedSnapshot(
+      '/tmp/project',
+      mockTaskConstants.TASK_STATUS.IMPLEMENTED,
+    ),
   });
 
   const response = await handleTaskApiRequest(
@@ -216,6 +256,11 @@ function approvedSnapshot(
     task: {
       ...snapshot.task,
       status,
+      lifecycle: TEST_TASK_LIFECYCLE.READY,
+      currentWorkflowKind:
+        status === TEST_TASK_STATUS.IMPLEMENTED
+          ? TEST_WORKFLOW_KIND.IMPLEMENTATION
+          : TEST_WORKFLOW_KIND.PLANNING,
       cwd,
       repoOwner: 'ranwawa',
       repoName: 'along',
@@ -223,7 +268,7 @@ function approvedSnapshot(
     artifacts,
     thread: {
       ...snapshot.thread,
-      status: 'approved',
+      status: TEST_PLAN_STATUS.APPROVED,
       currentPlanId: 'plan-1',
       approvedPlanId: 'plan-1',
     },
@@ -232,7 +277,7 @@ function approvedSnapshot(
       taskId: 'task-1',
       threadId: 'thread-1',
       version: 1,
-      status: 'approved',
+      status: TEST_THREAD_STATUS.APPROVED,
       artifactId: 'art-plan',
       body: '## Plan',
       createdAt: '2026-01-01T00:00:01.000Z',
@@ -243,7 +288,7 @@ function approvedSnapshot(
         taskId: 'task-1',
         threadId: 'thread-1',
         version: 1,
-        status: 'approved',
+        status: TEST_PLAN_STATUS.APPROVED,
         artifactId: 'art-plan',
         body: '## Plan',
         createdAt: '2026-01-01T00:00:01.000Z',

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -2,6 +2,36 @@ import { expect, vi } from 'vitest';
 
 type PlanningMock = ReturnType<typeof vi.fn>;
 
+export const TEST_TASK_STATUS = {
+  PLANNING: 'planning',
+  IMPLEMENTED: 'implemented',
+  COMPLETED: 'completed',
+  CLOSED: 'closed',
+} as const;
+
+export const TEST_TASK_LIFECYCLE = {
+  OPEN: 'open',
+  READY: 'ready',
+} as const;
+
+export const TEST_WORKFLOW_KIND = {
+  IMPLEMENTATION: 'implementation',
+  PLANNING: 'planning',
+} as const;
+
+export const TEST_THREAD_PURPOSE = {
+  PLANNING: 'planning',
+} as const;
+
+export const TEST_THREAD_STATUS = {
+  DRAFTING: 'drafting',
+  APPROVED: 'approved',
+} as const;
+
+export const TEST_PLAN_STATUS = {
+  APPROVED: 'approved',
+} as const;
+
 export type PlanningMocks = {
   approveTaskImplementationSteps: PlanningMock;
   approveCurrentTaskPlan: PlanningMock;
@@ -22,7 +52,9 @@ export const snapshot = {
     title: '实现 Task API',
     body: '通过 Web API 创建 planning task。',
     source: 'web',
-    status: 'planning',
+    status: TEST_TASK_STATUS.PLANNING,
+    lifecycle: TEST_TASK_LIFECYCLE.OPEN,
+    currentWorkflowKind: TEST_WORKFLOW_KIND.PLANNING,
     activeThreadId: 'thread-1',
     commitShas: [],
     executionMode: 'manual',
@@ -32,8 +64,8 @@ export const snapshot = {
   thread: {
     threadId: 'thread-1',
     taskId: 'task-1',
-    purpose: 'planning',
-    status: 'drafting',
+    purpose: TEST_THREAD_PURPOSE.PLANNING,
+    status: TEST_THREAD_STATUS.DRAFTING,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
   },
@@ -124,7 +156,7 @@ function mockPlanApproval(planningMocks: PlanningMocks) {
       taskId: 'task-1',
       threadId: 'thread-1',
       version: 1,
-      status: 'approved',
+      status: TEST_THREAD_STATUS.APPROVED,
       artifactId: 'art-plan',
       body: '## Plan',
       createdAt: '2026-01-01T00:00:01.000Z',
@@ -137,7 +169,7 @@ function mockTaskClose(planningMocks: PlanningMocks) {
     success: true,
     data: {
       ...snapshot,
-      task: { ...snapshot.task, status: 'closed' },
+      task: { ...snapshot.task, status: TEST_TASK_STATUS.CLOSED },
     },
   });
 }
@@ -147,7 +179,7 @@ function mockManualComplete(planningMocks: PlanningMocks) {
     success: true,
     data: {
       ...snapshot,
-      task: { ...snapshot.task, status: 'implemented' },
+      task: { ...snapshot.task, status: TEST_TASK_STATUS.IMPLEMENTED },
     },
   });
 }
@@ -157,7 +189,7 @@ function mockDeliveredComplete(planningMocks: PlanningMocks) {
     success: true,
     data: {
       ...snapshot,
-      task: { ...snapshot.task, status: 'completed' },
+      task: { ...snapshot.task, status: TEST_TASK_STATUS.COMPLETED },
     },
   });
 }

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -12,6 +12,7 @@ export type PlanningMocks = {
   listTaskPlanningSnapshots: PlanningMock;
   readTaskAgentBinding: PlanningMock;
   readTaskPlanningSnapshot: PlanningMock;
+  requestTaskPlan: PlanningMock;
   submitTaskMessage: PlanningMock;
 };
 
@@ -89,6 +90,10 @@ function mockTaskReads(planningMocks: PlanningMocks) {
   planningMocks.readTaskAgentBinding.mockReturnValue({
     success: true,
     data: null,
+  });
+  planningMocks.requestTaskPlan.mockReturnValue({
+    success: true,
+    data: undefined,
   });
 }
 

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -18,6 +18,7 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
   listTaskPlanningSnapshots: vi.fn(),
   readTaskAgentBinding: vi.fn(),
   readTaskPlanningSnapshot: vi.fn(),
+  requestTaskPlan: vi.fn(),
   submitTaskMessage: vi.fn(),
 }));
 
@@ -40,6 +41,7 @@ vi.mock('../domain/task-planning', () => ({
   listTaskPlanningSnapshots: planningMocks.listTaskPlanningSnapshots,
   readTaskAgentBinding: planningMocks.readTaskAgentBinding,
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
+  requestTaskPlan: planningMocks.requestTaskPlan,
   submitTaskMessage: planningMocks.submitTaskMessage,
 }));
 

--- a/packages/along/src/integration/task-autonomous-continuation.test.ts
+++ b/packages/along/src/integration/task-autonomous-continuation.test.ts
@@ -9,8 +9,7 @@ const planningMocks = vi.hoisted(() => ({
   approveCurrentTaskPlan: vi.fn(),
   readTaskPlanningSnapshot: vi.fn(),
 }));
-
-vi.mock('../domain/task-planning', () => ({
+const mockTaskConstants = vi.hoisted(() => ({
   PLAN_STATUS: {
     ACTIVE: 'active',
     APPROVED: 'approved',
@@ -19,10 +18,34 @@ vi.mock('../domain/task-planning', () => ({
     MANUAL: 'manual',
     AUTONOMOUS: 'autonomous',
   },
-  TASK_STATUS: {
-    PLANNING_APPROVED: 'planning_approved',
-    IMPLEMENTED: 'implemented',
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
+    OPEN: 'open',
+    READY: 'ready',
   },
+  TASK_STATUS: {
+    IMPLEMENTED: 'implemented',
+    PLANNING: 'planning',
+    PLANNING_APPROVED: 'planning_approved',
+  },
+  THREAD_PURPOSE: {
+    PLANNING: 'planning',
+  },
+  THREAD_STATUS: {
+    APPROVED: 'approved',
+    AWAITING_APPROVAL: 'awaiting_approval',
+  },
+  WORKFLOW_KIND: {
+    PLANNING: 'planning',
+    IMPLEMENTATION: 'implementation',
+  },
+}));
+
+vi.mock('../domain/task-planning', () => ({
+  PLAN_STATUS: mockTaskConstants.PLAN_STATUS,
+  TASK_EXECUTION_MODE: mockTaskConstants.TASK_EXECUTION_MODE,
+  TASK_LIFECYCLE: mockTaskConstants.TASK_LIFECYCLE,
+  WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
   readTaskPlanningSnapshot: planningMocks.readTaskPlanningSnapshot,
@@ -100,9 +123,13 @@ it('implementation 仅产出步骤时自动确认并二次调度', () => {
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
     data: makeSnapshot({
-      task: { status: 'planning_approved' },
+      task: {
+        status: mockTaskConstants.TASK_STATUS.PLANNING_APPROVED,
+        lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+        currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.PLANNING,
+      },
       thread: { approvedPlanId: 'plan-1' },
-      currentPlan: { status: 'approved' },
+      currentPlan: { status: mockTaskConstants.PLAN_STATUS.APPROVED },
       plans: [plan],
       artifacts: [steps],
     }),
@@ -131,7 +158,12 @@ it('implementation 完成且有 commit 后自动调度 delivery', () => {
   planningMocks.readTaskPlanningSnapshot.mockReturnValue({
     success: true,
     data: makeSnapshot({
-      task: { status: 'implemented', commitShas: ['abc123'] },
+      task: {
+        status: mockTaskConstants.TASK_STATUS.IMPLEMENTED,
+        lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+        currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
+        commitShas: ['abc123'],
+      },
     }),
   });
 
@@ -153,7 +185,9 @@ it('已有 prUrl 时不重复调度 delivery', () => {
     success: true,
     data: makeSnapshot({
       task: {
-        status: 'implemented',
+        status: mockTaskConstants.TASK_STATUS.IMPLEMENTED,
+        lifecycle: mockTaskConstants.TASK_LIFECYCLE.READY,
+        currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.IMPLEMENTATION,
         commitShas: ['abc123'],
         prUrl: 'https://github.com/ranwawa/along/pull/1',
       },
@@ -175,7 +209,7 @@ const plan = {
   taskId: 'task-1',
   threadId: 'thread-1',
   version: 1,
-  status: 'approved',
+  status: mockTaskConstants.PLAN_STATUS.APPROVED,
   artifactId: 'art-plan',
   body: 'Plan',
   createdAt: '2026-01-01T00:00:01.000Z',
@@ -226,10 +260,12 @@ function makeSnapshot(
       title: 'Task',
       body: 'Body',
       source: 'web',
-      status: 'planning',
+      status: mockTaskConstants.TASK_STATUS.PLANNING,
+      lifecycle: mockTaskConstants.TASK_LIFECYCLE.OPEN,
+      currentWorkflowKind: mockTaskConstants.WORKFLOW_KIND.PLANNING,
       activeThreadId: 'thread-1',
       commitShas: [],
-      executionMode: 'autonomous',
+      executionMode: mockTaskConstants.TASK_EXECUTION_MODE.AUTONOMOUS,
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
       ...overrides.task,
@@ -237,8 +273,8 @@ function makeSnapshot(
     thread: {
       threadId: 'thread-1',
       taskId: 'task-1',
-      purpose: 'planning',
-      status: 'awaiting_approval',
+      purpose: mockTaskConstants.THREAD_PURPOSE.PLANNING,
+      status: mockTaskConstants.THREAD_STATUS.AWAITING_APPROVAL,
       currentPlanId: 'plan-1',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
@@ -249,12 +285,14 @@ function makeSnapshot(
         ? null
         : {
             ...plan,
-            status: 'active',
+            status: mockTaskConstants.PLAN_STATUS.ACTIVE,
             ...overrides.currentPlan,
           },
     openRound: overrides.openRound ?? null,
     artifacts: overrides.artifacts || [],
-    plans: overrides.plans || [{ ...plan, status: 'active' }],
+    plans: overrides.plans || [
+      { ...plan, status: mockTaskConstants.PLAN_STATUS.ACTIVE },
+    ],
     agentRuns: [],
     agentProgressEvents: [],
     agentSessionEvents: [],

--- a/packages/along/src/integration/task-autonomous-continuation.ts
+++ b/packages/along/src/integration/task-autonomous-continuation.ts
@@ -10,8 +10,9 @@ import {
   PLAN_STATUS,
   readTaskPlanningSnapshot,
   TASK_EXECUTION_MODE,
-  TASK_STATUS,
+  TASK_LIFECYCLE,
   type TaskPlanningSnapshot,
+  WORKFLOW_KIND,
 } from '../domain/task-planning';
 import type {
   ScheduledTaskDeliveryRun,
@@ -50,6 +51,10 @@ function hasApprovedThread(snapshot: TaskPlanningSnapshot): boolean {
   return Boolean(snapshot.thread.approvedPlanId);
 }
 
+function isClosed(snapshot: TaskPlanningSnapshot): boolean {
+  return snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED;
+}
+
 export function continueAutonomousTaskAfterPlanning(
   input: TaskAutonomousContinuationInput & { plannerAction: string },
 ): Result<AutonomousContinuationAction> {
@@ -58,7 +63,7 @@ export function continueAutonomousTaskAfterPlanning(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
-  if (snapshot.task.status === TASK_STATUS.CLOSED) return success('skipped');
+  if (isClosed(snapshot)) return success('skipped');
   if (!isAutonomous(snapshot)) return success('skipped');
   if (
     !snapshot.currentPlan ||
@@ -88,13 +93,16 @@ export function continueAutonomousTaskAfterImplementation(
   const snapshotRes = readRequiredSnapshot(input.taskId);
   if (!snapshotRes.success) return snapshotRes;
   const snapshot = snapshotRes.data;
-  if (snapshot.task.status === TASK_STATUS.CLOSED) return success('skipped');
+  if (isClosed(snapshot)) return success('skipped');
   if (!isAutonomous(snapshot)) return success('skipped');
 
-  if (snapshot.task.status === TASK_STATUS.PLANNING_APPROVED) {
+  if (snapshot.task.currentWorkflowKind === WORKFLOW_KIND.PLANNING) {
     return continueAfterImplementationSteps(input, snapshot);
   }
-  if (snapshot.task.status === TASK_STATUS.IMPLEMENTED) {
+  if (
+    snapshot.task.currentWorkflowKind === WORKFLOW_KIND.IMPLEMENTATION &&
+    snapshot.task.lifecycle === TASK_LIFECYCLE.READY
+  ) {
     return continueAfterImplemented(input, snapshot);
   }
   return success('skipped');


### PR DESCRIPTION
along-task: #19

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskFlowStageCard.tsx`
- `packages/along-web/src/task-planning/TaskStatusBadge.tsx`
- `packages/along-web/src/task-planning/displayFormat.ts`
- `packages/along-web/src/task-planning/flowActionRouter.ts`
- `packages/along-web/src/task-planning/flowFormat.ts`
- `packages/along-web/src/task-planning/format.ts`
- `packages/along-web/src/types-flow.ts`
- `packages/along-web/src/types-task.ts`
- `packages/along-web/src/types-workflow.ts`
- `packages/along/src/agents/task-planning.ts`
- `packages/along/src/core/db-schema.ts`
- `packages/along/src/domain/task-auto-commit.test.ts`
- `packages/along/src/domain/task-auto-commit.ts`
- `packages/along/src/domain/task-delivery.test.ts`
- `packages/along/src/domain/task-delivery.ts`
- `packages/along/src/domain/task-display-state.ts`
- `packages/along/src/domain/task-implementation-agent.test.ts`
- `packages/along/src/domain/task-implementation-agent.ts`
- `packages/along/src/domain/task-implementation-auto-commit-loop.ts`
- `packages/along/src/domain/task-planning-agent.test.ts`
- `packages/along/src/domain/task-planning-agent.ts`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/domain/task-workflow-state.test.ts`
- `packages/along/src/domain/task-workflow-state.ts`
- `packages/along/src/domain/task-worktree.test.ts`
- `packages/along/src/domain/task-worktree.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api-scheduling.test.ts`
- `packages/along/src/integration/task-api.test-utils.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-autonomous-continuation.test.ts`
- `packages/along/src/integration/task-autonomous-continuation.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `fix/task-19`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment

反馈成立。上一版把 ask、planning、implementation、verification 全部摊平成一个“大而全”的任务状态机，虽然表达完整，但复杂度偏高，后续实现和维护都会吃力。更合理的架构不是继续扩展单一状态机，而是把状态拆成分层模型：Task 只负责统一生命周期，Workflow 负责当前业务流程，Blocking/Display 作为派生视图。

核心结论：不要用一个巨型 task.status 表达所有业务细节；改为“任务生命周期 + 当前工作流 + 工作流内部状态 + 派生展示状态”的组合架构。状态仍然只能由事件触发，但每个状态机都保持小而清晰。

Summary

修订为分层状态架构：

1. Task Lifecycle：所有任务共用的粗粒度生命周期，只回答“这个任务整体处于什么阶段”。
2. Workflow：任务当前正在走哪类业务流程，包括 ask、planning、implementation。
3. Workflow State：每类 workflow 自己维护小状态机，例如 ask 只有 active/waiting_user/answered，planning 只有 drafting/waiting_user/awaiting_approval/feedback/planned。
4. Display State：左侧列表和右侧节点只消费派生结果，不直接读取底层字段拼文案。

这样可以避免状态爆炸：纯咨询不会进入 planning；planning 不需要知道 ask 的全部细节；implementation 不会污染计划审批状态。

架构图

```mermaid
flowchart TD
    E[Domain Event] --> R[Workflow Event Reducer]
    R --> T[Task Lifecycle]
    R --> W[Current Workflow]
    W --> A[Ask Workflow]
    W --> P[Planning Workflow]
    W --> I[Implementation Workflow]
    T --> D[Display Adapter]
    W --> D
    A --> D
    P --> D
    I --> D
    D --> L[Left Task List]
    D --> S[Right Status Panel]
```

状态模型

Task Lifecycle 只保留少量稳定状态：

- open：任务已创建，仍在处理中。
- waiting_user：当前 workflow 需要用户补充信息或做决定。
- ready：当前 workflow 已完成，等待下一步动作。
- running：实现或验证等系统执行中。
- completed：任务完成。
- cancelled：任务取消。
- failed：任务失败且需要重试或人工处理。

Workflow Kind：

- ask：纯咨询、解释、探索、代码阅读、方案讨论但暂不要求落地修改。
- planning：需要形成正式计划、审批计划或处理计划反馈。
- implementation：已批准计划进入实现和验证。

Ask Workflow 状态：

```mermaid
stateDiagram-v2
    [*] --> active: ask.started
    active --> waiting_user: ask.needs_user_input
    waiting_user --> active: user.message.received
    active --> answered: ask.answer.completed
    answered --> active: user.continues_ask
    answered --> [*]: task.closed
```

Planning Workflow 状态：

```mermaid
stateDiagram-v2
    [*] --> drafting: plan.requested
    drafting --> waiting_user: plan.needs_user_input
    waiting_user --> drafting: user.message.received
    drafting --> awaiting_approval: plan.revision.created
    awaiting_approval --> feedback: feedback.round.opened
    feedback --> drafting: plan.revision.requested
    awaiting_approval --> planned: plan.approved
    planned --> [*]: implementation.requested
```

Implementation Workflow 状态：

```mermaid
stateDiagram-v2
    [*] --> implementing: implementation.started
    implementing --> waiting_user: implementation.needs_user_input
    waiting_user --> implementing: user.message.received
    implementing --> verifying: implementation.completed
    verifying --> implementing: verification.failed
    verifying --> completed: verification.passed
    implementing --> failed: implementation.failed
    failed --> implementing: implementation.retry_requested
```

关键转换规则

- 纯咨询任务创建时：task.lifecycle=open，workflow.kind=ask，ask.state=active。
- 用户要求制定计划时：触发 plan.requested，currentWorkflow 切到 planning，planning.state=drafting。
- plan.revision.created 后进入 awaiting_approval，右侧才显示批准计划。
- plan.approved 后 planning.state=planned，task.lifecycle=ready，可开始 implementation。
- implementation.started 后 currentWorkflow 切到 implementation，task.lifecycle=running。
- user.message.received 本身不直接改变状态，只作为输入事件，必须由 reducer 判定后触发 ask.needs_user_input、plan.revision.requested 等业务事件。
- completed、cancelled 默认是终态；如未来需要重开，必须新增 task.reopened 事件，不允许直接改状态。

Implementation Changes

1. 新增统一领域状态层：定义 TaskLifecycle、WorkflowKind、AskWorkflowState、PlanningWorkflowState、ImplementationWorkflowState、DomainEvent 和合法转换表。

2. 用 Workflow Reducer 处理所有状态改变：任何 task、thread、plan、round 的状态变更都必须由事件进入 reducer 后产生，UI、Agent 结果写入、普通 service 不允许直接写状态。

3. 调整任务创建入口：首轮意图无法确定时默认 ask；只有用户明确要求修复、实现、生成计划、进入审批时才创建 planning workflow。

4. 调整 Agent 产物契约：ask 回答只更新 ask workflow，不创建 plan/round/approval；plan_revision 只在 planning workflow 内有效；implementation 只能从 approved/planned 后启动。

5. 调整右侧状态面板：根据 currentWorkflow.kind 渲染对应小流程。ask 不显示批准计划；planning 不显示实现验证；implementation 不显示计划草拟节点。

6. 调整左侧任务列表：通过 Display Adapter 派生展示文案，例如咨询中、待补充、已回答、规划中、待批准、计划反馈中、已规划、实现中、验证中、已完成、失败、已取消。组件不得自行拼接或判断业务状态。

Contracts / Interfaces

建议领域契约如下，具体命名遵循现有代码风格：

- task.lifecycle: open | waiting_user | ready | running | completed | cancelled | failed
- task.currentWorkflowKind: ask | planning | implementation
- askWorkflow.state: active | waiting_user | answered
- planningWorkflow.state: drafting | waiting_user | awaiting_approval | feedback | planned
- implementationWorkflow.state: implementing | waiting_user | verifying | completed | failed
- display.state/display.label：由 Display Adapter 从 lifecycle + currentWorkflowKind + workflow.state 派生。

显示派生规则：

- ask.active => 咨询中
- ask.waiting_user => 待补充
- ask.answered => 已回答
- planning.drafting => 规划中
- planning.waiting_user => 待补充
- planning.awaiting_approval => 待批准
- planning.feedback => 计划反馈中
- planning.planned => 已规划
- implementation.implementing => 实现中
- implementation.waiting_user => 待补充
- implementation.verifying => 验证中
- implementation.completed + task.completed => 已完成
- task.cancelled => 已取消
- task.failed 或 implementation.failed => 失败

Failure Handling

- 非法事件转换必须拒绝落库，并保留上一稳定状态。
- Agent 产物写入成功但状态事件处理失败时，不得半更新状态；应记录错误并允许重试事件处理。
- 历史任务缺少 workflowKind 时按关联对象推断：有 implementation 记录归为 implementation；有 plan 或 openRound 归为 planning；否则归为 ask。
- UI 收到未知组合时显示“处理中”，但不得渲染与 workflowKind 冲突的按钮或节点。

Test Plan

1. 单元测试覆盖三个小状态机的合法转换和非法转换。
2. 单元测试覆盖 user.message.received 不直接改变状态。
3. 单元测试覆盖 ask 转 planning、planning 转 implementation 的跨 workflow 事件。
4. 组件测试覆盖 ask 不显示批准计划，planning 未批准不显示实现节点，implementation 不显示计划草拟节点。
5. 左侧列表测试覆盖所有 display label 派生。
6. 历史数据测试覆盖无 workflowKind 的任务推断策略。

Assumptions

- 产品接受将纯咨询作为一等 workflow，而不是 planning 的子状态。
- 可以调整现有不合理状态字段，不以旧 task.status=planning 为兼容目标。
- 本次优先建立分层状态架构和展示契约，具体字段名可按现有代码风格落地。

## 交付信息
- Commit: ac62ab9ce316cd2bca8f037446e577f660322476