### PR TITLE
Task #25: 拉取远程分支同步

### DIFF
--- a/packages/along/src/domain/cleanup-utils.test.ts
+++ b/packages/along/src/domain/cleanup-utils.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const sessionMocks = vi.hoisted(() => ({
+  logEvent: vi.fn(),
+}));
+
 vi.mock('../core/common', () => ({
-  success: (data: any) => ({ success: true, data }),
+  success: (data: unknown) => ({ success: true, data }),
   failure: (error: string) => ({ success: false, error }),
   git: {
     fetch: vi.fn(),
@@ -57,7 +61,7 @@ vi.mock('../core/session-paths', () => ({
 
 vi.mock('./session-manager', () => ({
   SessionManager: vi.fn(() => ({
-    logEvent: vi.fn(),
+    logEvent: sessionMocks.logEvent,
   })),
 }));
 
@@ -88,13 +92,27 @@ vi.mock('bun', () => ({
   $: vi.fn(),
 }));
 
+import { $ } from 'bun';
 import { getGit, git } from '../core/common';
-import { pullDefaultBranch } from './cleanup-utils';
+import { cleanupIssue, pullDefaultBranch } from './cleanup-utils';
 import { getDefaultBranch } from './worktree-init';
 
 describe('cleanup-utils.ts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked($).mockImplementation(
+      () =>
+        ({
+          cwd: vi.fn().mockReturnThis(),
+          text: vi.fn().mockResolvedValue(''),
+          quiet: vi.fn().mockReturnThis(),
+          nothrow: vi.fn().mockResolvedValue(undefined),
+        }) as unknown as ReturnType<typeof $>,
+    );
+    vi.mocked(getGit).mockReturnValue({
+      fetch: vi.fn(),
+      raw: vi.fn(),
+    } as unknown as ReturnType<typeof getGit>);
   });
 
   describe('pullDefaultBranch()', () => {
@@ -103,8 +121,8 @@ describe('cleanup-utils.ts', () => {
         success: true,
         data: 'master',
       });
-      vi.mocked(git.fetch).mockResolvedValue(undefined as any);
-      vi.mocked(git.raw).mockResolvedValue('');
+      vi.mocked(git.fetch).mockResolvedValue(undefined);
+      vi.mocked(git.raw).mockResolvedValueOnce('').mockResolvedValueOnce('');
 
       const result = await pullDefaultBranch();
 
@@ -121,13 +139,15 @@ describe('cleanup-utils.ts', () => {
 
     it('使用自定义 repoPath 时调用 getGit', async () => {
       const mockGitInstance = { fetch: vi.fn(), raw: vi.fn() };
-      vi.mocked(getGit).mockReturnValue(mockGitInstance as any);
+      vi.mocked(getGit).mockReturnValue(
+        mockGitInstance as unknown as ReturnType<typeof getGit>,
+      );
       vi.mocked(getDefaultBranch).mockResolvedValue({
         success: true,
         data: 'main',
       });
       mockGitInstance.fetch.mockResolvedValue(undefined);
-      mockGitInstance.raw.mockResolvedValue('');
+      mockGitInstance.raw.mockResolvedValueOnce('').mockResolvedValueOnce('');
 
       const result = await pullDefaultBranch('/custom/repo');
 
@@ -162,20 +182,78 @@ describe('cleanup-utils.ts', () => {
       if (!result.success) expect(result.error).toContain('fetch 失败');
     });
 
-    it('当前在默认分支上时 branch -f 失败，降级为仅 fetch 成功', async () => {
+    it('当前在默认分支上时使用 ff-only 更新当前分支', async () => {
       vi.mocked(getDefaultBranch).mockResolvedValue({
         success: true,
         data: 'master',
       });
-      vi.mocked(git.fetch).mockResolvedValue(undefined as any);
+      vi.mocked(git.fetch).mockResolvedValue(undefined);
       vi.mocked(git.raw).mockRejectedValue(
         new Error('cannot force update the current branch'),
       );
+      vi.mocked(git.raw)
+        .mockResolvedValueOnce('master\n')
+        .mockResolvedValueOnce('');
 
       const result = await pullDefaultBranch();
 
       expect(result.success).toBe(true);
       if (result.success) expect(result.data).toBe('master');
+      expect(git.raw).toHaveBeenCalledWith([
+        'merge',
+        '--ff-only',
+        'origin/master',
+      ]);
+    });
+
+    it('branch -f 失败时返回 failure，不误报本地默认分支已同步', async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({
+        success: true,
+        data: 'master',
+      });
+      vi.mocked(git.fetch).mockResolvedValue(undefined);
+      vi.mocked(git.raw)
+        .mockResolvedValueOnce('feature/demo\n')
+        .mockRejectedValueOnce(new Error('checked out in another worktree'));
+
+      const result = await pullDefaultBranch();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('更新本地默认分支失败');
+      }
+    });
+
+    it('清理成功但默认分支同步失败时记录事件且不阻断清理', async () => {
+      vi.mocked(getDefaultBranch).mockResolvedValue({
+        success: true,
+        data: 'master',
+      });
+      const mockGitInstance = { fetch: vi.fn(), raw: vi.fn() };
+      vi.mocked(getGit).mockReturnValue(
+        mockGitInstance as unknown as ReturnType<typeof getGit>,
+      );
+      mockGitInstance.fetch.mockRejectedValue(new Error('network error'));
+
+      const result = await cleanupIssue(
+        '42',
+        {
+          worktreePath: '/mock/worktree',
+          branchName: 'feat/demo',
+          silent: true,
+        },
+        'ranwawa',
+        'along',
+        '/repo/along',
+      );
+
+      expect(result.success).toBe(true);
+      expect(sessionMocks.logEvent).toHaveBeenCalledWith(
+        'default-branch-sync-failed',
+        expect.objectContaining({
+          error: expect.stringContaining('fetch 失败'),
+        }),
+      );
     });
   });
 });

--- a/packages/along/src/domain/cleanup-utils.ts
+++ b/packages/along/src/domain/cleanup-utils.ts
@@ -24,6 +24,8 @@ export interface CleanupOptions {
   force?: boolean;
   reason?: string; // "normal" | "force" | "gc"
   silent?: boolean;
+  worktreePath?: string;
+  branchName?: string;
 }
 
 function info(msg: string, silent?: boolean) {
@@ -32,6 +34,10 @@ function info(msg: string, silent?: boolean) {
 
 function warn(msg: string, silent?: boolean) {
   if (!silent) logger.warn(msg);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**
@@ -148,23 +154,33 @@ export async function pullDefaultBranch(
 
   try {
     await g.fetch('origin', defaultBranch);
-  } catch (e: any) {
-    logger.warn(`fetch origin/${defaultBranch} 失败: ${e.message}`);
-    return failure(`fetch 失败: ${e.message}`);
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    logger.warn(`fetch origin/${defaultBranch} 失败: ${message}`);
+    return failure(`fetch 失败: ${message}`);
   }
 
+  let currentBranch = '';
   try {
-    await g.raw(['branch', '-f', defaultBranch, `origin/${defaultBranch}`]);
+    currentBranch = (
+      await g.raw(['symbolic-ref', '--quiet', '--short', 'HEAD'])
+    ).trim();
+  } catch {}
+
+  try {
+    if (currentBranch === defaultBranch) {
+      await g.raw(['merge', '--ff-only', `origin/${defaultBranch}`]);
+    } else {
+      await g.raw(['branch', '-f', defaultBranch, `origin/${defaultBranch}`]);
+    }
     logger.info(
       `本地默认分支 ${defaultBranch} 已更新到 origin/${defaultBranch}`,
     );
     return success(defaultBranch);
-  } catch {
-    // 当前 checkout 在默认分支上时 git branch -f 会失败，降级为仅 fetch
-    logger.warn(
-      `git branch -f ${defaultBranch} 失败（可能当前在该分支上），已完成 fetch`,
-    );
-    return success(defaultBranch);
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    logger.warn(`更新本地默认分支 ${defaultBranch} 失败: ${message}`);
+    return failure(`更新本地默认分支失败: ${message}`);
   }
 }
 
@@ -191,7 +207,7 @@ export async function cleanupIssue(
 
   const paths = new SessionPathManager(owner, repo, Number(issueNumber));
   const session = new SessionManager(owner, repo, Number(issueNumber));
-  const worktreePath = paths.getWorktreeDir();
+  const worktreePath = options.worktreePath || paths.getWorktreeDir();
   const reason = options.reason || (options.force ? 'force' : 'normal');
 
   session.logEvent('cleanup-started', {
@@ -213,7 +229,8 @@ export async function cleanupIssue(
   }
 
   // 读取分支名（必须在归档前读取）
-  const branchName = readBranchName(owner, repo, Number(issueNumber));
+  const branchName =
+    options.branchName || readBranchName(owner, repo, Number(issueNumber));
 
   // 清理 worktree
   await cleanupWorktree(worktreePath, options.silent, session, repoPath);
@@ -225,6 +242,9 @@ export async function cleanupIssue(
   const pullRes = await pullDefaultBranch(repoPath);
   if (pullRes.success) {
     session.logEvent('default-branch-updated', { branch: pullRes.data });
+  } else {
+    warn(`默认分支同步失败: ${pullRes.error}`, options.silent);
+    session.logEvent('default-branch-sync-failed', { error: pullRes.error });
   }
 
   session.logEvent('cleanup-completed', { issueNumber, reason, branchName });
@@ -284,15 +304,21 @@ export async function cleanupIssueAssets(
   await cleanupBranch(branchName, options.silent, session, repoPath);
 
   // 更新本地默认分支到远程最新
-  await pullDefaultBranch(repoPath);
+  const pullRes = await pullDefaultBranch(repoPath);
+  if (pullRes.success) {
+    session.logEvent('default-branch-updated', { branch: pullRes.data });
+  } else {
+    warn(`默认分支同步失败: ${pullRes.error}`, options.silent);
+    session.logEvent('default-branch-sync-failed', { error: pullRes.error });
+  }
 
   const issueDir = paths.getIssueDir();
   if (fs.existsSync(issueDir)) {
     info(`删除本地数据目录: ${issueDir}`, options.silent);
     try {
       fs.rmSync(issueDir, { recursive: true, force: true });
-    } catch (e: any) {
-      return failure(`删除本地数据目录失败: ${e.message}`);
+    } catch (error: unknown) {
+      return failure(`删除本地数据目录失败: ${getErrorMessage(error)}`);
     }
   }
 

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -345,10 +345,73 @@ export async function handleTaskManualCompleteRequest(
   return jsonResponse({ taskId, snapshot: completeRes.data });
 }
 
-export function handleTaskCompleteRequest(taskId: string): Response {
+export async function handleTaskCompleteRequest(
+  taskId: string,
+  _context: TaskApiContext,
+): Promise<Response> {
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  const snapshot = snapshotRes.data;
+  if (!snapshot) return errorResponse(`Task 不存在: ${taskId}`, 404);
+
+  if (snapshot.task.lifecycle !== TASK_LIFECYCLE.COMPLETED) {
+    const cleanupInputRes = readTaskCleanupInput(snapshot);
+    if (!cleanupInputRes.success) {
+      return errorResponse(cleanupInputRes.error, 409);
+    }
+
+    const { cleanupIssue } = await import('../domain/cleanup-utils');
+    const cleanupRes = await cleanupIssue(
+      String(cleanupInputRes.data.seq),
+      {
+        reason: 'delivery_acceptance',
+        worktreePath: cleanupInputRes.data.worktreePath,
+        branchName: cleanupInputRes.data.branchName,
+      },
+      cleanupInputRes.data.repoOwner,
+      cleanupInputRes.data.repoName,
+      cleanupInputRes.data.cwd,
+    );
+    if (!cleanupRes.success) return errorResponse(cleanupRes.error, 409);
+  }
+
   const completeRes = completeDeliveredTask(taskId);
   if (!completeRes.success) return errorResponse(completeRes.error, 409);
   return jsonResponse({ taskId, snapshot: completeRes.data });
+}
+
+function readTaskCleanupInput(snapshot: TaskPlanningSnapshot): Result<{
+  seq: number;
+  repoOwner: string;
+  repoName: string;
+  cwd: string;
+  worktreePath: string;
+  branchName?: string;
+}> {
+  if (snapshot.task.lifecycle === TASK_LIFECYCLE.CANCELLED) {
+    return failure('Task 已关闭，不能验收完成');
+  }
+  if (!snapshot.task.prUrl) return failure('只有已交付 Task 可以验收完成');
+  if (!snapshot.task.repoOwner || !snapshot.task.repoName) {
+    return failure('当前 Task 缺少仓库信息，不能清理本地资源');
+  }
+  if (!snapshot.task.cwd) {
+    return failure('当前 Task 缺少仓库路径，不能同步默认分支');
+  }
+  if (snapshot.task.seq == null) {
+    return failure('当前 Task 缺少本地序号，不能清理本地资源');
+  }
+  if (!snapshot.task.worktreePath) {
+    return failure('当前 Task 缺少 worktree 路径，不能清理本地资源');
+  }
+  return success({
+    seq: snapshot.task.seq,
+    repoOwner: snapshot.task.repoOwner,
+    repoName: snapshot.task.repoName,
+    cwd: snapshot.task.cwd,
+    worktreePath: snapshot.task.worktreePath,
+    branchName: snapshot.task.branchName,
+  });
 }
 
 function readExistingTaskError(taskId: string): Response | null {

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -5,7 +5,7 @@ import {
   jsonRequest,
   type PlanningMocks,
   resetPlanningMocks,
-  type snapshot,
+  snapshot,
 } from './task-api.test-utils';
 
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
@@ -22,6 +22,10 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
   submitTaskMessage: vi.fn(),
 }));
 
+const cleanupMocks = vi.hoisted(() => ({
+  cleanupIssue: vi.fn(),
+}));
+
 vi.mock('../domain/task-planning', () => ({
   TASK_EXECUTION_MODE: {
     MANUAL: 'manual',
@@ -31,6 +35,16 @@ vi.mock('../domain/task-planning', () => ({
     PLANNING: 'planning',
     IMPLEMENTATION: 'implementation',
     DELIVERY: 'delivery',
+  },
+  TASK_LIFECYCLE: {
+    CANCELLED: 'cancelled',
+    COMPLETED: 'completed',
+    OPEN: 'open',
+    READY: 'ready',
+  },
+  WORKFLOW_KIND: {
+    IMPLEMENTATION: 'implementation',
+    PLANNING: 'planning',
   },
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
@@ -45,7 +59,17 @@ vi.mock('../domain/task-planning', () => ({
   submitTaskMessage: planningMocks.submitTaskMessage,
 }));
 
+vi.mock('../domain/cleanup-utils', () => ({
+  cleanupIssue: cleanupMocks.cleanupIssue,
+}));
+
 beforeEach(() => resetPlanningMocks(planningMocks));
+beforeEach(() => {
+  cleanupMocks.cleanupIssue.mockResolvedValue({
+    success: true,
+    data: undefined,
+  });
+});
 
 it('当路径属于 Task API 时，期望能识别', () => {
   expect(isTaskApiPath('/api/tasks')).toBe(true);
@@ -295,6 +319,26 @@ it('当人工标记实现阶段已处理时，期望返回更新后的 snapshot'
 });
 
 it('当验收已交付 Task 时，期望返回完成后的 snapshot', async () => {
+  const deliveredSnapshot = {
+    ...snapshot,
+    task: {
+      ...snapshot.task,
+      lifecycle: 'open',
+      repoOwner: 'ranwawa',
+      repoName: 'along',
+      cwd: '/repo/along',
+      seq: 25,
+      worktreePath: '/repo/along/tasks/25/worktree',
+      branchName: 'fix/demo-25',
+      prUrl: 'https://github.com/ranwawa/along/pull/25',
+      prNumber: 25,
+    },
+  };
+  planningMocks.readTaskPlanningSnapshot.mockReturnValueOnce({
+    success: true,
+    data: deliveredSnapshot,
+  });
+
   const response = await handleTaskApiRequest(
     jsonRequest('/api/tasks/task-1/complete', {}),
     new URL('http://localhost/api/tasks/task-1/complete'),
@@ -307,7 +351,56 @@ it('当验收已交付 Task 时，期望返回完成后的 snapshot', async () =
 
   expect(response.status).toBe(200);
   expect(payload.taskId).toBe('task-1');
+  expect(cleanupMocks.cleanupIssue).toHaveBeenCalledWith(
+    '25',
+    {
+      reason: 'delivery_acceptance',
+      worktreePath: '/repo/along/tasks/25/worktree',
+      branchName: 'fix/demo-25',
+    },
+    'ranwawa',
+    'along',
+    '/repo/along',
+  );
   expect(planningMocks.completeDeliveredTask).toHaveBeenCalledWith('task-1');
+  expect(cleanupMocks.cleanupIssue.mock.invocationCallOrder[0]).toBeLessThan(
+    planningMocks.completeDeliveredTask.mock.invocationCallOrder[0],
+  );
+});
+
+it('当验收清理失败时，期望不继续完成 Task', async () => {
+  cleanupMocks.cleanupIssue.mockResolvedValueOnce({
+    success: false,
+    error: 'worktree 清理失败',
+  });
+  planningMocks.readTaskPlanningSnapshot.mockReturnValueOnce({
+    success: true,
+    data: {
+      ...snapshot,
+      task: {
+        ...snapshot.task,
+        repoOwner: 'ranwawa',
+        repoName: 'along',
+        cwd: '/repo/along',
+        seq: 25,
+        worktreePath: '/repo/along/tasks/25/worktree',
+        branchName: 'fix/demo-25',
+        prUrl: 'https://github.com/ranwawa/along/pull/25',
+        prNumber: 25,
+      },
+    },
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/complete', {}),
+    new URL('http://localhost/api/tasks/task-1/complete'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as { error: string };
+
+  expect(response.status).toBe(409);
+  expect(payload.error).toBe('worktree 清理失败');
+  expect(planningMocks.completeDeliveredTask).not.toHaveBeenCalled();
 });
 
 it('当关闭 Task 时，期望返回关闭后的 snapshot', async () => {

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -68,7 +68,8 @@ type TaskActionHandler = (
 const ACTION_ROUTES: Record<string, TaskActionHandler> = {
   approve: (_req, taskId) => handleTaskApproveRequest(taskId),
   close: (req, taskId) => handleTaskCloseRequest(req, taskId),
-  complete: (_req, taskId) => handleTaskCompleteRequest(taskId),
+  complete: (_req, taskId, context) =>
+    handleTaskCompleteRequest(taskId, context),
   delivery: handleTaskDeliveryRequest,
   implementation: handleTaskImplementationRequest,
   'manual-complete': (req, taskId) =>


### PR DESCRIPTION
along-task: #25

## 修改内容
- `packages/along/src/domain/cleanup-utils.test.ts`
- `packages/along/src/domain/cleanup-utils.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-api.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-25`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立且值得做。验收完成后本地任务 worktree 和任务分支已经进入清理阶段，此时再同步本地默认分支，可以保证后续新任务从最新默认分支创建 worktree，避免基于旧代码继续开发。该同步属于验收后的维护动作，不应该反向影响验收完成结果。

Summary
在“验收完成”流程中，将远程默认分支同步作为本地清理成功后的后置步骤执行：先完成现有 worktree/任务分支清理，再 fetch 远程默认分支并更新本地默认分支到远程默认分支最新提交。同步失败只记录日志或状态提示，不阻断验收完成。

```mermaid
flowchart TD
  A[用户点击验收完成] --> B[执行现有验收完成流程]
  B --> C[清理任务 worktree 和本地任务分支]
  C --> D{清理是否完成}
  D -- 否 --> E[按现有失败逻辑返回]
  D -- 是 --> F[识别远程默认分支]
  F --> G[fetch 远程默认分支]
  G --> H{fetch 是否成功}
  H -- 否 --> I[记录同步失败，不阻断验收完成]
  H -- 是 --> J[更新本地默认分支到远程默认分支]
  J --> K{更新是否成功}
  K -- 否 --> I
  K -- 是 --> L[记录同步成功]
  I --> M[验收完成]
  L --> M
```

Implementation Changes
1. 在验收完成的后端流程中，找到现有本地 worktree 和任务分支清理完成的位置，把“同步默认分支”接在清理成功之后执行。
2. 新增或复用 Git 服务能力：识别当前仓库 remote 默认分支，优先使用 `origin/HEAD` 或现有项目配置中的默认分支；拿到远程默认分支后执行 fetch，确保远程引用是最新的。
3. 更新本地默认分支时，以远程默认分支为准，让本地默认分支指向对应远程提交。允许流程在清理完成后切换分支或直接更新引用，核心约束是最终本地默认分支必须与远程默认分支一致。
4. 同步动作失败时捕获错误，写入用户可见日志或任务事件，说明默认分支同步失败及原因；不得让该错误覆盖验收完成结果。
5. 保持现有验收失败语义不变：如果验收完成主流程或清理本身失败，仍按现有失败逻辑处理，不继续伪装为成功。

Contracts / Interfaces
- 输入：当前任务关联仓库路径、remote 信息、验收完成流程上下文。
- 输出：验收完成结果保持原有契约；额外产生默认分支同步成功或失败的日志/事件。
- 失败处理：默认分支同步失败为非阻断失败；worktree/任务分支清理失败仍为阻断失败。
- 分支语义：本地默认分支同步目标是远程默认分支最新提交，而不是当前任务分支或 MR 源分支。

Test Plan
1. 单元测试：验收清理成功后会调用默认分支同步能力，并且调用顺序在清理之后。
2. 单元测试：默认分支同步失败时，验收完成结果仍为成功，同时记录同步失败信息。
3. 单元测试：清理失败时不会继续执行默认分支同步，保持现有失败行为。
4. Git 服务测试：远程默认分支可识别时，本地默认分支会更新到远程默认分支对应提交。
5. 回归测试：现有验收完成、worktree 清理、分支删除相关测试继续通过。

Assumptions
- 用户会在 MR 合并后点击验收完成，因此任务分支清理后的同步动作不需要兼容未合并任务分支保护逻辑。
- 同步默认分支失败不阻断验收完成，只作为可见日志或事件提示。
- 不额外设计旧版本兼容逻辑；若历史任务数据缺少仓库 remote/default branch 信息，则按同步失败记录处理。

## 交付信息
- Commit: 8fceab53ee90c1ce87becd416c9902f8fc1c60be