### PR TITLE
Task #24: web along左侧交互任务

### DIFF
--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -1,6 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import type { TaskPlanningSnapshot } from '../types';
+import {
+  TASK_LEGACY_STATUS_COLORS,
+  TASK_STATUS_COLOR_STYLES,
+} from './statusStyles';
 import { TaskListPanel } from './TaskSidebar';
 
 function makeTask(
@@ -101,7 +105,9 @@ describe('TaskListPanel', () => {
 
     expect(html).toContain('#12');
     expect(html).toContain('优化左侧任务列表展示');
-    expect(html).toContain('实现中');
+    expect(html).toContain('aria-label="实现中"');
+    expect(html).toContain('title="实现中"');
+    expect(html).not.toContain('>实现中<');
     expect(html).not.toContain('custom-updated-at');
     expect(html).not.toContain('这段任务正文不应该出现在左侧列表');
     expect(html).not.toContain('命令退出码 1');
@@ -113,8 +119,55 @@ describe('TaskListPanel', () => {
       tasks: [makeSnapshot({ task: makeTask({ status: 'closed' }) })],
     });
 
-    expect(html).toContain('已关闭');
-    expect(html).toContain('zinc');
+    expect(html).toContain('aria-label="已关闭"');
+    expect(html).not.toContain('>已关闭<');
+    expect(html).toContain(
+      TASK_STATUS_COLOR_STYLES[TASK_LEGACY_STATUS_COLORS.closed].dotClass,
+    );
+  });
+
+  it('优先使用 display 状态文案和颜色点', () => {
+    const html = renderPanel({
+      tasks: [
+        makeSnapshot({
+          display: {
+            state: 'waiting_user',
+            label: '待用户补充',
+          },
+        }),
+      ],
+    });
+
+    expect(html).toContain('aria-label="待用户补充"');
+    expect(html).toContain('title="待用户补充"');
+    expect(html).not.toContain('>待用户补充<');
+    expect(html).toContain(TASK_STATUS_COLOR_STYLES.amber.dotClass);
+  });
+
+  it('agentStages 存在运行阶段时显示运行动画', () => {
+    const html = renderPanel({
+      tasks: [
+        makeSnapshot({
+          agentStages: [
+            {
+              stage: 'implementation',
+              agentId: 'implementer',
+              label: '实现',
+              status: 'running',
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(html).toContain('after:animate-ping');
+    expect(html).toContain('motion-reduce:after:animate-none');
+  });
+
+  it('agentStages 非运行阶段时不显示运行动画', () => {
+    const html = renderPanel();
+
+    expect(html).not.toContain('after:animate-ping');
   });
 
   it('序号缺失时不补造占位内容', () => {

--- a/packages/along-web/src/task-planning/TaskStatusBadge.tsx
+++ b/packages/along-web/src/task-planning/TaskStatusBadge.tsx
@@ -1,21 +1,38 @@
 import type { TaskPlanningSnapshot } from '../types';
-import { getTaskDisplayClass } from './displayFormat';
-import { getTaskStatusClass, getTaskStatusLabel } from './format';
+import { getTaskStatusLabel } from './format';
+import {
+  getTaskDisplayStatusStyle,
+  getTaskLegacyStatusStyle,
+} from './statusStyles';
+
+const TASK_STATUS_DOT_BASE_CLASS =
+  'relative inline-flex h-2.5 w-2.5 shrink-0 rounded-full ring-2';
+
+const TASK_STATUS_DOT_RUNNING_CLASS =
+  "after:absolute after:inset-0 after:rounded-full after:bg-current after:content-[''] after:animate-ping after:opacity-60 motion-reduce:after:animate-none motion-reduce:after:opacity-30";
 
 export function TaskStatusBadge({
   snapshot,
 }: {
   snapshot: TaskPlanningSnapshot;
 }) {
+  const label =
+    snapshot.display?.label || getTaskStatusLabel(snapshot.task.status);
+  const style = snapshot.display
+    ? getTaskDisplayStatusStyle(snapshot.display.state)
+    : getTaskLegacyStatusStyle(snapshot.task.status);
+  const isAgentRunning = snapshot.agentStages.some(
+    (stage) => stage.status === 'running',
+  );
+
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${
-        snapshot.display
-          ? getTaskDisplayClass(snapshot.display.state)
-          : getTaskStatusClass(snapshot.task.status)
+      aria-label={label}
+      className={`${TASK_STATUS_DOT_BASE_CLASS} ${style.dotClass} ${
+        isAgentRunning ? TASK_STATUS_DOT_RUNNING_CLASS : ''
       }`}
-    >
-      {snapshot.display?.label || getTaskStatusLabel(snapshot.task.status)}
-    </span>
+      role="img"
+      title={label}
+    />
   );
 }

--- a/packages/along-web/src/task-planning/displayFormat.ts
+++ b/packages/along-web/src/task-planning/displayFormat.ts
@@ -1,30 +1,6 @@
 import type { TaskDisplayState } from '../types';
+import { getTaskDisplayStatusStyle } from './statusStyles';
 
 export function getTaskDisplayClass(state: TaskDisplayState): string {
-  switch (state) {
-    case 'ask_active':
-      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
-    case 'ask_answered':
-      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
-    case 'waiting_user':
-    case 'planning_awaiting_approval':
-      return 'bg-amber-500/15 text-amber-300 border-amber-500/30';
-    case 'planning_drafting':
-      return 'bg-sky-500/15 text-sky-300 border-sky-500/30';
-    case 'planning_feedback':
-    case 'implementation_verifying':
-      return 'bg-violet-500/15 text-violet-300 border-violet-500/30';
-    case 'planning_planned':
-      return 'bg-blue-500/15 text-blue-300 border-blue-500/30';
-    case 'implementation_implementing':
-      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
-    case 'completed':
-      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
-    case 'failed':
-      return 'bg-rose-500/15 text-rose-300 border-rose-500/30';
-    case 'cancelled':
-      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
-    default:
-      return 'bg-white/10 text-text-secondary border-border-color';
-  }
+  return getTaskDisplayStatusStyle(state).badgeClass;
 }

--- a/packages/along-web/src/task-planning/format.ts
+++ b/packages/along-web/src/task-planning/format.ts
@@ -8,6 +8,14 @@ import type {
   TaskStatus,
   TaskThreadStatus,
 } from '../types';
+import {
+  getTaskAgentStageStatusStyle,
+  getTaskLegacyStatusStyle,
+} from './statusStyles';
+
+const MIN_DURATION_SECONDS = 1;
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
 
 export function formatTime(value: string): string {
   const date = new Date(value);
@@ -26,9 +34,12 @@ export function formatDuration(startedAt: string, endedAt?: string): string {
   if (Number.isNaN(started) || Number.isNaN(ended) || ended < started) {
     return '-';
   }
-  const totalSeconds = Math.max(1, Math.round((ended - started) / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
+  const totalSeconds = Math.max(
+    MIN_DURATION_SECONDS,
+    Math.round((ended - started) / MILLISECONDS_PER_SECOND),
+  );
+  const minutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
+  const seconds = totalSeconds % SECONDS_PER_MINUTE;
   if (minutes === 0) return `${seconds}s`;
   return `${minutes}m ${seconds}s`;
 }
@@ -88,26 +99,7 @@ export function getTaskStatusLabel(status: TaskStatus): string {
 }
 
 export function getTaskStatusClass(status: TaskStatus): string {
-  switch (status) {
-    case 'planning':
-      return 'bg-sky-500/15 text-sky-300 border-sky-500/30';
-    case 'planning_approved':
-      return 'bg-amber-500/15 text-amber-300 border-amber-500/30';
-    case 'implementing':
-      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
-    case 'implemented':
-      return 'bg-blue-500/15 text-blue-300 border-blue-500/30';
-    case 'delivering':
-      return 'bg-violet-500/15 text-violet-300 border-violet-500/30';
-    case 'delivered':
-      return 'bg-teal-500/15 text-teal-300 border-teal-500/30';
-    case 'completed':
-      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
-    case 'closed':
-      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
-    default:
-      return 'bg-white/10 text-text-secondary border-border-color';
-  }
+  return getTaskLegacyStatusStyle(status).badgeClass;
 }
 
 export function getStageStatusLabel(status: TaskAgentStageStatus): string {
@@ -128,18 +120,7 @@ export function getStageStatusLabel(status: TaskAgentStageStatus): string {
 }
 
 export function getStageStatusClass(status: TaskAgentStageStatus): string {
-  switch (status) {
-    case 'running':
-      return 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30';
-    case 'succeeded':
-      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
-    case 'failed':
-      return 'bg-rose-500/15 text-rose-300 border-rose-500/30';
-    case 'cancelled':
-      return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
-    default:
-      return 'bg-white/5 text-text-muted border-border-color';
-  }
+  return getTaskAgentStageStatusStyle(status).badgeClass;
 }
 
 export function getProgressPhaseLabel(phase: TaskAgentProgressPhase): string {

--- a/packages/along-web/src/task-planning/statusStyles.ts
+++ b/packages/along-web/src/task-planning/statusStyles.ts
@@ -1,0 +1,122 @@
+import type {
+  TaskAgentStageStatus,
+  TaskDisplayState,
+  TaskStatus,
+} from '../types';
+
+export const TASK_STATUS_COLOR_STYLES = {
+  cyan: {
+    badgeClass: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30',
+    dotClass:
+      'bg-current text-cyan-400 ring-cyan-400/35 shadow-[0_0_10px_rgba(34,211,238,0.45)]',
+  },
+  emerald: {
+    badgeClass: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+    dotClass:
+      'bg-current text-emerald-400 ring-emerald-400/35 shadow-[0_0_10px_rgba(52,211,153,0.45)]',
+  },
+  amber: {
+    badgeClass: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+    dotClass:
+      'bg-current text-amber-400 ring-amber-400/35 shadow-[0_0_10px_rgba(251,191,36,0.45)]',
+  },
+  sky: {
+    badgeClass: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+    dotClass:
+      'bg-current text-sky-400 ring-sky-400/35 shadow-[0_0_10px_rgba(56,189,248,0.45)]',
+  },
+  violet: {
+    badgeClass: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
+    dotClass:
+      'bg-current text-violet-400 ring-violet-400/35 shadow-[0_0_10px_rgba(167,139,250,0.45)]',
+  },
+  blue: {
+    badgeClass: 'bg-blue-500/15 text-blue-300 border-blue-500/30',
+    dotClass:
+      'bg-current text-blue-400 ring-blue-400/35 shadow-[0_0_10px_rgba(96,165,250,0.45)]',
+  },
+  rose: {
+    badgeClass: 'bg-rose-500/15 text-rose-300 border-rose-500/30',
+    dotClass:
+      'bg-current text-rose-400 ring-rose-400/35 shadow-[0_0_10px_rgba(251,113,133,0.45)]',
+  },
+  zinc: {
+    badgeClass: 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30',
+    dotClass:
+      'bg-current text-zinc-400 ring-zinc-400/35 shadow-[0_0_10px_rgba(161,161,170,0.35)]',
+  },
+  teal: {
+    badgeClass: 'bg-teal-500/15 text-teal-300 border-teal-500/30',
+    dotClass:
+      'bg-current text-teal-400 ring-teal-400/35 shadow-[0_0_10px_rgba(45,212,191,0.45)]',
+  },
+  neutral: {
+    badgeClass: 'bg-white/10 text-text-secondary border-border-color',
+    dotClass:
+      'bg-current text-text-muted ring-border-color shadow-[0_0_8px_rgba(255,255,255,0.18)]',
+  },
+  muted: {
+    badgeClass: 'bg-white/5 text-text-muted border-border-color',
+    dotClass:
+      'bg-current text-text-muted ring-border-color shadow-[0_0_8px_rgba(255,255,255,0.14)]',
+  },
+} as const;
+
+export type TaskStatusColor = keyof typeof TASK_STATUS_COLOR_STYLES;
+
+export const TASK_DISPLAY_STATE_COLORS: Record<
+  TaskDisplayState,
+  TaskStatusColor
+> = {
+  ask_active: 'cyan',
+  ask_answered: 'emerald',
+  waiting_user: 'amber',
+  planning_drafting: 'sky',
+  planning_awaiting_approval: 'amber',
+  planning_feedback: 'violet',
+  planning_planned: 'blue',
+  implementation_implementing: 'cyan',
+  implementation_verifying: 'violet',
+  completed: 'emerald',
+  failed: 'rose',
+  cancelled: 'zinc',
+  processing: 'cyan',
+};
+
+export const TASK_LEGACY_STATUS_COLORS: Record<TaskStatus, TaskStatusColor> = {
+  planning: 'sky',
+  planning_approved: 'amber',
+  implementing: 'cyan',
+  implemented: 'blue',
+  delivering: 'violet',
+  delivered: 'teal',
+  completed: 'emerald',
+  closed: 'zinc',
+};
+
+export const TASK_AGENT_STAGE_STATUS_COLORS: Record<
+  TaskAgentStageStatus,
+  TaskStatusColor
+> = {
+  idle: 'muted',
+  running: 'cyan',
+  succeeded: 'emerald',
+  failed: 'rose',
+  cancelled: 'zinc',
+};
+
+export function getTaskStatusColorStyle(color: TaskStatusColor) {
+  return TASK_STATUS_COLOR_STYLES[color];
+}
+
+export function getTaskDisplayStatusStyle(state: TaskDisplayState) {
+  return getTaskStatusColorStyle(TASK_DISPLAY_STATE_COLORS[state]);
+}
+
+export function getTaskLegacyStatusStyle(status: TaskStatus) {
+  return getTaskStatusColorStyle(TASK_LEGACY_STATUS_COLORS[status]);
+}
+
+export function getTaskAgentStageStatusStyle(status: TaskAgentStageStatus) {
+  return getTaskStatusColorStyle(TASK_AGENT_STAGE_STATUS_COLORS[status]);
+}


### PR DESCRIPTION
along-task: #24

## 修改内容
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/TaskStatusBadge.tsx`
- `packages/along-web/src/task-planning/displayFormat.ts`
- `packages/along-web/src/task-planning/format.ts`
- `packages/along-web/src/task-planning/statusStyles.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/web-along-24`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立且值得实施。左侧任务列表中的状态是信息提示，不应以文字按钮呈现；改成颜色点可以降低交互误导。状态颜色抽象为常量可以保证同一状态在不同展示位置颜色一致，减少后续维护成本。运行态动画只使用 agentStages 判断，不再做 display.state 或 agentRuns 兜底，语义更贴近“当前 agent 阶段是否正在运行”。

Summary
将 web 端左侧任务列表的 TaskStatusBadge 从文字徽标改为固定尺寸颜色点，并通过 tooltip / aria-label 提供状态说明。颜色映射统一抽象为状态样式常量，所有相关状态展示从同一份映射读取。运行中动画以 snapshot.agentStages.some(stage.status === 'running') 为唯一判定来源。

Implementation Changes
1. 调整 packages/along-web/src/task-planning/TaskStatusBadge.tsx：保留组件入口，但渲染结果改为颜色点，不再显示状态文字；title 和 aria-label 使用 snapshot.display.label，缺失时使用既有 task.status label。
2. 新增或改造状态样式映射模块：把 display.state 与旧 task.status 的颜色抽象为常量，避免颜色散落在 switch 中；同一状态在 TaskStatusBadge 以及其他相关状态展示中复用同一颜色定义。
3. 运行态判断：TaskStatusBadge 内基于 snapshot.agentStages 判断是否存在 status = running；存在时为颜色点增加轻量运行动画。动画只表示 agent 阶段运行中，不把 ask_active、planning_drafting 等展示状态直接视为运行中。
4. 动画表现：使用不改变布局尺寸的脉冲或环形扩散效果，颜色沿用当前状态点颜色；在 prefers-reduced-motion: reduce 下禁用或弱化动画，避免可访问性问题。
5. 左侧列表集成：TaskSidebar 继续使用 TaskStatusBadge，不再额外承担状态判断；列表项布局保持稳定，状态点固定尺寸，避免标题挤压或行高跳动。

Contracts / Interfaces
TaskPlanningSnapshot 结构不变，不调整后端 API。前端使用 snapshot.display.state / snapshot.display.label 决定状态颜色与 tooltip，使用 snapshot.agentStages[].status === 'running' 决定运行动画。agentStages 是后端快照中的阶段聚合字段，来源于 task_agent_runs 与 task_agent_bindings 的派生结果，本次只消费现有字段。

Test Plan
1. 更新 TaskStatusBadge 或 TaskSidebar 相关测试，覆盖状态文字不再直接渲染、tooltip/aria-label 仍包含状态说明。
2. 增加运行态用例：当 agentStages 任一阶段为 running 时状态点带动画类；所有阶段非 running 时不带动画类。
3. 覆盖不同 display.state / task.status 的颜色映射，确保同一状态始终使用同一常量。
4. 执行 along-web 相关单测与类型检查；如仓库已有 lint/quality 脚本，执行对应前端质量检查。

Assumptions
仅调整 web 左侧任务列表及共享状态样式，不修改后端快照结构。状态点不显示文字，状态说明只通过 tooltip 和 aria-label 提供。运行态动画只认 agentStages，不使用 agentRuns 或 display.state 兜底。

## 交付信息
- Commit: ad3c159b1c8596774c6b2bc4910b9262d660a2a5