### PR TITLE
Task #26: 聊天框交互逻辑优化

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -58,6 +58,7 @@ function TaskPlanningMain({
         onMessageAttachmentsChange={taskPlanning.setMessageAttachments}
         onMessageExecutionModeChange={taskPlanning.setMessageExecutionMode}
         onSubmitMessage={taskPlanning.submitMessageFromFlow}
+        onCancelAgentRun={taskPlanning.cancelAgentRun}
         onAction={taskPlanning.handleFlowAction}
       />
     </div>

--- a/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
+++ b/packages/along-web/src/task-planning/ExistingTaskComposer.tsx
@@ -1,4 +1,5 @@
 import type {
+  TaskAgentRunRecord,
   TaskExecutionMode,
   TaskFlowAction,
   TaskPlanningSnapshot,
@@ -22,7 +23,28 @@ function getMessageActions(flow: TaskPlanningSnapshot['flow']) {
       );
 }
 
+function getLatestRunningRun(
+  snapshot: TaskPlanningSnapshot,
+): TaskAgentRunRecord | null {
+  const runFromRuns =
+    [...(snapshot.agentRuns || [])]
+      .filter((run) => run.status === 'running')
+      .sort((left, right) =>
+        right.startedAt.localeCompare(left.startedAt),
+      )[0] || null;
+  if (runFromRuns) return runFromRuns;
+  return (
+    (snapshot.agentStages || [])
+      .map((stage) => stage.latestRun)
+      .filter((run): run is TaskAgentRunRecord => run?.status === 'running')
+      .sort((left, right) =>
+        right.startedAt.localeCompare(left.startedAt),
+      )[0] || null
+  );
+}
+
 export function ExistingTaskComposer({
+  snapshot,
   flow,
   messageBody,
   attachments,
@@ -32,7 +54,9 @@ export function ExistingTaskComposer({
   onAttachmentsChange,
   onExecutionModeChange,
   onSubmitMessage,
+  onCancelAgentRun,
 }: {
+  snapshot: TaskPlanningSnapshot;
   flow: TaskPlanningSnapshot['flow'];
   messageBody: string;
   attachments: File[];
@@ -42,27 +66,36 @@ export function ExistingTaskComposer({
   onAttachmentsChange: (files: File[]) => void;
   onExecutionModeChange: (value: TaskExecutionMode) => void;
   onSubmitMessage: () => void;
+  onCancelAgentRun: (runId?: string) => void;
 }) {
   const messageActions = getMessageActions(flow);
   const canSubmitMessage = messageActions.some((action) => action.enabled);
   const hasDraft = Boolean(messageBody.trim()) || attachments.length > 0;
   const submitAction =
     messageActions.find((action) => action.enabled) || messageActions[0];
+  const runningRun = getLatestRunningRun(snapshot);
   return (
     <TaskComposerInput
       attachments={attachments}
       body={messageBody}
       busy={busyAction === 'message'}
-      disabled={!canSubmitMessage}
+      disabled={!canSubmitMessage && !runningRun}
       executionMode={executionMode}
       placeholder="补充反馈、继续提问或说明交付后的修改要求"
-      submitDisabled={!canSubmitMessage || !hasDraft || Boolean(busyAction)}
+      runningRun={runningRun}
+      submitDisabled={
+        runningRun
+          ? busyAction === 'cancel-agent'
+          : !canSubmitMessage || !hasDraft || Boolean(busyAction)
+      }
       submitTitle={submitAction?.description || submitAction?.label || '发送'}
       onAttachmentsChange={onAttachmentsChange}
       onBodyChange={onMessageChange}
       onExecutionModeChange={onExecutionModeChange}
+      onCancelAgentRun={onCancelAgentRun}
       onSubmit={(event) => {
         event.preventDefault();
+        if (runningRun) return;
         onSubmitMessage();
       }}
     />

--- a/packages/along-web/src/task-planning/TaskComposerInput.tsx
+++ b/packages/along-web/src/task-planning/TaskComposerInput.tsx
@@ -1,5 +1,6 @@
-import { type FormEvent, useState } from 'react';
-import type { TaskExecutionMode } from '../types-task';
+// biome-ignore-all lint/style/noJsxLiterals: existing composer controls use inline UI labels.
+import { type FormEvent, type KeyboardEvent, useState } from 'react';
+import type { TaskAgentRunRecord, TaskExecutionMode } from '../types-task';
 import {
   ImageAttachmentPicker,
   type ImageAttachmentPickerRenderProps,
@@ -13,8 +14,10 @@ interface TaskComposerInputProps {
   executionMode: TaskExecutionMode;
   placeholder: string;
   rows?: number;
+  runningRun?: TaskAgentRunRecord | null;
   submitDisabled: boolean;
   submitTitle?: string;
+  onCancelAgentRun?: (runId?: string) => void;
   onAttachmentsChange: (files: File[]) => void;
   onBodyChange: (value: string) => void;
   onExecutionModeChange: (value: TaskExecutionMode) => void;
@@ -79,6 +82,15 @@ function SendIcon() {
   );
 }
 
+function SpinnerIcon() {
+  return (
+    <span
+      aria-hidden="true"
+      className="h-4 w-4 animate-spin rounded-full border-2 border-white/45 border-t-white motion-reduce:animate-none"
+    />
+  );
+}
+
 function isTaskExecutionMode(value: string): value is TaskExecutionMode {
   return value === 'manual' || value === 'autonomous';
 }
@@ -139,15 +151,32 @@ function ComposerTextarea({
   disabled,
   placeholder,
   rows,
+  runningRun,
   onBodyChange,
+  onSubmitShortcut,
 }: Pick<
   TaskComposerInputProps,
-  'body' | 'busy' | 'disabled' | 'placeholder' | 'rows' | 'onBodyChange'
->) {
+  | 'body'
+  | 'busy'
+  | 'disabled'
+  | 'placeholder'
+  | 'rows'
+  | 'runningRun'
+  | 'onBodyChange'
+> & {
+  onSubmitShortcut: (form: HTMLFormElement | null) => void;
+}) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
+    if (event.ctrlKey || event.altKey || event.shiftKey || runningRun) return;
+    event.preventDefault();
+    onSubmitShortcut(event.currentTarget.form);
+  };
   return (
     <textarea
       value={body}
       onChange={(event) => onBodyChange(event.target.value)}
+      onKeyDown={handleKeyDown}
       placeholder={placeholder}
       rows={rows}
       disabled={disabled || busy}
@@ -186,24 +215,27 @@ function ExecutionModeSelect({
 
 function SubmitIconButton({
   busy,
+  runningRun,
   submitDisabled,
   submitTitle,
-}: Pick<TaskComposerInputProps, 'busy' | 'submitDisabled' | 'submitTitle'>) {
+  onCancelAgentRun,
+}: Pick<
+  TaskComposerInputProps,
+  'busy' | 'runningRun' | 'submitDisabled' | 'submitTitle' | 'onCancelAgentRun'
+>) {
+  const isCancelling = Boolean(runningRun);
   return (
     <button
-      type="submit"
-      aria-label={busy ? '发送中' : '发送'}
-      title={busy ? '发送中' : submitTitle}
+      type={isCancelling ? 'button' : 'submit'}
+      aria-label={isCancelling ? '中断当前 Agent' : busy ? '发送中' : '发送'}
+      title={isCancelling ? '中断当前 Agent' : busy ? '发送中' : submitTitle}
       disabled={submitDisabled || busy}
+      onClick={() => {
+        if (runningRun) onCancelAgentRun?.(runningRun.runId);
+      }}
       className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-brand bg-brand text-white transition-colors hover:bg-brand-hover focus:outline-none focus:ring-1 focus:ring-brand/70 disabled:cursor-not-allowed disabled:opacity-50"
     >
-      {busy ? (
-        <span aria-hidden="true" className="text-sm leading-none">
-          ...
-        </span>
-      ) : (
-        <SendIcon />
-      )}
+      {isCancelling ? <SpinnerIcon /> : busy ? <SpinnerIcon /> : <SendIcon />}
     </button>
   );
 }
@@ -232,14 +264,16 @@ function ComposerActionRow({
 
 function ComposerContent({
   controls,
+  onSubmitShortcut,
   ...props
 }: ComposerDisplayProps & {
   controls: ImageAttachmentPickerRenderProps;
+  onSubmitShortcut: (form: HTMLFormElement | null) => void;
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-3">
       {controls.previews}
-      <ComposerTextarea {...props} />
+      <ComposerTextarea {...props} onSubmitShortcut={onSubmitShortcut} />
       {controls.error}
       <ComposerActionRow controls={controls} {...props} />
     </div>
@@ -271,7 +305,15 @@ export function TaskComposerInput({
         onChange={onAttachmentsChange}
       >
         {(controls) => (
-          <ComposerContent controls={controls} {...composerProps} />
+          <ComposerContent
+            controls={controls}
+            {...composerProps}
+            onSubmitShortcut={(form) => {
+              if (!composerProps.submitDisabled && !composerProps.runningRun) {
+                form?.requestSubmit();
+              }
+            }}
+          />
         )}
       </ImageAttachmentPicker>
     </form>

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/style/noJsxLiterals: existing dashboard view uses inline labels throughout.
+// biome-ignore-all lint/style/noMagicNumbers: existing dashboard layout uses numeric UI thresholds.
 import {
   type FormEvent,
   type RefObject,
@@ -193,6 +195,7 @@ type TaskDetailProps = {
   onMessageAttachmentsChange: (files: File[]) => void;
   onMessageExecutionModeChange: (value: TaskExecutionMode) => void;
   onSubmitMessage: () => void;
+  onCancelAgentRun: (runId?: string) => void;
   onAction: (action: TaskFlowAction) => void;
 };
 
@@ -315,6 +318,7 @@ function SelectedTaskDetail({
         </div>
         <div className="shrink-0 border-t border-border-color bg-bg-secondary p-3 md:p-4">
           <ExistingTaskComposer
+            snapshot={selected}
             flow={selected.flow}
             messageBody={detail.messageBody}
             attachments={detail.messageAttachments}
@@ -324,6 +328,7 @@ function SelectedTaskDetail({
             onAttachmentsChange={detail.onMessageAttachmentsChange}
             onExecutionModeChange={detail.onMessageExecutionModeChange}
             onSubmitMessage={detail.onSubmitMessage}
+            onCancelAgentRun={detail.onCancelAgentRun}
           />
         </div>
       </section>

--- a/packages/along-web/src/task-planning/api.ts
+++ b/packages/along-web/src/task-planning/api.ts
@@ -37,6 +37,13 @@ export interface ManualCompleteResponse {
   snapshot: TaskPlanningSnapshot;
 }
 
+export interface CancelAgentRunResponse {
+  taskId: string;
+  cancelled: boolean;
+  runId?: string;
+  snapshot: TaskPlanningSnapshot;
+}
+
 export interface CompleteTaskResponse {
   taskId: string;
   snapshot: TaskPlanningSnapshot;

--- a/packages/along-web/src/task-planning/flowActionRouter.test.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.test.ts
@@ -115,6 +115,7 @@ function makeInput(
 function makeActions() {
   return {
     submitMessageFromFlow: vi.fn(),
+    cancelAgentRun: vi.fn(),
     copyManualResumeCommand: vi.fn(),
     completeManualStage: vi.fn(),
     runSimpleAction: vi.fn(),

--- a/packages/along-web/src/task-planning/flowActionRouter.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.ts
@@ -8,6 +8,7 @@ import { getLatestFailedStage } from './format';
 
 export type FlowActionParts = {
   submitMessageFromFlow: () => Promise<void>;
+  cancelAgentRun: (runId?: string) => Promise<void>;
   copyManualResumeCommand: (stage: TaskAgentStageRecord) => Promise<void>;
   completeManualStage: (stage: TaskAgentStageRecord) => Promise<void>;
   runSimpleAction: (

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -8,6 +8,7 @@ import type {
   UseTaskPlanningActionsInput,
 } from './actionTypes';
 import {
+  type CancelAgentRunResponse,
   type ManualCompleteResponse,
   readJsonResponse,
   type SubmitTaskMessageResponse,
@@ -98,26 +99,9 @@ function useMessageActions(
   api: ReturnType<typeof useSelectedTaskApi>,
 ) {
   const sendTaskMessage = async (body: string) => {
-    const attachments = input.messageAttachments;
-    if (!input.selected || input.busyAction) return;
+    if (shouldSkipMessageSend(input)) return;
     await runBusy(input, 'message', async () => {
-      const payload = {
-        body,
-        autoRun: true,
-        executionMode: input.messageExecutionMode,
-      };
-      const result =
-        attachments.length > 0
-          ? await postSelectedMultipart<SubmitTaskMessageResponse>(
-              input,
-              'messages',
-              payload,
-              attachments,
-            )
-          : await api.postSelected<SubmitTaskMessageResponse>(
-              'messages',
-              payload,
-            );
+      const result = await postTaskMessage(input, api, body);
       input.setMessageBody('');
       input.setMessageAttachments([]);
       await api.updateFromOptionalSnapshot(result.snapshot);
@@ -130,6 +114,58 @@ function useMessageActions(
     }
   };
   return { sendTaskMessage, submitMessageFromFlow };
+}
+
+function shouldSkipMessageSend(input: UseTaskPlanningActionsInput): boolean {
+  return (
+    !input.selected ||
+    Boolean(input.busyAction) ||
+    hasRunningAgentRun(input.selected)
+  );
+}
+
+function postTaskMessage(
+  input: UseTaskPlanningActionsInput,
+  api: ReturnType<typeof useSelectedTaskApi>,
+  body: string,
+): Promise<SubmitTaskMessageResponse> {
+  const payload = {
+    body,
+    autoRun: true,
+    executionMode: input.messageExecutionMode,
+  };
+  return input.messageAttachments.length > 0
+    ? postSelectedMultipart<SubmitTaskMessageResponse>(
+        input,
+        'messages',
+        payload,
+        input.messageAttachments,
+      )
+    : api.postSelected<SubmitTaskMessageResponse>('messages', payload);
+}
+
+function hasRunningAgentRun(snapshot: TaskPlanningSnapshot): boolean {
+  return snapshot.agentRuns.some((run) => run.status === 'running');
+}
+
+function useAgentCancellationActions(
+  input: UseTaskPlanningActionsInput,
+  api: ReturnType<typeof useSelectedTaskApi>,
+) {
+  const cancelAgentRun = async (runId?: string) => {
+    if (!input.selected || input.busyAction) return;
+    await runBusy(input, 'cancel-agent', async () => {
+      const result = await api.postSelected<CancelAgentRunResponse>(
+        'cancel-agent',
+        {
+          runId,
+          reason: '用户从聊天框中断当前 Agent 会话',
+        },
+      );
+      applySnapshot(result.snapshot, input);
+    });
+  };
+  return { cancelAgentRun };
 }
 
 async function postSelectedMultipart<T>(
@@ -231,9 +267,10 @@ function useFlowActionParts(
 ): FlowActionParts {
   const api = useSelectedTaskApi(input);
   const messages = useMessageActions(input, api);
+  const cancellations = useAgentCancellationActions(input, api);
   const simple = useSimpleFlowActions(input, api);
   const manual = useManualActions(input, api);
-  return { ...messages, ...simple, ...manual };
+  return { ...messages, ...cancellations, ...simple, ...manual };
 }
 
 function useFlowActions(input: UseTaskPlanningActionsInput) {
@@ -244,6 +281,7 @@ function useFlowActions(input: UseTaskPlanningActionsInput) {
   };
   return {
     submitMessageFromFlow: parts.submitMessageFromFlow,
+    cancelAgentRun: parts.cancelAgentRun,
     handleFlowAction,
   };
 }

--- a/packages/along/src/commands/webhook-server.ts
+++ b/packages/along/src/commands/webhook-server.ts
@@ -2,6 +2,7 @@
 
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy webhook server predates current function-size rule.
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy webhook server predates current file-size rule.
+// biome-ignore-all lint/style/noMagicNumbers: legacy webhook server uses route and timeout literals throughout.
 /**
  * webhook-server.ts - 本地 webhook 接收服务器
  *
@@ -460,6 +461,10 @@ function enqueueTaskPlanningRun(input: ScheduledTaskPlanningRun) {
         personalityVersion: input.personalityVersion,
       });
       if (!result.success) {
+        if (isTaskAgentCancellationError(result.error)) {
+          logger.info(`[Task ${input.taskId}] planning 已中断`);
+          return;
+        }
         logger.error(`[Task ${input.taskId}] planning 失败: ${result.error}`);
         return;
       }
@@ -500,6 +505,10 @@ function enqueueTaskImplementationRun(input: ScheduledTaskImplementationRun) {
         personalityVersion: input.personalityVersion,
       });
       if (!result.success) {
+        if (isTaskAgentCancellationError(result.error)) {
+          logger.info(`[Task ${input.taskId}] implementation 已中断`);
+          return;
+        }
         logger.error(
           `[Task ${input.taskId}] implementation 失败: ${result.error}`,
         );
@@ -523,6 +532,10 @@ function enqueueTaskImplementationRun(input: ScheduledTaskImplementationRun) {
       }
     });
   });
+}
+
+function isTaskAgentCancellationError(error: string): boolean {
+  return error.includes('已取消') || error.includes('已中断');
 }
 
 function enqueueTaskDeliveryRun(input: ScheduledTaskDeliveryRun) {

--- a/packages/along/src/domain/task-agent-run-lifecycle.ts
+++ b/packages/along/src/domain/task-agent-run-lifecycle.ts
@@ -10,6 +10,7 @@ import {
   createTaskAgentRun,
   ensureTaskAgentBinding,
   finishTaskAgentRun,
+  readTaskAgentRun,
   recordTaskAgentResult,
   TASK_AGENT_PROGRESS_PHASE,
   type TaskAgentBindingRecord,
@@ -32,6 +33,61 @@ export interface StartedTaskAgentRun {
   run: TaskAgentRunRecord;
   progressContext: TaskAgentProgressContext;
   usedResume: boolean;
+}
+
+type TaskAgentCancelHandler = (reason?: string) => void;
+
+const runningTaskAgentCancels = new Map<string, TaskAgentCancelHandler>();
+
+export function registerTaskAgentCancellation(
+  runId: string,
+  cancel: TaskAgentCancelHandler,
+): () => void {
+  runningTaskAgentCancels.set(runId, cancel);
+  return () => {
+    if (runningTaskAgentCancels.get(runId) === cancel) {
+      runningTaskAgentCancels.delete(runId);
+    }
+  };
+}
+
+export function requestTaskAgentCancellation(
+  runId: string,
+  reason?: string,
+): boolean {
+  const cancel = runningTaskAgentCancels.get(runId);
+  if (!cancel) return false;
+  cancel(reason);
+  return true;
+}
+
+export function isTaskAgentRunCancelled(runId: string): boolean {
+  const runRes = readTaskAgentRun(runId);
+  return runRes.success && runRes.data?.status === AGENT_RUN_STATUS.CANCELLED;
+}
+
+export function completeTaskAgentCancellation(
+  context: TaskAgentProgressContext,
+  summary = 'Agent 运行已中断。',
+  detail?: string,
+): Result<TaskAgentRunRecord> {
+  if (isTaskAgentRunCancelled(context.runId)) {
+    const runRes = readTaskAgentRun(context.runId);
+    return runRes.success && runRes.data
+      ? success(runRes.data)
+      : failure('Agent Run 已取消，但读取状态失败');
+  }
+  writeTaskAgentProgress(
+    context,
+    TASK_AGENT_PROGRESS_PHASE.CANCELLED,
+    summary,
+    detail,
+  );
+  return finishTaskAgentRun({
+    runId: context.runId,
+    status: AGENT_RUN_STATUS.CANCELLED,
+    error: detail,
+  });
 }
 
 export function startTaskAgentRun(
@@ -98,6 +154,7 @@ export function markTaskAgentFailed(
   providerSessionIdAtEnd?: string,
   summary = 'Agent 运行失败，正在记录错误。',
 ): Result<void> {
+  if (isTaskAgentRunCancelled(context.runId)) return success(undefined);
   writeTaskAgentProgress(
     context,
     TASK_AGENT_PROGRESS_PHASE.FAILED,
@@ -121,6 +178,9 @@ export function saveTaskAgentOutput(
   providerSessionIdAtEnd?: string,
 ): Result<string[]> {
   if (!assistantText) return success([]);
+  if (isTaskAgentRunCancelled(context.runId)) {
+    return failure('Agent Run 已取消，跳过保存输出');
+  }
   writeTaskAgentProgress(
     context,
     TASK_AGENT_PROGRESS_PHASE.FINALIZING,
@@ -158,6 +218,12 @@ export function finishTaskAgentSuccess(
   outputArtifactIds: string[],
   providerSessionIdAtEnd?: string,
 ): Result<TaskAgentRunRecord> {
+  if (isTaskAgentRunCancelled(context.runId)) {
+    const runRes = readTaskAgentRun(context.runId);
+    return runRes.success && runRes.data
+      ? success(runRes.data)
+      : failure('Agent Run 已取消，但读取状态失败');
+  }
   const finishedRun = finishTaskAgentRun({
     runId: context.runId,
     status: AGENT_RUN_STATUS.SUCCEEDED,

--- a/packages/along/src/domain/task-claude-runner.test.ts
+++ b/packages/along/src/domain/task-claude-runner.test.ts
@@ -12,6 +12,7 @@ const planningMocks = vi.hoisted(() => ({
   ensureTaskAgentBinding: vi.fn(),
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
+  readTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
   recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock('./task-planning', () => ({
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
+  readTaskAgentRun: planningMocks.readTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
   recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
@@ -129,6 +131,20 @@ describe('task-claude-runner', () => {
         outputArtifactIds: ['art-result'],
         startedAt: '2026-01-01T00:00:00.000Z',
         endedAt: '2026-01-01T00:00:01.000Z',
+      },
+    });
+    planningMocks.readTaskAgentRun.mockReturnValue({
+      success: true,
+      data: {
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        provider: 'claude',
+        status: 'running',
+        inputArtifactIds: [],
+        outputArtifactIds: [],
+        startedAt: '2026-01-01T00:00:00.000Z',
       },
     });
     planningMocks.recordTaskAgentResult.mockReturnValue({

--- a/packages/along/src/domain/task-claude-runner.ts
+++ b/packages/along/src/domain/task-claude-runner.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy runner keeps provider orchestration together.
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy runner keeps provider orchestration together.
 import {
   type Options as ClaudeSDKOptions,
   query,
@@ -11,8 +13,11 @@ import {
   writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
+  completeTaskAgentCancellation,
   finishTaskAgentSuccess,
+  isTaskAgentRunCancelled,
   markTaskAgentFailed,
+  registerTaskAgentCancellation,
   type StartedTaskAgentRun,
   saveTaskAgentOutput,
   startTaskAgentRun,
@@ -38,6 +43,7 @@ import {
 import { resolveAndRecordInputImages } from './task-runner-images';
 
 const PROVIDER = 'claude';
+const DEFAULT_MAX_TURNS = 50;
 
 export interface RunTaskClaudeTurnInput {
   taskId: string;
@@ -68,17 +74,25 @@ interface ClaudeTurnState {
   structuredOutput?: unknown;
 }
 
+type AbortableClaudeOptions = ClaudeSDKOptions & {
+  abortController?: AbortController;
+  signal?: AbortSignal;
+};
+
 function buildOptions(
   input: RunTaskClaudeTurnInput,
   resumeSessionId?: string,
-): ClaudeSDKOptions {
+  abortController?: AbortController,
+): AbortableClaudeOptions {
   return {
     ...input.options,
     cwd: input.cwd,
     model: input.model,
     resume: resumeSessionId,
     permissionMode: input.options?.permissionMode || 'plan',
-    maxTurns: input.options?.maxTurns || 50,
+    maxTurns: input.options?.maxTurns || DEFAULT_MAX_TURNS,
+    abortController,
+    signal: abortController?.signal,
   };
 }
 
@@ -99,6 +113,11 @@ async function runStartedClaudeTurn(
   started: StartedTaskAgentRun,
 ): Promise<Result<RunTaskClaudeTurnOutput>> {
   const stopHeartbeat = startClaudeHeartbeat(started, input.cwd);
+  const abortController = new AbortController();
+  const unregisterCancel = registerTaskAgentCancellation(
+    started.run.runId,
+    (reason) => abortController.abort(reason),
+  );
 
   try {
     const promptRes = await prepareClaudePrompt(input, prompt, started);
@@ -109,24 +128,41 @@ async function runStartedClaudeTurn(
         started.binding.providerSessionId,
       );
     }
+    if (isTaskAgentRunCancelled(started.run.runId)) {
+      return completeCancelledClaudeTurn(started);
+    }
     const conversation = query({
       prompt: promptRes.data,
-      options: buildOptions(input, started.binding.providerSessionId),
+      options: buildOptions(
+        input,
+        started.binding.providerSessionId,
+        abortController,
+      ),
     });
     const stateRes = await collectClaudeConversation(
       conversation,
       started.progressContext,
       started.binding.providerSessionId,
     );
+    if (isTaskAgentRunCancelled(started.run.runId)) {
+      return completeCancelledClaudeTurn(
+        started,
+        stateRes.success ? stateRes.data : undefined,
+      );
+    }
     if (!stateRes.success) return stateRes;
     return completeClaudeTurn(input, started, stateRes.data);
   } catch (error: unknown) {
+    if (isTaskAgentRunCancelled(started.run.runId)) {
+      return completeCancelledClaudeTurn(started);
+    }
     return failClaudeTurn(
       started.progressContext,
       error,
       started.binding.providerSessionId,
     );
   } finally {
+    unregisterCancel();
     stopHeartbeat();
   }
 }
@@ -247,6 +283,26 @@ function completeClaudeTurn(
     assistantText,
     structuredOutput: state.structuredOutput,
     outputArtifactIds: outputRes.data,
+  });
+}
+
+function completeCancelledClaudeTurn(
+  started: StartedTaskAgentRun,
+  state?: ClaudeTurnState,
+): Result<RunTaskClaudeTurnOutput> {
+  const runRes = completeTaskAgentCancellation(
+    started.progressContext,
+    'Claude Agent 运行已中断，跳过保存输出。',
+  );
+  if (!runRes.success) return runRes;
+  return success({
+    run: runRes.data,
+    providerSessionId:
+      state?.latestSessionId || started.binding.providerSessionId,
+    usedResume: started.usedResume,
+    assistantText: '',
+    structuredOutput: undefined,
+    outputArtifactIds: [],
   });
 }
 

--- a/packages/along/src/domain/task-codex-runner.test.ts
+++ b/packages/along/src/domain/task-codex-runner.test.ts
@@ -6,6 +6,7 @@ const planningMocks = vi.hoisted(() => ({
   ensureTaskAgentBinding: vi.fn(),
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
+  readTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
   recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock('./task-planning', () => ({
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
+  readTaskAgentRun: planningMocks.readTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
   recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
@@ -91,6 +93,20 @@ describe('task-codex-runner', () => {
         outputArtifactIds: ['art-result'],
         startedAt: '2026-01-01T00:00:00.000Z',
         endedAt: '2026-01-01T00:00:01.000Z',
+      },
+    });
+    planningMocks.readTaskAgentRun.mockReturnValue({
+      success: true,
+      data: {
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        provider: 'codex',
+        status: 'running',
+        inputArtifactIds: [],
+        outputArtifactIds: [],
+        startedAt: '2026-01-01T00:00:00.000Z',
       },
     });
     planningMocks.recordTaskAgentResult.mockReturnValue({

--- a/packages/along/src/domain/task-codex-runner.ts
+++ b/packages/along/src/domain/task-codex-runner.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy runner keeps provider orchestration together.
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy runner keeps provider orchestration together.
 import type { ThreadOptions } from '@openai/codex-sdk';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
@@ -6,8 +8,11 @@ import {
   writeTaskAgentProgress,
 } from './task-agent-progress';
 import {
+  completeTaskAgentCancellation,
   finishTaskAgentSuccess,
+  isTaskAgentRunCancelled,
   markTaskAgentFailed,
+  registerTaskAgentCancellation,
   type StartedTaskAgentRun,
   saveTaskAgentOutput,
   startTaskAgentRun,
@@ -102,9 +107,28 @@ async function runStartedCodexTurn(
     const promptRes = await prepareCodexPrompt(input, prompt, progressContext);
     if (!promptRes.success)
       return failCodexTurn(progressContext, promptRes.error, latestThreadId);
+    if (isTaskAgentRunCancelled(progressContext.runId)) {
+      return completeCancelledCodexTurn(
+        progressContext,
+        usedResume,
+        latestThreadId,
+      );
+    }
     thread = openCodexThread(input, progressContext, binding.providerSessionId);
-    const turn = await runCodexPrompt(thread, promptRes.data, outputSchema);
+    const turn = await runCodexPrompt(
+      progressContext.runId,
+      thread,
+      promptRes.data,
+      outputSchema,
+    );
     latestThreadId = thread.id || binding.providerSessionId;
+    if (isTaskAgentRunCancelled(progressContext.runId)) {
+      return completeCancelledCodexTurn(
+        progressContext,
+        usedResume,
+        latestThreadId,
+      );
+    }
     writeCodexTurnSessionEvents(progressContext, turn);
     return completeCodexTurn(
       input,
@@ -115,6 +139,13 @@ async function runStartedCodexTurn(
       latestThreadId,
     );
   } catch (error: unknown) {
+    if (isTaskAgentRunCancelled(progressContext.runId)) {
+      return completeCancelledCodexTurn(
+        progressContext,
+        usedResume,
+        thread?.id || latestThreadId,
+      );
+    }
     return failCodexTurn(progressContext, error, thread?.id || latestThreadId);
   } finally {
     stopHeartbeat();
@@ -195,12 +226,16 @@ function openCodexThread(
 }
 
 async function runCodexPrompt(
+  runId: string,
   thread: TaskCodexThread,
   prompt: string | TaskCodexInputItem[],
   outputSchema: unknown,
 ): Promise<TaskCodexTurn> {
   const timeoutMs = readCodexTurnTimeoutMs();
   const abortController = new AbortController();
+  const unregisterCancel = registerTaskAgentCancellation(runId, (reason) =>
+    abortController.abort(reason),
+  );
   let timedOut = false;
   const timeout = setTimeout(() => {
     timedOut = true;
@@ -214,6 +249,7 @@ async function runCodexPrompt(
     timeout,
     () => timedOut,
     timeoutMs,
+    unregisterCancel,
   );
 }
 
@@ -225,6 +261,7 @@ async function runCodexThreadWithTimeout(
   timeout: ReturnType<typeof setTimeout>,
   isTimedOut: () => boolean,
   timeoutMs: number,
+  unregisterCancel: () => void,
 ): Promise<TaskCodexTurn> {
   try {
     return await thread.run(prompt, {
@@ -240,8 +277,28 @@ async function runCodexThreadWithTimeout(
       },
     );
   } finally {
+    unregisterCancel();
     clearTimeout(timeout);
   }
+}
+
+function completeCancelledCodexTurn(
+  context: TaskAgentProgressContext,
+  usedResume: boolean,
+  latestThreadId?: string,
+): Result<RunTaskClaudeTurnOutput> {
+  const runRes = completeTaskAgentCancellation(
+    context,
+    'Codex Agent 运行已中断，跳过保存输出。',
+  );
+  if (!runRes.success) return runRes;
+  return success({
+    run: runRes.data,
+    providerSessionId: latestThreadId,
+    usedResume,
+    assistantText: '',
+    outputArtifactIds: [],
+  });
 }
 
 function completeCodexTurn(

--- a/packages/along/src/domain/task-implementation-agent.ts
+++ b/packages/along/src/domain/task-implementation-agent.ts
@@ -229,6 +229,12 @@ async function runConfirmedImplementation(input: {
   if (!result.success) {
     return rollbackToPlanningApproved(input.taskInput.taskId, result);
   }
+  if (result.data.run.status === 'cancelled') {
+    return rollbackToPlanningApproved(
+      input.taskInput.taskId,
+      failure('Implementation Agent Run 已取消'),
+    );
+  }
 
   return runAutoCommitLoop({
     taskInput: input.taskInput,

--- a/packages/along/src/domain/task-implementation-step-runner.ts
+++ b/packages/along/src/domain/task-implementation-step-runner.ts
@@ -1,4 +1,5 @@
 import { buildImplementationStepsPrompt } from '../agents/task-implementation';
+import { failure } from '../core/result';
 import { runTaskAgentTurn } from './task-agent-runtime';
 import type { RunTaskImplementationAgentInput } from './task-implementation-agent';
 import { IMPLEMENTATION_STEPS_KIND } from './task-implementation-steps';
@@ -13,7 +14,7 @@ export async function runImplementationStepsTurn(input: {
   approvedPlan: TaskPlanRevisionRecord;
   agentId: string;
 }) {
-  return runTaskAgentTurn({
+  const result = await runTaskAgentTurn({
     taskId: input.taskInput.taskId,
     threadId: input.snapshot.thread.threadId,
     agentId: input.agentId,
@@ -40,4 +41,8 @@ export async function runImplementationStepsTurn(input: {
       maxTurns: 20,
     },
   });
+  if (result.success && result.data.run.status === 'cancelled') {
+    return failure('Implementation Steps Agent Run 已取消');
+  }
+  return result;
 }

--- a/packages/along/src/domain/task-planning-agent.ts
+++ b/packages/along/src/domain/task-planning-agent.ts
@@ -160,6 +160,9 @@ export async function runTaskPlanningAgent(
     agentId,
   });
   if (!result.success) return result;
+  if (result.data.run.status === 'cancelled') {
+    return failure('Planner Agent Run 已取消');
+  }
 
   const parsed = parseTaskPlannerTurnOutput(result.data);
   if (!parsed.success) return parsed;

--- a/packages/along/src/domain/task-planning.test.ts
+++ b/packages/along/src/domain/task-planning.test.ts
@@ -76,6 +76,10 @@ const mockDbState = vi.hoisted(() => {
         if (normalized === 'SELECT * FROM task_items WHERE task_id = ?') {
           return findTask(String(args[0])) || null;
         }
+        if (normalized === 'SELECT task_id FROM task_items WHERE task_id = ?') {
+          const row = findTask(String(args[0]));
+          return row ? { task_id: row.task_id } : null;
+        }
         if (
           normalized ===
           'SELECT * FROM task_threads WHERE thread_id = ? AND task_id = ?'
@@ -114,6 +118,33 @@ const mockDbState = vi.hoisted(() => {
         }
         if (normalized === 'SELECT * FROM task_agent_runs WHERE run_id = ?') {
           return state.runs.find((row) => row.run_id === args[0]) || null;
+        }
+        if (
+          normalized.includes('FROM task_agent_runs') &&
+          normalized.includes('WHERE task_id = ? AND run_id = ? AND status = ?')
+        ) {
+          return (
+            state.runs.find(
+              (row) =>
+                row.task_id === args[0] &&
+                row.run_id === args[1] &&
+                row.status === args[2],
+            ) || null
+          );
+        }
+        if (
+          normalized.includes('FROM task_agent_runs') &&
+          normalized.includes('WHERE task_id = ? AND status = ?')
+        ) {
+          return (
+            state.runs
+              .filter(
+                (row) => row.task_id === args[0] && row.status === args[1],
+              )
+              .sort((left, right) =>
+                String(right.started_at).localeCompare(String(left.started_at)),
+              )[0] || null
+          );
         }
         if (
           normalized.includes('SELECT provider_session_id_at_end') &&
@@ -868,6 +899,7 @@ vi.mock('../core/db', () => ({
 import {
   AGENT_RUN_STATUS,
   approveCurrentTaskPlan,
+  cancelTaskAgentRun,
   closeTask,
   completeDeliveredTask,
   createPlanningTask,
@@ -1275,6 +1307,56 @@ describe('task-planning', () => {
     expect(closed.data.flow.blockers).not.toContain(
       '当前反馈轮次已打开，等待 Planner 处理你的补充反馈。',
     );
+  });
+
+  it('当取消当前 running agent 时，期望只取消 run 且不关闭 Task', () => {
+    const { taskId } = createTaskWithPlan();
+    const snapshot = readTaskPlanningSnapshot(taskId);
+    expect(snapshot.success).toBe(true);
+    if (!snapshot.success || !snapshot.data)
+      throw new Error('missing snapshot');
+    const run = createTaskAgentRun({
+      taskId,
+      threadId: snapshot.data.thread.threadId,
+      agentId: 'planner',
+      provider: 'codex',
+    });
+    expect(run.success).toBe(true);
+
+    const cancelled = cancelTaskAgentRun({
+      taskId,
+      reason: '用户中断',
+    });
+    expect(cancelled.success).toBe(true);
+    if (!cancelled.success) throw new Error(cancelled.error);
+
+    expect(cancelled.data.cancelled).toBe(true);
+    expect(cancelled.data.runId).toBe(run.success ? run.data.runId : '');
+    const refreshed = readTaskPlanningSnapshot(taskId);
+    expect(refreshed.success).toBe(true);
+    if (!refreshed.success || !refreshed.data)
+      throw new Error('missing refreshed snapshot');
+    expect(refreshed.data.task.lifecycle).not.toBe(TASK_LIFECYCLE.CANCELLED);
+    expect(refreshed.data.agentRuns[0].status).toBe(AGENT_RUN_STATUS.CANCELLED);
+    expect(
+      refreshed.data.agentProgressEvents.some(
+        (event) => event.phase === TASK_AGENT_PROGRESS_PHASE.CANCELLED,
+      ),
+    ).toBe(true);
+    expect(
+      refreshed.data.artifacts.some(
+        (artifact) => artifact.type === 'task_closed',
+      ),
+    ).toBe(false);
+  });
+
+  it('当没有 running agent 时，取消当前 agent 期望幂等返回 false', () => {
+    const { taskId } = createTaskWithPlan();
+    const cancelled = cancelTaskAgentRun({ taskId });
+    expect(cancelled.success).toBe(true);
+    if (!cancelled.success) throw new Error(cancelled.error);
+
+    expect(cancelled.data).toEqual({ cancelled: false });
   });
 
   it('当任务已关闭后继续推进流程时，期望拒绝且不改变 closed 状态', () => {

--- a/packages/along/src/domain/task-planning.ts
+++ b/packages/along/src/domain/task-planning.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy planning module predates current function-size rule.
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy planning module predates current file-size rule.
+// biome-ignore-all lint/style/noMagicNumbers: legacy planning module uses numeric limits throughout.
 import type { Database } from 'bun:sqlite';
 import crypto from 'node:crypto';
 import { iso_timestamp } from '../core/common';
@@ -487,6 +488,18 @@ export interface FinishTaskAgentRunInput {
   providerSessionIdAtEnd?: string;
   outputArtifactIds?: string[];
   error?: string;
+}
+
+export interface CancelTaskAgentRunInput {
+  taskId: string;
+  runId?: string;
+  reason?: string;
+}
+
+export interface CancelTaskAgentRunOutput {
+  cancelled: boolean;
+  runId?: string;
+  run?: TaskAgentRunRecord;
 }
 
 export interface RecordTaskAgentProgressInput {
@@ -4157,6 +4170,121 @@ export function createTaskAgentRun(
     const message = error instanceof Error ? error.message : String(error);
     return failure(`创建 Agent Run 失败: ${message}`);
   }
+}
+
+export function readTaskAgentRun(
+  runId: string,
+): Result<TaskAgentRunRecord | null> {
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+
+  try {
+    const row = dbRes.data
+      .prepare('SELECT * FROM task_agent_runs WHERE run_id = ?')
+      .get(runId) as TaskAgentRunRow | null;
+    return success(row ? mapRun(row) : null);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failure(`读取 Agent Run 失败: ${message}`);
+  }
+}
+
+function findCancelableTaskAgentRun(
+  db: Database,
+  input: CancelTaskAgentRunInput,
+): Result<TaskAgentRunRow | null> {
+  const taskRow = db
+    .prepare('SELECT task_id FROM task_items WHERE task_id = ?')
+    .get(input.taskId) as TaskIdRow | null;
+  if (!taskRow) return failure(`Task 不存在: ${input.taskId}`);
+
+  const row = input.runId
+    ? (db
+        .prepare(
+          `
+            SELECT * FROM task_agent_runs
+            WHERE task_id = ? AND run_id = ? AND status = ?
+            LIMIT 1
+          `,
+        )
+        .get(
+          input.taskId,
+          input.runId,
+          AGENT_RUN_STATUS.RUNNING,
+        ) as TaskAgentRunRow | null)
+    : (db
+        .prepare(
+          `
+            SELECT * FROM task_agent_runs
+            WHERE task_id = ? AND status = ?
+            ORDER BY started_at DESC
+            LIMIT 1
+          `,
+        )
+        .get(input.taskId, AGENT_RUN_STATUS.RUNNING) as TaskAgentRunRow | null);
+  return success(row);
+}
+
+function recordTaskAgentCancelledProgress(
+  run: TaskAgentRunRecord,
+  reason?: string,
+): Result<void> {
+  const detail = reason?.trim() || undefined;
+  const summary = 'Agent 运行已被用户中断。';
+  const progressRes = recordTaskAgentProgress({
+    runId: run.runId,
+    taskId: run.taskId,
+    threadId: run.threadId,
+    agentId: run.agentId,
+    provider: run.provider,
+    phase: TASK_AGENT_PROGRESS_PHASE.CANCELLED,
+    summary,
+    detail,
+  });
+  if (!progressRes.success) return failure(progressRes.error);
+
+  const sessionRes = recordTaskAgentSessionEvent({
+    runId: run.runId,
+    taskId: run.taskId,
+    threadId: run.threadId,
+    agentId: run.agentId,
+    provider: run.provider,
+    source: 'system',
+    kind: 'progress',
+    content: detail ? `${summary}\n${detail}` : summary,
+    metadata: { phase: TASK_AGENT_PROGRESS_PHASE.CANCELLED },
+  });
+  return sessionRes.success ? success(undefined) : failure(sessionRes.error);
+}
+
+export function cancelTaskAgentRun(
+  input: CancelTaskAgentRunInput,
+): Result<CancelTaskAgentRunOutput> {
+  const dbRes = getDb();
+  if (!dbRes.success) return dbRes;
+
+  const rowRes = findCancelableTaskAgentRun(dbRes.data, input);
+  if (!rowRes.success) return rowRes;
+  if (!rowRes.data) return success({ cancelled: false });
+
+  const runningRun = mapRun(rowRes.data);
+  const progressRes = recordTaskAgentCancelledProgress(
+    runningRun,
+    input.reason,
+  );
+  if (!progressRes.success) return progressRes;
+
+  const finishRes = finishTaskAgentRun({
+    runId: runningRun.runId,
+    status: AGENT_RUN_STATUS.CANCELLED,
+    error: input.reason,
+  });
+  if (!finishRes.success) return finishRes;
+  return success({
+    cancelled: finishRes.data.status === AGENT_RUN_STATUS.CANCELLED,
+    runId: finishRes.data.runId,
+    run: finishRes.data,
+  });
 }
 
 export function finishTaskAgentRun(

--- a/packages/along/src/domain/task-spawn-command.ts
+++ b/packages/along/src/domain/task-spawn-command.ts
@@ -1,13 +1,17 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { config, type EditorConfig } from '../core/config';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
+
+const SPAWN_CANCEL_KILL_GRACE_MS = 3000;
 
 export interface TaskAgentSpawnCommand {
   command: string;
   args: string[];
   cwd: string;
   stdin?: string;
+  abortSignal?: AbortSignal;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
 }
@@ -32,6 +36,16 @@ export interface TaskSpawnCommandInput {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function terminateSpawnProcess(proc: ChildProcessWithoutNullStreams) {
+  if (proc.killed) return;
+  proc.kill('SIGTERM');
+  const timer = setTimeout(() => {
+    if (!proc.killed) proc.kill('SIGKILL');
+  }, SPAWN_CANCEL_KILL_GRACE_MS);
+  timer.unref?.();
+  proc.once('close', () => clearTimeout(timer));
 }
 
 export function getTaskAgentEditor(editorId: string): Result<EditorConfig> {
@@ -83,6 +97,9 @@ export async function defaultTaskAgentSpawnRunner(
       cwd: command.cwd,
       env: process.env,
     });
+    const abort = () => terminateSpawnProcess(proc);
+    if (command.abortSignal?.aborted) abort();
+    command.abortSignal?.addEventListener('abort', abort, { once: true });
 
     let stdout = '';
     let stderr = '';
@@ -97,9 +114,11 @@ export async function defaultTaskAgentSpawnRunner(
       command.onStderr?.(chunk);
     });
     proc.on('error', (error) => {
+      command.abortSignal?.removeEventListener('abort', abort);
       resolve(failure(getErrorMessage(error)));
     });
     proc.on('close', (exitCode) => {
+      command.abortSignal?.removeEventListener('abort', abort);
       resolve(success({ exitCode: exitCode ?? 1, stdout, stderr }));
     });
     proc.stdin?.on('error', () => {});

--- a/packages/along/src/domain/task-spawn-runner.test.ts
+++ b/packages/along/src/domain/task-spawn-runner.test.ts
@@ -5,6 +5,7 @@ const planningMocks = vi.hoisted(() => ({
   ensureTaskAgentBinding: vi.fn(),
   createTaskAgentRun: vi.fn(),
   finishTaskAgentRun: vi.fn(),
+  readTaskAgentRun: vi.fn(),
   recordTaskAgentProgress: vi.fn(),
   recordTaskAgentSessionEvent: vi.fn(),
   recordTaskAgentResult: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('./task-planning', () => ({
   ensureTaskAgentBinding: planningMocks.ensureTaskAgentBinding,
   createTaskAgentRun: planningMocks.createTaskAgentRun,
   finishTaskAgentRun: planningMocks.finishTaskAgentRun,
+  readTaskAgentRun: planningMocks.readTaskAgentRun,
   recordTaskAgentProgress: planningMocks.recordTaskAgentProgress,
   recordTaskAgentSessionEvent: planningMocks.recordTaskAgentSessionEvent,
   recordTaskAgentResult: planningMocks.recordTaskAgentResult,
@@ -88,6 +90,20 @@ describe('task-spawn-runner', () => {
         outputArtifactIds: ['art-result'],
         startedAt: '2026-01-01T00:00:00.000Z',
         endedAt: '2026-01-01T00:00:01.000Z',
+      },
+    });
+    planningMocks.readTaskAgentRun.mockReturnValue({
+      success: true,
+      data: {
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'implementer',
+        provider: 'pi',
+        status: 'running',
+        inputArtifactIds: [],
+        outputArtifactIds: [],
+        startedAt: '2026-01-01T00:00:00.000Z',
       },
     });
     planningMocks.recordTaskAgentResult.mockReturnValue({

--- a/packages/along/src/domain/task-spawn-runner.ts
+++ b/packages/along/src/domain/task-spawn-runner.ts
@@ -7,8 +7,11 @@ import {
   writeTaskAgentSessionEvent,
 } from './task-agent-progress';
 import {
+  completeTaskAgentCancellation,
   finishTaskAgentSuccess,
+  isTaskAgentRunCancelled,
   markTaskAgentFailed,
+  registerTaskAgentCancellation,
   type StartedTaskAgentRun,
   saveTaskAgentOutput,
   startTaskAgentRun,
@@ -86,25 +89,31 @@ export async function runTaskSpawnTurn(
   );
 }
 
-function runPreparedSpawnCommand(
+async function runPreparedSpawnCommand(
   input: RunTaskSpawnTurnInput,
   command: TaskAgentSpawnCommand,
   editor: EditorConfig,
   started: StartedTaskAgentRun,
   runner: TaskAgentSpawnRunner,
-) {
+): Promise<Result<RunTaskClaudeTurnOutput>> {
   const stopHeartbeat = startSpawnHeartbeat(started, editor.name, command.cwd);
+  const abortController = new AbortController();
+  const unregisterCancel = registerTaskAgentCancellation(
+    started.run.runId,
+    (reason) => abortController.abort(reason),
+  );
   try {
     const streamState = { seen: false };
-    return executeSpawnTurn(
+    return await executeSpawnTurn(
       input,
-      command,
+      { ...command, abortSignal: abortController.signal },
       editor,
       started,
       runner,
       streamState,
     );
   } finally {
+    unregisterCancel();
     stopHeartbeat();
   }
 }
@@ -169,6 +178,9 @@ async function executeSpawnTurn(
   const executionRes = await runner(
     withSessionStreamCallbacks(command, started.progressContext, streamState),
   );
+  if (isTaskAgentRunCancelled(started.run.runId)) {
+    return completeCancelledSpawnTurn(started);
+  }
   if (!executionRes.success) {
     return failSpawnTurn(
       started.progressContext,
@@ -244,6 +256,23 @@ function finishSpawnExecution(
     usedResume: started.usedResume,
     assistantText,
     outputArtifactIds: outputRes.data,
+  });
+}
+
+function completeCancelledSpawnTurn(
+  started: StartedTaskAgentRun,
+): Result<RunTaskClaudeTurnOutput> {
+  const runRes = completeTaskAgentCancellation(
+    started.progressContext,
+    '外部 Agent 运行已中断，跳过保存输出。',
+  );
+  if (!runRes.success) return runRes;
+  return success({
+    run: runRes.data,
+    providerSessionId: started.binding.providerSessionId,
+    usedResume: started.usedResume,
+    assistantText: '',
+    outputArtifactIds: [],
   });
 }
 

--- a/packages/along/src/integration/task-api-handlers.ts
+++ b/packages/along/src/integration/task-api-handlers.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy API handler file keeps related route handlers together.
+// biome-ignore-all lint/style/noMagicNumbers: legacy API handler uses HTTP status literals throughout.
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
+import { requestTaskAgentCancellation } from '../domain/task-agent-run-lifecycle';
 import type { TaskAttachmentUploadInput } from '../domain/task-attachments';
 import {
   areImplementationStepsApproved,
@@ -9,6 +11,7 @@ import {
 import {
   approveCurrentTaskPlan,
   approveTaskImplementationSteps,
+  cancelTaskAgentRun,
   closeTask,
   completeDeliveredTask,
   completeTaskAgentStageManually,
@@ -212,6 +215,57 @@ export async function handleTaskCloseRequest(
   const closeRes = closeTask(taskId, readStringField(bodyRes.data, 'reason'));
   if (!closeRes.success) return errorResponse(closeRes.error, 409);
   return jsonResponse({ taskId, snapshot: closeRes.data });
+}
+
+export async function handleTaskCancelAgentRequest(
+  req: Request,
+  taskId: string,
+): Promise<Response> {
+  const bodyRes = await readOptionalJsonObject(req);
+  if (!bodyRes.success) return errorResponse(bodyRes.error, 400);
+
+  const existing = readTaskPlanningSnapshot(taskId);
+  if (!existing.success) return errorResponse(existing.error, 500);
+  if (!existing.data) return errorResponse(`Task 不存在: ${taskId}`, 404);
+
+  const cancelRes = cancelTaskAgentRun({
+    taskId,
+    runId: readStringField(bodyRes.data, 'runId'),
+    reason: readStringField(bodyRes.data, 'reason'),
+  });
+  if (!cancelRes.success) return errorResponse(cancelRes.error, 409);
+  if (cancelRes.data.runId) {
+    requestTaskAgentCancellation(
+      cancelRes.data.runId,
+      readStringField(bodyRes.data, 'reason'),
+    );
+  }
+
+  const snapshotRes = readTaskPlanningSnapshot(taskId);
+  if (!snapshotRes.success) return errorResponse(snapshotRes.error, 500);
+  return jsonResponse({
+    taskId,
+    cancelled: cancelRes.data.cancelled,
+    runId: cancelRes.data.runId,
+    snapshot: snapshotRes.data || existing.data,
+  });
+}
+
+async function readOptionalJsonObject(
+  req: Request,
+): Promise<Result<UnknownRecord>> {
+  try {
+    const raw = await req.text();
+    if (!raw.trim()) return success({});
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+      ? success(parsed as UnknownRecord)
+      : failure('请求体必须是 JSON 对象');
+  } catch {
+    return failure('请求体必须是合法 JSON');
+  }
 }
 
 export async function handleTaskPlannerRequest(

--- a/packages/along/src/integration/task-api-scheduling.test.ts
+++ b/packages/along/src/integration/task-api-scheduling.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/noMagicNumbers: tests assert HTTP status codes directly.
 import { beforeEach, expect, it, vi } from 'vitest';
 import { handleTaskApiRequest } from './task-api';
 import {
@@ -17,6 +18,7 @@ import {
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
   approveTaskImplementationSteps: vi.fn(),
   approveCurrentTaskPlan: vi.fn(),
+  cancelTaskAgentRun: vi.fn(),
   closeTask: vi.fn(),
   completeDeliveredTask: vi.fn(),
   completeTaskAgentStageManually: vi.fn(),
@@ -61,6 +63,7 @@ vi.mock('../domain/task-planning', () => ({
   WORKFLOW_KIND: mockTaskConstants.WORKFLOW_KIND,
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  cancelTaskAgentRun: planningMocks.cancelTaskAgentRun,
   closeTask: planningMocks.closeTask,
   completeDeliveredTask: planningMocks.completeDeliveredTask,
   completeTaskAgentStageManually: planningMocks.completeTaskAgentStageManually,

--- a/packages/along/src/integration/task-api.test-utils.ts
+++ b/packages/along/src/integration/task-api.test-utils.ts
@@ -35,6 +35,7 @@ export const TEST_PLAN_STATUS = {
 export type PlanningMocks = {
   approveTaskImplementationSteps: PlanningMock;
   approveCurrentTaskPlan: PlanningMock;
+  cancelTaskAgentRun: PlanningMock;
   closeTask: PlanningMock;
   completeDeliveredTask: PlanningMock;
   completeTaskAgentStageManually: PlanningMock;
@@ -79,11 +80,34 @@ export function resetPlanningMocks(planningMocks: PlanningMocks) {
   vi.clearAllMocks();
   mockTaskReads(planningMocks);
   mockTaskMessage(planningMocks);
+  mockTaskAgentCancellation(planningMocks);
   mockPlanApproval(planningMocks);
   mockTaskClose(planningMocks);
   mockImplementationStepsApproval(planningMocks);
   mockManualComplete(planningMocks);
   mockDeliveredComplete(planningMocks);
+}
+
+function mockTaskAgentCancellation(planningMocks: PlanningMocks) {
+  planningMocks.cancelTaskAgentRun.mockReturnValue({
+    success: true,
+    data: {
+      cancelled: true,
+      runId: 'run-1',
+      run: {
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'planner',
+        provider: 'codex',
+        status: 'cancelled',
+        inputArtifactIds: [],
+        outputArtifactIds: [],
+        startedAt: '2026-01-01T00:00:00.000Z',
+        endedAt: '2026-01-01T00:00:01.000Z',
+      },
+    },
+  });
 }
 
 function mockImplementationStepsApproval(planningMocks: PlanningMocks) {

--- a/packages/along/src/integration/task-api.test.ts
+++ b/packages/along/src/integration/task-api.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/noMagicNumbers: tests assert HTTP status codes and binary fixtures directly.
 import { beforeEach, expect, it, vi } from 'vitest';
 import { handleTaskApiRequest, isTaskApiPath } from './task-api';
 import {
@@ -11,6 +12,7 @@ import {
 const planningMocks: PlanningMocks = vi.hoisted(() => ({
   approveTaskImplementationSteps: vi.fn(),
   approveCurrentTaskPlan: vi.fn(),
+  cancelTaskAgentRun: vi.fn(),
   closeTask: vi.fn(),
   completeDeliveredTask: vi.fn(),
   completeTaskAgentStageManually: vi.fn(),
@@ -20,6 +22,9 @@ const planningMocks: PlanningMocks = vi.hoisted(() => ({
   readTaskPlanningSnapshot: vi.fn(),
   requestTaskPlan: vi.fn(),
   submitTaskMessage: vi.fn(),
+}));
+const lifecycleMocks = vi.hoisted(() => ({
+  requestTaskAgentCancellation: vi.fn(),
 }));
 
 const cleanupMocks = vi.hoisted(() => ({
@@ -48,6 +53,7 @@ vi.mock('../domain/task-planning', () => ({
   },
   approveTaskImplementationSteps: planningMocks.approveTaskImplementationSteps,
   approveCurrentTaskPlan: planningMocks.approveCurrentTaskPlan,
+  cancelTaskAgentRun: planningMocks.cancelTaskAgentRun,
   closeTask: planningMocks.closeTask,
   completeDeliveredTask: planningMocks.completeDeliveredTask,
   completeTaskAgentStageManually: planningMocks.completeTaskAgentStageManually,
@@ -59,11 +65,18 @@ vi.mock('../domain/task-planning', () => ({
   submitTaskMessage: planningMocks.submitTaskMessage,
 }));
 
+vi.mock('../domain/task-agent-run-lifecycle', () => ({
+  requestTaskAgentCancellation: lifecycleMocks.requestTaskAgentCancellation,
+}));
+
 vi.mock('../domain/cleanup-utils', () => ({
   cleanupIssue: cleanupMocks.cleanupIssue,
 }));
 
 beforeEach(() => resetPlanningMocks(planningMocks));
+beforeEach(() => {
+  lifecycleMocks.requestTaskAgentCancellation.mockReturnValue(true);
+});
 beforeEach(() => {
   cleanupMocks.cleanupIssue.mockResolvedValue({
     success: true,
@@ -275,6 +288,112 @@ it('当 multipart 追加用户消息带图片时，期望附件传给消息层',
       }),
     ],
   });
+});
+
+it('当取消当前 running agent 时，期望返回最新 snapshot 并请求中断句柄', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/cancel-agent', {
+      reason: '用户中断',
+    }),
+    new URL('http://localhost/api/tasks/task-1/cancel-agent'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as {
+    taskId: string;
+    cancelled: boolean;
+    runId?: string;
+    snapshot: typeof snapshot;
+  };
+
+  expect(response.status).toBe(200);
+  expect(payload.taskId).toBe('task-1');
+  expect(payload.cancelled).toBe(true);
+  expect(payload.runId).toBe('run-1');
+  expect(planningMocks.cancelTaskAgentRun).toHaveBeenCalledWith({
+    taskId: 'task-1',
+    runId: undefined,
+    reason: '用户中断',
+  });
+  expect(lifecycleMocks.requestTaskAgentCancellation).toHaveBeenCalledWith(
+    'run-1',
+    '用户中断',
+  );
+  expect(payload.snapshot.task.lifecycle).toBe('open');
+  expect(planningMocks.closeTask).not.toHaveBeenCalled();
+});
+
+it('当指定 runId 取消 agent 时，期望 runId 传给领域层', async () => {
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/cancel-agent', {
+      runId: 'run-target',
+    }),
+    new URL('http://localhost/api/tasks/task-1/cancel-agent'),
+    { defaultCwd: '/tmp/default' },
+  );
+
+  expect(response.status).toBe(200);
+  expect(planningMocks.cancelTaskAgentRun).toHaveBeenCalledWith({
+    taskId: 'task-1',
+    runId: 'run-target',
+    reason: undefined,
+  });
+});
+
+it('当没有 running agent 时，取消接口期望幂等返回 cancelled=false', async () => {
+  planningMocks.cancelTaskAgentRun.mockReturnValueOnce({
+    success: true,
+    data: { cancelled: false },
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/task-1/cancel-agent', {}),
+    new URL('http://localhost/api/tasks/task-1/cancel-agent'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as {
+    cancelled: boolean;
+    runId?: string;
+  };
+
+  expect(response.status).toBe(200);
+  expect(payload.cancelled).toBe(false);
+  expect(payload.runId).toBeUndefined();
+  expect(lifecycleMocks.requestTaskAgentCancellation).not.toHaveBeenCalled();
+});
+
+it('当取消 agent 未提供请求体时，期望按取消最新 running run 处理', async () => {
+  const response = await handleTaskApiRequest(
+    new Request('http://localhost/api/tasks/task-1/cancel-agent', {
+      method: 'POST',
+    }),
+    new URL('http://localhost/api/tasks/task-1/cancel-agent'),
+    { defaultCwd: '/tmp/default' },
+  );
+
+  expect(response.status).toBe(200);
+  expect(planningMocks.cancelTaskAgentRun).toHaveBeenCalledWith({
+    taskId: 'task-1',
+    runId: undefined,
+    reason: undefined,
+  });
+});
+
+it('当取消不存在 Task 的 agent 时，期望返回 404', async () => {
+  planningMocks.readTaskPlanningSnapshot.mockReturnValueOnce({
+    success: true,
+    data: null,
+  });
+
+  const response = await handleTaskApiRequest(
+    jsonRequest('/api/tasks/missing/cancel-agent', {}),
+    new URL('http://localhost/api/tasks/missing/cancel-agent'),
+    { defaultCwd: '/tmp/default' },
+  );
+  const payload = (await response.json()) as { error: string };
+
+  expect(response.status).toBe(404);
+  expect(payload.error).toBe('Task 不存在: missing');
+  expect(planningMocks.cancelTaskAgentRun).not.toHaveBeenCalled();
 });
 
 it('当批准 Task Plan 时，期望不再调度 planner', async () => {

--- a/packages/along/src/integration/task-api.ts
+++ b/packages/along/src/integration/task-api.ts
@@ -1,7 +1,9 @@
+// biome-ignore-all lint/style/noMagicNumbers: API router uses HTTP status literals.
 import type { TaskPlanningSnapshot } from '../domain/task-planning';
 import {
   handleTaskApproveRequest,
   handleTaskAttachmentRequest,
+  handleTaskCancelAgentRequest,
   handleTaskCloseRequest,
   handleTaskCompleteRequest,
   handleTaskCreateRequest,
@@ -67,6 +69,7 @@ type TaskActionHandler = (
 
 const ACTION_ROUTES: Record<string, TaskActionHandler> = {
   approve: (_req, taskId) => handleTaskApproveRequest(taskId),
+  'cancel-agent': (req, taskId) => handleTaskCancelAgentRequest(req, taskId),
   close: (req, taskId) => handleTaskCloseRequest(req, taskId),
   complete: (_req, taskId, context) =>
     handleTaskCompleteRequest(taskId, context),


### PR DESCRIPTION
along-task: #26

## 修改内容
- `packages/along-web/src/TaskPlanningView.tsx`
- `packages/along-web/src/task-planning/ExistingTaskComposer.tsx`
- `packages/along-web/src/task-planning/TaskComposerInput.tsx`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/api.ts`
- `packages/along-web/src/task-planning/flowActionRouter.test.ts`
- `packages/along-web/src/task-planning/flowActionRouter.ts`
- `packages/along-web/src/task-planning/useTaskPlanningActions.ts`
- `packages/along/src/commands/webhook-server.ts`
- `packages/along/src/domain/task-agent-run-lifecycle.ts`
- `packages/along/src/domain/task-claude-runner.test.ts`
- `packages/along/src/domain/task-claude-runner.ts`
- `packages/along/src/domain/task-codex-runner.test.ts`
- `packages/along/src/domain/task-codex-runner.ts`
- `packages/along/src/domain/task-implementation-agent.ts`
- `packages/along/src/domain/task-implementation-step-runner.ts`
- `packages/along/src/domain/task-planning-agent.ts`
- `packages/along/src/domain/task-planning.test.ts`
- `packages/along/src/domain/task-planning.ts`
- `packages/along/src/domain/task-spawn-command.ts`
- `packages/along/src/domain/task-spawn-runner.test.ts`
- `packages/along/src/domain/task-spawn-runner.ts`
- `packages/along/src/integration/task-api-handlers.ts`
- `packages/along/src/integration/task-api-scheduling.test.ts`
- `packages/along/src/integration/task-api.test-utils.ts`
- `packages/along/src/integration/task-api.test.ts`
- `packages/along/src/integration/task-api.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/task-26`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立且值得做：Enter 发送符合聊天产品直觉；组合键换行能保留长文本输入能力；运行中提供中断入口能降低 agent 卡住或误触发后的等待成本。第三点必须按“取消当前 agent run”实现，不能只把按钮改成 loading，因为当前前端 busyAction 只代表一次 HTTP 请求中，不能代表后端 agent 正在运行。

Summary
按“输入区保持可编辑，运行中发送按钮变为中断按钮”的方案实现。无运行中 agent 时，Enter 发送消息，Ctrl/Alt/Shift+Enter 换行；中文输入法 composition 期间不触发送。存在当前 Task 的 running agent run 时，按钮显示旋转中断态，点击取消最新 running run；此时 Enter 不触发发送或取消，避免误中断。

Mermaid
flowchart TD
  A[用户在聊天框输入] --> B{当前 Task 是否有 running agent run}
  B -- 否 --> C{按键}
  C -- Enter 且非 composition --> D[提交消息]
  C -- Ctrl/Alt/Shift + Enter --> E[插入换行]
  B -- 是 --> F[按钮显示旋转中断态]
  F --> G[点击按钮]
  G --> H[POST /api/tasks/:taskId/cancel-agent]
  H --> I[后端调用当前 run 的取消句柄]
  I --> J[run 标记为 cancelled 并写入 cancelled progress]
  J --> K[返回最新 snapshot，前端恢复可继续输入]

Contracts / Interfaces
新增 POST /api/tasks/:taskId/cancel-agent。请求体可选：runId、reason。未传 runId 时取消该 Task 最新的 running run。返回：taskId、cancelled、runId、snapshot。Task 不存在返回 404；没有 running run 时返回 200 且 cancelled=false，并返回最新 snapshot，保证前端轮询竞态下点击取消是幂等的。

Implementation Changes
1. 前端 TaskComposerInput 增加 textarea keydown 语义：Enter 直接提交；Ctrl/Alt/Shift+Enter 保持浏览器默认换行；composition 输入期间不提交；空草稿仍按现有 submitDisabled 规则禁止发送。
2. 前端 running 状态不再使用 busyAction 推断，而从 selected snapshot 的 agentRuns 或 agentStages 中取最新 status=running 的 run。ExistingTaskComposer 将 runningRun 传给输入组件；按钮在 running 时显示 animate-spin 的中断态，title/aria-label 改为“中断当前 Agent”。
3. 前端新增 cancelAgentRun action：点击 running 按钮调用 /cancel-agent，成功后应用返回 snapshot；失败显示现有错误栏。运行中保持输入框和附件选择可编辑，但发送相关禁用逻辑改为“不能发送新消息，只能显式点击按钮中断”。
4. 后端新增 cancel-agent 路由和领域函数：查找目标 running run，写入 cancelled progress，调用 finishTaskAgentRun(status=cancelled)，不关闭 Task，不写 task_closed artifact，不把 Task lifecycle 改成 cancelled。
5. 后端 runner 增加运行中取消注册表，按 runId 注册取消句柄并在 finally 清理。Claude 使用 SDK Options.abortController；Codex 复用并外置当前 AbortController；spawn runner 保存 ChildProcess，先 SIGTERM，超时后 SIGKILL。取消触发后 runner 不再保存成功输出，不触发 autonomous continuation。
6. 调度层在 runner 返回后检查 run 是否已 cancelled；已取消时只记录简短日志并跳过后续自动推进，避免取消后继续进入 implementation 或 delivery。

Test Plan
1. 为 TaskComposerInput 增加组件测试：Enter 发送、Ctrl/Alt/Shift+Enter 换行、composition 期间不发送、running 时 Enter 不发送且按钮点击走取消。
2. 为 useTaskPlanningActions 增加 action 测试：cancel-agent 请求成功后应用 snapshot，失败时写入 error。
3. 为 Task API 增加 cancel-agent 测试：取消最新 running run、指定 runId、无 running run 幂等返回、Task 不存在返回 404，并确认不关闭 Task。
4. 为 Claude/Codex/spawn runner 增加取消测试：触发取消句柄后 run 状态为 cancelled，progress phase 为 cancelled，成功输出不落库，调度层不继续 autonomous continuation。
5. 执行相关包的单元测试和类型检查；若全量测试耗时过长，至少跑 along-web task-planning 测试、along task-api/runner 测试和 TypeScript 检查。

Assumptions
采用前述建议：运行中输入区保持可编辑，按钮承担中断动作；取消 agent run 不等于关闭 Task，用户可继续补充消息或重新触发后续流程。不做旧快捷键兼容，因为当前没有明确的已发布快捷键契约。

## 交付信息
- Commit: 427d5e3b40c44e0ef627a5d992917d67a68a5e42