### PR TITLE
Task #27: 沿Web左侧UI调整

### DIFF
--- a/packages/along-web/src/TaskPlanningView.test.tsx
+++ b/packages/along-web/src/TaskPlanningView.test.tsx
@@ -1,0 +1,13 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { TaskPlanningView } from './TaskPlanningView';
+
+describe('TaskPlanningView', () => {
+  it('默认使用更窄左侧栏并提供折叠入口', () => {
+    const html = renderToStaticMarkup(<TaskPlanningView />);
+
+    expect(html).toContain('xl:grid-cols-[320px_minmax(0,1fr)]');
+    expect(html).toContain('aria-label="折叠左侧栏"');
+    expect(html).toContain('&lt;');
+  });
+});

--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -1,17 +1,79 @@
+import { useState } from 'react';
 import { TaskDetail } from './task-planning/TaskDetail';
-import { RepositorySelector, TaskListPanel } from './task-planning/TaskSidebar';
+import { TaskListPanel } from './task-planning/TaskSidebar';
 import { useTaskPlanningController } from './task-planning/useTaskPlanningController';
 
 type TaskPlanningController = ReturnType<typeof useTaskPlanningController>;
 
-function TaskPlanningSidebar({
-  taskPlanning,
+const SIDEBAR_COLLAPSE_ICON = '<';
+const SIDEBAR_EXPAND_ICON = '>';
+
+function SidebarToggleButton({
+  ariaLabel,
+  children,
+  className,
+  onClick,
 }: {
-  taskPlanning: TaskPlanningController;
+  ariaLabel: string;
+  children: string;
+  className: string;
+  onClick: () => void;
 }) {
   return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={className}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CollapsedSidebar({
+  onToggleCollapsed,
+}: {
+  onToggleCollapsed: () => void;
+}) {
+  return (
+    <div className="min-h-0 xl:h-full border-b xl:border-b-0 xl:border-r border-border-color flex xl:flex-col items-center justify-end xl:justify-start gap-2 bg-bg-glass p-2">
+      <SidebarToggleButton
+        ariaLabel="展开左侧栏"
+        onClick={onToggleCollapsed}
+        className="h-9 w-9 rounded-lg border border-border-color text-text-secondary hover:bg-white/5"
+      >
+        {SIDEBAR_EXPAND_ICON}
+      </SidebarToggleButton>
+    </div>
+  );
+}
+
+function TaskPlanningSidebar({
+  collapsed,
+  onToggleCollapsed,
+  taskPlanning,
+}: {
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  taskPlanning: TaskPlanningController;
+}) {
+  if (collapsed) {
+    return <CollapsedSidebar onToggleCollapsed={onToggleCollapsed} />;
+  }
+
+  return (
     <div className="min-h-[360px] xl:min-h-0 xl:h-full border-b xl:border-b-0 xl:border-r border-border-color flex flex-col bg-bg-glass">
-      <RepositorySelector
+      <div className="shrink-0 px-4 pt-3 flex justify-end">
+        <SidebarToggleButton
+          ariaLabel="折叠左侧栏"
+          onClick={onToggleCollapsed}
+          className="h-8 w-8 rounded-lg border border-border-color text-text-secondary hover:bg-white/5"
+        >
+          {SIDEBAR_COLLAPSE_ICON}
+        </SidebarToggleButton>
+      </div>
+      <TaskListPanel
         draft={taskPlanning.draft}
         repositories={taskPlanning.repositories}
         selectedRepository={taskPlanning.selectedRepository}
@@ -19,8 +81,6 @@ function TaskPlanningSidebar({
         error={taskPlanning.error}
         onDraftChange={taskPlanning.updateDraft}
         onRefreshRepositories={taskPlanning.refreshRepositories}
-      />
-      <TaskListPanel
         tasks={taskPlanning.tasks}
         loading={taskPlanning.loading}
         selectedTaskId={taskPlanning.selected?.task.taskId}
@@ -66,10 +126,21 @@ function TaskPlanningMain({
 
 export function TaskPlanningView() {
   const taskPlanning = useTaskPlanningController();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
-    <div className="flex-1 min-h-0 grid grid-cols-1 xl:grid-cols-[420px_minmax(0,1fr)] border-t border-border-color overflow-auto xl:overflow-hidden">
-      <TaskPlanningSidebar taskPlanning={taskPlanning} />
+    <div
+      className={`flex-1 min-h-0 grid grid-cols-1 ${
+        sidebarCollapsed
+          ? 'xl:grid-cols-[56px_minmax(0,1fr)]'
+          : 'xl:grid-cols-[320px_minmax(0,1fr)]'
+      } border-t border-border-color overflow-auto xl:overflow-hidden`}
+    >
+      <TaskPlanningSidebar
+        collapsed={sidebarCollapsed}
+        onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
+        taskPlanning={taskPlanning}
+      />
       <TaskPlanningMain taskPlanning={taskPlanning} />
     </div>
   );

--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import type { TaskPlanningSnapshot } from '../types';
+import type { RepositoryOption } from './api';
 import {
   TASK_LEGACY_STATUS_COLORS,
   TASK_STATUS_COLOR_STYLES,
@@ -83,15 +84,38 @@ function makeSnapshot(
   };
 }
 
+const repositories: RepositoryOption[] = [
+  {
+    fullName: 'ranwawa/along',
+    owner: 'ranwawa',
+    repo: 'along',
+    path: '/workspace/along',
+    isDefault: true,
+  },
+];
+
 function renderPanel(
   overrides: Partial<Parameters<typeof TaskListPanel>[0]> = {},
 ): string {
   return renderToStaticMarkup(
     <TaskListPanel
+      draft={{
+        repository: 'ranwawa/along',
+        title: '',
+        body: '',
+        attachments: [],
+        executionMode: 'manual',
+      }}
+      repositories={repositories}
+      selectedRepository={repositories[0]}
+      repositoriesRefreshing={false}
+      error={null}
       tasks={[makeSnapshot()]}
       loading={false}
       selectedTaskId={undefined}
       isNewTaskOpen={false}
+      onDraftChange={() => undefined}
+      onRefreshRepositories={() => undefined}
       onNewTask={() => undefined}
       onSelect={() => undefined}
       {...overrides}
@@ -209,8 +233,25 @@ describe('TaskListPanel', () => {
     const emptyHtml = renderPanel({ tasks: [] });
 
     expect(selectedHtml).toContain('bg-white/10');
+    expect(selectedHtml).toContain('aria-label="新任务"');
     expect(selectedHtml).toContain('新任务');
+    expect(selectedHtml).toContain('>+</button>');
+    expect(selectedHtml).not.toContain('>任务列表<');
+    expect(selectedHtml).not.toContain('>1</span>');
     expect(loadingHtml).toContain('加载中...');
     expect(emptyHtml).toContain('暂无任务。');
+  });
+
+  it('在列表头部展示仓库下拉和刷新入口，不使用原生 title', () => {
+    const html = renderPanel();
+
+    expect(html).toContain('aria-label="仓库"');
+    expect(html).toContain('ranwawa/along');
+    expect(html).toContain('/workspace/along');
+    expect(html).toContain('刷新');
+    expect(html).toContain('role="tooltip"');
+    expect(html).not.toContain('主入口');
+    expect(html).not.toContain('title="/workspace/along"');
+    expect(html).not.toContain('title="新任务"');
   });
 });

--- a/packages/along-web/src/task-planning/TaskSidebar.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.tsx
@@ -1,8 +1,35 @@
+import type { ReactNode } from 'react';
 import type { TaskPlanningSnapshot } from '../types';
 import type { DraftTaskInput, RepositoryOption } from './api';
 import { TaskStatusBadge } from './TaskStatusBadge';
 
-export function RepositorySelector({
+const EMPTY_REPOSITORY_LABEL = '暂无已注册仓库';
+const LOADING_TASKS_TEXT = '加载中...';
+const EMPTY_TASKS_TEXT = '暂无任务。';
+const NEW_TASK_ICON = '+';
+const TASK_SEQ_PREFIX = '#';
+
+function PopupTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className="relative inline-flex group">
+      {children}
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-[calc(100%+6px)] z-20 whitespace-nowrap rounded-md border border-border-color bg-bg-secondary px-2 py-1 text-xs text-text-secondary opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function RepositoryControls({
   draft,
   repositories,
   selectedRepository,
@@ -20,19 +47,16 @@ export function RepositorySelector({
   onRefreshRepositories: () => void;
 }) {
   return (
-    <div className="shrink-0 p-4 md:p-5 border-b border-border-color flex flex-col gap-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="font-semibold text-sm md:text-base">仓库</div>
-        <span className="text-xs text-text-muted">主入口</span>
-      </div>
+    <div className="min-w-0 flex-1 flex flex-col gap-2">
       <div className="flex gap-2">
         <select
+          aria-label="仓库"
           value={draft.repository}
           onChange={(event) => onDraftChange('repository', event.target.value)}
           className="min-w-0 flex-1 bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
         >
           {repositories.length === 0 ? (
-            <option value="">暂无已注册仓库</option>
+            <option value="">{EMPTY_REPOSITORY_LABEL}</option>
           ) : (
             repositories.map((repository) => (
               <option key={repository.fullName} value={repository.fullName}>
@@ -52,10 +76,7 @@ export function RepositorySelector({
         </button>
       </div>
       {selectedRepository && (
-        <div
-          className="text-xs text-text-muted truncate"
-          title={selectedRepository.path}
-        >
+        <div className="text-xs text-text-muted truncate">
           {selectedRepository.path}
         </div>
       )}
@@ -69,91 +90,169 @@ export function RepositorySelector({
 }
 
 export function TaskListPanel({
+  draft,
+  repositories,
+  selectedRepository,
+  repositoriesRefreshing,
+  error,
   tasks,
   loading,
   selectedTaskId,
   isNewTaskOpen,
+  onDraftChange,
+  onRefreshRepositories,
   onNewTask,
   onSelect,
 }: {
+  draft: DraftTaskInput;
+  repositories: RepositoryOption[];
+  selectedRepository?: RepositoryOption;
+  repositoriesRefreshing: boolean;
+  error: string | null;
   tasks: TaskPlanningSnapshot[];
   loading: boolean;
   selectedTaskId?: string;
   isNewTaskOpen: boolean;
+  onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onRefreshRepositories: () => void;
   onNewTask: () => void;
   onSelect: (snapshot: TaskPlanningSnapshot) => void;
 }) {
   return (
     <>
       <TaskListHeader
-        taskCount={tasks.length}
+        draft={draft}
+        repositories={repositories}
+        selectedRepository={selectedRepository}
+        repositoriesRefreshing={repositoriesRefreshing}
+        error={error}
         isNewTaskOpen={isNewTaskOpen}
+        onDraftChange={onDraftChange}
+        onRefreshRepositories={onRefreshRepositories}
         onNewTask={onNewTask}
       />
-      <div className="flex-1 min-h-0 overflow-auto">
-        {loading && tasks.length === 0 ? (
-          <div className="p-5 text-text-muted text-sm">加载中...</div>
-        ) : tasks.length === 0 ? (
-          <div className="p-5 text-text-muted text-sm">暂无任务。</div>
-        ) : (
-          tasks.map((snapshot) => (
-            <button
-              type="button"
-              key={snapshot.task.taskId}
-              onClick={() => onSelect(snapshot)}
-              className={`w-full text-left px-4 md:px-5 py-2.5 border-b border-white/5 hover:bg-white/5 transition-colors ${
-                selectedTaskId === snapshot.task.taskId
-                  ? 'bg-white/10'
-                  : 'bg-transparent'
-              }`}
-            >
-              <div className="flex items-center justify-between gap-3 min-w-0">
-                <div className="min-w-0 flex-1 font-medium text-sm truncate">
-                  {snapshot.task.seq != null && (
-                    <span className="text-text-muted mr-1">
-                      #{snapshot.task.seq}
-                    </span>
-                  )}
-                  {snapshot.task.title}
-                </div>
-                <div className="shrink-0 whitespace-nowrap">
-                  <TaskStatusBadge snapshot={snapshot} />
-                </div>
-              </div>
-            </button>
-          ))
-        )}
-      </div>
+      <TaskListContent
+        tasks={tasks}
+        loading={loading}
+        selectedTaskId={selectedTaskId}
+        onSelect={onSelect}
+      />
     </>
   );
 }
 
+function TaskListContent({
+  tasks,
+  loading,
+  selectedTaskId,
+  onSelect,
+}: {
+  tasks: TaskPlanningSnapshot[];
+  loading: boolean;
+  selectedTaskId?: string;
+  onSelect: (snapshot: TaskPlanningSnapshot) => void;
+}) {
+  return (
+    <div className="flex-1 min-h-0 overflow-auto">
+      {loading && tasks.length === 0 ? (
+        <div className="p-5 text-text-muted text-sm">{LOADING_TASKS_TEXT}</div>
+      ) : tasks.length === 0 ? (
+        <div className="p-5 text-text-muted text-sm">{EMPTY_TASKS_TEXT}</div>
+      ) : (
+        tasks.map((snapshot) => (
+          <TaskListItem
+            key={snapshot.task.taskId}
+            snapshot={snapshot}
+            selected={selectedTaskId === snapshot.task.taskId}
+            onSelect={onSelect}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function TaskListItem({
+  snapshot,
+  selected,
+  onSelect,
+}: {
+  snapshot: TaskPlanningSnapshot;
+  selected: boolean;
+  onSelect: (snapshot: TaskPlanningSnapshot) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(snapshot)}
+      className={`w-full text-left px-4 md:px-5 py-2.5 border-b border-white/5 hover:bg-white/5 transition-colors ${
+        selected ? 'bg-white/10' : 'bg-transparent'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3 min-w-0">
+        <div className="min-w-0 flex-1 font-medium text-sm truncate">
+          {snapshot.task.seq != null && (
+            <span className="text-text-muted mr-1">
+              {TASK_SEQ_PREFIX}
+              {snapshot.task.seq}
+            </span>
+          )}
+          {snapshot.task.title}
+        </div>
+        <div className="shrink-0 whitespace-nowrap">
+          <TaskStatusBadge snapshot={snapshot} />
+        </div>
+      </div>
+    </button>
+  );
+}
+
 function TaskListHeader({
-  taskCount,
+  draft,
+  repositories,
+  selectedRepository,
+  repositoriesRefreshing,
+  error,
   isNewTaskOpen,
+  onDraftChange,
+  onRefreshRepositories,
   onNewTask,
 }: {
-  taskCount: number;
+  draft: DraftTaskInput;
+  repositories: RepositoryOption[];
+  selectedRepository?: RepositoryOption;
+  repositoriesRefreshing: boolean;
+  error: string | null;
   isNewTaskOpen: boolean;
+  onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
+  onRefreshRepositories: () => void;
   onNewTask: () => void;
 }) {
   return (
-    <div className="px-4 md:px-5 py-3 border-b border-border-color flex items-center justify-between gap-3">
-      <div className="min-w-0 flex items-center gap-2">
-        <span className="text-sm font-semibold">任务列表</span>
-        <span className="text-xs text-text-muted">{taskCount}</span>
-      </div>
-      <button
-        type="button"
-        onClick={onNewTask}
-        className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
-          isNewTaskOpen
-            ? 'bg-brand text-white border-brand'
-            : 'border-border-color text-text-secondary hover:bg-white/5'
-        }`}
-      >
-        新任务
-      </button>
+    <div className="px-4 py-3 border-b border-border-color flex items-start gap-2">
+      <RepositoryControls
+        draft={draft}
+        repositories={repositories}
+        selectedRepository={selectedRepository}
+        repositoriesRefreshing={repositoriesRefreshing}
+        error={error}
+        onDraftChange={onDraftChange}
+        onRefreshRepositories={onRefreshRepositories}
+      />
+      <PopupTooltip label="新任务">
+        <button
+          type="button"
+          aria-label="新任务"
+          onClick={onNewTask}
+          className={`shrink-0 h-9 w-9 rounded-lg text-lg leading-none font-semibold border transition-colors ${
+            isNewTaskOpen
+              ? 'bg-brand text-white border-brand'
+              : 'border-border-color text-text-secondary hover:bg-white/5'
+          }`}
+        >
+          {NEW_TASK_ICON}
+        </button>
+      </PopupTooltip>
     </div>
   );
 }

--- a/packages/along-web/src/task-planning/useTaskPlanningState.test.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningState.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RepositoryOption } from './api';
+import {
+  LAST_TASK_REPOSITORY_KEY,
+  readLastRepository,
+  resolveInitialRepository,
+  writeLastRepository,
+} from './useTaskPlanningState';
+
+const repositories: RepositoryOption[] = [
+  {
+    fullName: 'ranwawa/along',
+    owner: 'ranwawa',
+    repo: 'along',
+    path: '/workspace/along',
+    isDefault: true,
+  },
+  {
+    fullName: 'ranwawa/site',
+    owner: 'ranwawa',
+    repo: 'site',
+    path: '/workspace/site',
+    isDefault: false,
+  },
+];
+
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+  });
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('resolveInitialRepository', () => {
+  it('有效缓存优先于服务端默认仓库', () => {
+    expect(
+      resolveInitialRepository(repositories, 'ranwawa/along', 'ranwawa/site'),
+    ).toBe('ranwawa/site');
+  });
+
+  it('缓存仓库不存在时回退到默认仓库', () => {
+    expect(
+      resolveInitialRepository(repositories, 'ranwawa/along', 'missing/repo'),
+    ).toBe('ranwawa/along');
+  });
+
+  it('写入和读取上次选择的仓库', () => {
+    const store = stubLocalStorage();
+
+    writeLastRepository('ranwawa/site');
+
+    expect(store.get(LAST_TASK_REPOSITORY_KEY)).toBe('ranwawa/site');
+    expect(readLastRepository()).toBe('ranwawa/site');
+  });
+});

--- a/packages/along-web/src/task-planning/useTaskPlanningState.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningState.ts
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import type { TaskPlanningSnapshot } from '../types';
@@ -17,8 +18,53 @@ import {
   sortTaskSnapshotsBySeqDesc,
 } from './api';
 
+export const LAST_TASK_REPOSITORY_KEY = 'along-web:last-task-repository';
+const TASK_POLLING_INTERVAL_MS = 3000;
+
 function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+export function readLastRepository() {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(LAST_TASK_REPOSITORY_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function writeLastRepository(repository: string) {
+  if (!repository || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LAST_TASK_REPOSITORY_KEY, repository);
+  } catch {
+    // localStorage can be disabled; selection still works for the current page.
+  }
+}
+
+function isKnownRepository(
+  repository: string,
+  repositories: RepositoryOption[],
+) {
+  return repositories.some((option) => option.fullName === repository);
+}
+
+export function resolveInitialRepository(
+  repositories: RepositoryOption[],
+  defaultRepository?: string,
+  cachedRepository = readLastRepository(),
+) {
+  const repositoryNames = new Set(
+    repositories.map((repository) => repository.fullName),
+  );
+  if (cachedRepository && repositoryNames.has(cachedRepository)) {
+    return cachedRepository;
+  }
+  if (defaultRepository && repositoryNames.has(defaultRepository)) {
+    return defaultRepository;
+  }
+  return repositories[0]?.fullName || '';
 }
 
 export function useTaskState() {
@@ -47,21 +93,41 @@ export function useTaskState() {
 
 export function useRepositories() {
   const [repositories, setRepositories] = useState<RepositoryOption[]>([]);
+  const repositoriesRef = useRef<RepositoryOption[]>([]);
   const [draft, setDraft] = useState<DraftTaskInput>(emptyDraft);
+  const setDraftWithRepositoryCache: Dispatch<SetStateAction<DraftTaskInput>> =
+    useCallback((value) => {
+      setDraft((previous) => {
+        const next = typeof value === 'function' ? value(previous) : value;
+        if (isKnownRepository(next.repository, repositoriesRef.current)) {
+          writeLastRepository(next.repository);
+        }
+        return next;
+      });
+    }, []);
   const loadRepositories = useCallback(async () => {
     const response = await fetch('/api/repositories');
     const result = await readJsonResponse<RepositoryListResponse>(response);
+    repositoriesRef.current = result.repositories;
     setRepositories(result.repositories);
-    setDraft((previous) => {
+    setDraftWithRepositoryCache((previous) => {
       if (previous.repository) return previous;
       return {
         ...previous,
-        repository:
-          result.defaultRepository || result.repositories[0]?.fullName || '',
+        repository: resolveInitialRepository(
+          result.repositories,
+          result.defaultRepository,
+        ),
       };
     });
-  }, []);
-  return { repositories, setRepositories, draft, setDraft, loadRepositories };
+  }, [setDraftWithRepositoryCache]);
+  return {
+    repositories,
+    setRepositories,
+    draft,
+    setDraft: setDraftWithRepositoryCache,
+    loadRepositories,
+  };
 }
 
 export type TaskLoaderInput = {
@@ -185,7 +251,7 @@ export function useTaskPolling(
       .finally(() => active && setLoading(false));
     const timer = setInterval(() => {
       loadTasks().catch((err: unknown) => setError(getErrorMessage(err)));
-    }, 3000);
+    }, TASK_POLLING_INTERVAL_MS);
     return () => {
       active = false;
       clearInterval(timer);
@@ -207,7 +273,7 @@ export function useSelectedTaskPolling(
         if (active) setError(getErrorMessage(err));
       });
     refresh();
-    const timer = setInterval(refresh, 3000);
+    const timer = setInterval(refresh, TASK_POLLING_INTERVAL_MS);
     return () => {
       active = false;
       clearInterval(timer);


### PR DESCRIPTION
along-task: #27

## 修改内容
- `packages/along-web/src/TaskPlanningView.test.tsx`
- `packages/along-web/src/TaskPlanningView.tsx`
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/TaskSidebar.tsx`
- `packages/along-web/src/task-planning/useTaskPlanningState.test.ts`
- `packages/along-web/src/task-planning/useTaskPlanningState.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/webui-27`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立，属于 along-web 任务规划页左侧信息架构收敛：当前 `TaskPlanningView` 左侧宽度为 420px，顶部是 `RepositorySelector` 主入口模块，下面 `TaskListPanel` 头部展示“任务列表 + 数量 + 新任务”。用户希望保留核心任务导航能力，但降低左侧占宽和视觉噪音。该改动符合产品目标，工程风险主要在仓库选择状态、任务轮询依赖 selectedRepository，以及折叠后仍需可恢复操作。

Summary
将任务规划页左侧栏改成更紧凑的可折叠侧栏：移除顶部仓库主入口模块；移除“任务列表”和任务小计文案；在原任务列表头部位置放置仓库下拉框、刷新入口和新任务 `+` 图标；仓库选择写入本地缓存，下次进入优先恢复；侧栏默认宽度从约 420px 缩小到约 320px，并支持快速折叠/展开。

Mermaid
flowchart LR
  View[TaskPlanningView] --> Sidebar[TaskPlanningSidebar]
  Sidebar --> Header[紧凑侧栏头部]
  Header --> RepoSelect[仓库下拉框]
  Header --> Refresh[刷新仓库]
  Header --> NewTask[+ 新任务 popup tooltip]
  Header --> Collapse[折叠/展开]
  Sidebar --> TaskItems[任务列表项]
  RepoSelect --> LocalStorage[本地缓存 last repository]
  RepoSelect --> Controller[useTaskPlanningController]
  Controller --> LoadTasks[按 selectedRepository 加载任务]
  Sidebar --> Main[TaskDetail]

Implementation Changes
1. 调整 `packages/along-web/src/TaskPlanningView.tsx`：左侧容器增加折叠状态，桌面默认列宽从 `420px` 缩到约 `320px`；折叠态改为窄列，仅保留展开按钮和必要入口，不渲染任务列表内容；移动端仍保持可用的纵向布局，不让折叠按钮遮挡主内容。
2. 重构 `packages/along-web/src/task-planning/TaskSidebar.tsx`：删除当前 `RepositorySelector` 的顶部主入口视觉模块；删除 `TaskListHeader` 中“任务列表”和数量展示；新增紧凑头部，把仓库下拉框放到原任务列表头部区域，并保留刷新仓库能力。
3. 新任务按钮改为图标按钮：显示 `+`，点击仍调用现有 `openNewTask`；hover/focus 使用项目内 popup/浮层实现 tooltip 文案“新任务”，不使用原生 `title` 属性。若仓库里没有现成 popup 组件，则在 along-web 内实现一个轻量、可访问的本地 Tooltip 组件，支持鼠标悬停和键盘聚焦。
4. 仓库本地缓存放在 `useRepositories` 所在状态层处理：读取固定 key，例如 `along-web:last-task-repository`；加载仓库列表后优先使用缓存值，但仅当缓存仓库仍存在于 API 返回列表时生效；否则回退到服务端 defaultRepository 或第一个仓库。用户切换仓库时同步写入缓存；选择空值或仓库不可用时不写入无效值。
5. 任务数据流保持不变：`selectedRepository` 仍由 draft.repository 派生，`loadTasks` 继续按 owner/repo 请求 `/api/tasks`；切换仓库后沿用现有清空草稿和重载任务的行为，不新增向下兼容逻辑。
6. 视觉边界：折叠态必须能一键展开；展开态必须能一键折叠；仓库路径提示不要继续依赖 `title`，可改为小号文本或 popup，避免和“不要使用 title”要求冲突。

Contracts / Interfaces
- 不改后端 API。
- 不改 `DraftTaskInput.repository` 的含义，仍使用 repository fullName。
- 新增 localStorage key 只影响浏览器本地偏好，不写入服务端，不影响不同用户或不同浏览器。
- Tooltip/popup 不使用 HTML `title` 属性；若状态徽标现有测试仍覆盖 `title`，本任务只处理新任务按钮和本次触达的仓库路径提示，是否统一替换状态徽标 title 可另行评估。

Test Plan
1. 更新 `TaskSidebar.test.tsx`：断言不再出现“任务列表”和任务数量文案；断言新任务按钮展示 `+` 且存在 popup/tooltip 文案“新任务”；断言空态、加载态、选中态仍可用。
2. 为仓库缓存补充 hook/controller 单元测试：有有效缓存时优先选中缓存仓库；缓存仓库不存在时回退默认仓库；用户切换仓库会写入 localStorage。
3. 补充或更新 `TaskPlanningView` 渲染测试：展开态默认较窄，折叠按钮可切换侧栏内容可见性。
4. 执行 along-web 相关测试与类型检查，至少覆盖 `TaskSidebar`、`useTaskPlanningController/useTaskPlanningState` 相关测试；若本地环境无法完整跑通，需要说明失败命令、原因和残余风险。

Assumptions
- “去掉任务列表+任务小计模块”理解为去掉任务列表头部的标题和数量小计，不删除实际任务列表项；否则用户将无法从左侧切换历史任务。
- “顶部主入口整个模块”指现有顶部仓库选择卡片式区域，而不是删除仓库选择能力本身。
- “缩小100px左右”按桌面左侧栏 420px 调整到约 320px 执行。

## 交付信息
- Commit: e322a923a60dc727db67cc847c9211c448b0a665