### PR TITLE
Task #28: Agent实时输出问题分析与解决

### DIFF
--- a/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.test.tsx
@@ -93,6 +93,7 @@ describe('TaskProgressPanel progress event', () => {
         agentProgressEvents: [makeProgressEvent({ detail: '运行局部测试。' })],
       }),
     );
+    expect(html).toContain('Along 编排状态');
     expect(html).toContain('正在执行命令');
     expect(html).toContain('运行局部测试');
   });
@@ -138,7 +139,46 @@ describe('TaskProgressPanel session tail', () => {
       }),
     );
     expect(html).toContain('Agent 会话 Tail');
+    expect(html).toContain('Codex 实时输出');
     expect(html).toContain('正在修改 TaskProgressPanel');
+  });
+
+  it('渲染 Codex 多来源会话事件', () => {
+    const html = renderPanel(
+      makeSnapshot({
+        agentSessionEvents: [
+          makeSessionEvent({
+            eventId: 'sess-system',
+            source: 'system',
+            kind: 'progress',
+            content: 'Codex 已开始处理本轮请求。',
+          }),
+          makeSessionEvent({
+            eventId: 'sess-tool',
+            source: 'tool',
+            kind: 'message',
+            content: '开始执行命令。',
+          }),
+          makeSessionEvent({
+            eventId: 'sess-stdout',
+            source: 'stdout',
+            kind: 'output',
+            content: 'test passed',
+          }),
+          makeSessionEvent({
+            eventId: 'sess-stderr',
+            source: 'stderr',
+            kind: 'error',
+            content: 'command failed',
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('System / codex');
+    expect(html).toContain('Tool / codex');
+    expect(html).toContain('stdout / codex');
+    expect(html).toContain('stderr / codex');
+    expect(html).toContain('command failed');
   });
 
   it('运行中但无会话输出时渲染可观测提示', () => {
@@ -147,7 +187,7 @@ describe('TaskProgressPanel session tail', () => {
         agentRuns: [makeRunningRun()],
       }),
     );
-    expect(html).toContain('正在等待第一条会话输出');
+    expect(html).toContain('正在等待第一条 Codex 实时输出');
   });
 });
 
@@ -181,5 +221,24 @@ function makeRunningRun(): TaskPlanningSnapshot['agentRuns'][number] {
     inputArtifactIds: [],
     outputArtifactIds: [],
     startedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeSessionEvent(
+  overrides: Partial<TaskPlanningSnapshot['agentSessionEvents'][number]>,
+): TaskPlanningSnapshot['agentSessionEvents'][number] {
+  return {
+    eventId: 'sess-1',
+    runId: 'run-1',
+    taskId: 'task-1',
+    threadId: 'thread-1',
+    agentId: 'implementer',
+    provider: 'codex',
+    source: 'agent',
+    kind: 'output',
+    content: '正在处理。',
+    metadata: {},
+    createdAt: '2026-01-01T00:04:50.000Z',
+    ...overrides,
   };
 }

--- a/packages/along-web/src/task-planning/TaskProgressPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.tsx
@@ -13,7 +13,27 @@ import {
 
 const RECENT_PROGRESS_LIMIT = 8;
 const RECENT_SESSION_LIMIT = 40;
-const STALE_PROGRESS_MS = 2 * 60 * 1000;
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const STALE_PROGRESS_MINUTES = 2;
+const STALE_PROGRESS_MS =
+  STALE_PROGRESS_MINUTES * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
+const SESSION_QUIET_SECONDS = 2 * SECONDS_PER_MINUTE;
+const TEXT_PROGRESS_TITLE = '实时进展';
+const TEXT_ORCHESTRATION_STATE = 'Along 编排状态';
+const TEXT_SESSION_TAIL_TITLE = 'Agent 会话 Tail';
+
+function formatCount(count: number): string {
+  return `${count} 条`;
+}
+
+function formatHiddenProgressCount(count: number): string {
+  return `已折叠较早 ${count} 条进展。`;
+}
+
+function formatHiddenSessionCount(count: number): string {
+  return `已折叠较早 ${count} 条会话。`;
+}
 
 function sortProgressEvents(events: TaskAgentProgressEventRecord[]) {
   return [...events].sort((left, right) =>
@@ -42,7 +62,7 @@ function getLatestRunningRun(
 function getRelativeSeconds(value: string, nowMs: number): number | null {
   const time = new Date(value).getTime();
   if (Number.isNaN(time) || nowMs < time) return null;
-  return Math.round((nowMs - time) / 1000);
+  return Math.round((nowMs - time) / MILLISECONDS_PER_SECOND);
 }
 
 function formatRelativeTime(value: string, nowMs: number): string {
@@ -57,7 +77,10 @@ function formatRelativeTime(value: string, nowMs: number): string {
 function formatDurationToNow(startedAt: string, nowMs: number): string {
   const started = new Date(startedAt).getTime();
   if (Number.isNaN(started) || nowMs < started) return '-';
-  const totalSeconds = Math.max(1, Math.round((nowMs - started) / 1000));
+  const totalSeconds = Math.max(
+    1,
+    Math.round((nowMs - started) / MILLISECONDS_PER_SECOND),
+  );
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   if (minutes === 0) return `${seconds}s`;
@@ -91,7 +114,7 @@ function buildSessionQuietHint(input: {
     return 'Agent 仍在执行，但当前暂无可展示会话信息。';
   }
   const seconds = getRelativeSeconds(input.latestEvent.createdAt, input.nowMs);
-  if (seconds === null || seconds < 120) return null;
+  if (seconds === null || seconds < SESSION_QUIET_SECONDS) return null;
   return `最近一条会话在 ${formatRelativeTime(
     input.latestEvent.createdAt,
     input.nowMs,
@@ -214,15 +237,20 @@ function SessionTail({
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
           <div className="text-sm font-semibold text-text-secondary">
-            Agent 会话 Tail
+            {TEXT_SESSION_TAIL_TITLE}
           </div>
           <div className="mt-1 text-xs text-text-muted">
             {latestEvent
-              ? `最近更新 ${formatRelativeTime(latestEvent.createdAt, nowMs)}`
-              : '暂无可展示会话信息'}
+              ? `Codex 实时输出，最近更新 ${formatRelativeTime(
+                  latestEvent.createdAt,
+                  nowMs,
+                )}`
+              : '暂无 Codex 实时输出'}
           </div>
         </div>
-        <span className="text-xs text-text-muted">{events.length} 条</span>
+        <span className="text-xs text-text-muted">
+          {formatCount(events.length)}
+        </span>
       </div>
       {quietHint && (
         <div className="mb-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-200">
@@ -231,14 +259,14 @@ function SessionTail({
       )}
       {hiddenCount > 0 && (
         <div className="mb-2 text-xs text-text-muted">
-          已折叠较早 {hiddenCount} 条会话。
+          {formatHiddenSessionCount(hiddenCount)}
         </div>
       )}
       {visibleEvents.length === 0 ? (
         <div className="rounded-md border border-border-color bg-black/25 px-3 py-3 text-sm text-text-muted">
           {runningRun
-            ? 'Agent 已开始运行，正在等待第一条会话输出。'
-            : '暂无可展示会话信息。'}
+            ? 'Agent 已开始运行，正在等待第一条 Codex 实时输出。'
+            : '暂无 Codex 实时输出。'}
         </div>
       ) : (
         <ol className="flex max-h-[520px] flex-col gap-2 overflow-auto pr-1">
@@ -285,7 +313,7 @@ function ProgressEventsPanel({
       )}
       {hiddenCount > 0 && (
         <div className="mb-2 text-xs text-text-muted">
-          已折叠较早 {hiddenCount} 条进展。
+          {formatHiddenProgressCount(hiddenCount)}
         </div>
       )}
       <ol className="flex flex-col gap-2">
@@ -316,8 +344,17 @@ export function TaskProgressPanel({
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
-        <h3 className="text-sm font-semibold text-text-secondary">实时进展</h3>
-        <span className="text-xs text-text-muted">{events.length} 条</span>
+        <div>
+          <h3 className="text-sm font-semibold text-text-secondary">
+            {TEXT_PROGRESS_TITLE}
+          </h3>
+          <div className="mt-1 text-xs text-text-muted">
+            {TEXT_ORCHESTRATION_STATE}
+          </div>
+        </div>
+        <span className="text-xs text-text-muted">
+          {formatCount(events.length)}
+        </span>
       </div>
 
       <ProgressEventsPanel

--- a/packages/along/src/domain/task-codex-runner.test.ts
+++ b/packages/along/src/domain/task-codex-runner.test.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy runner tests use large shared mock setup.
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy runner test file predates current file-size rule.
+import type { ThreadEvent } from '@openai/codex-sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const planningMocks = vi.hoisted(() => ({
@@ -48,7 +49,35 @@ vi.mock('./task-attachment-read', () => ({
   resolveInputImageAttachments: attachmentMocks.resolveInputImageAttachments,
 }));
 
+import { requestTaskAgentCancellation } from './task-agent-run-lifecycle';
 import { runTaskCodexTurn } from './task-codex-runner';
+
+async function* streamEvents(
+  events: ThreadEvent[],
+): AsyncGenerator<ThreadEvent> {
+  for (const event of events) yield event;
+}
+
+function makeCompletedStream(
+  threadId: string,
+  text: string,
+  usage = {
+    input_tokens: 1,
+    cached_input_tokens: 0,
+    output_tokens: 1,
+    reasoning_output_tokens: 0,
+  },
+): ThreadEvent[] {
+  return [
+    { type: 'thread.started', thread_id: threadId },
+    { type: 'turn.started' },
+    {
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agent_message', text },
+    },
+    { type: 'turn.completed', usage },
+  ];
+}
 
 describe('task-codex-runner', () => {
   beforeEach(() => {
@@ -172,10 +201,8 @@ describe('task-codex-runner', () => {
     });
     const thread = {
       id: 'codex-thread-1',
-      run: vi.fn().mockResolvedValue({
-        finalResponse: '完成',
-        items: [],
-        usage: null,
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents(makeCompletedStream('codex-thread-1', '完成')),
       }),
     };
     const client = {
@@ -194,7 +221,7 @@ describe('task-codex-runner', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(thread.run).toHaveBeenCalledWith(
+    expect(thread.runStreamed).toHaveBeenCalledWith(
       [
         { type: 'text', text: '看图生成计划' },
         { type: 'local_image', path: '/tmp/screen.png' },
@@ -215,10 +242,13 @@ describe('task-codex-runner', () => {
   it('使用 Codex SDK 新建 thread 并保存结构化输出', async () => {
     const thread = {
       id: 'codex-thread-1',
-      run: vi.fn().mockResolvedValue({
-        finalResponse: '{"action":"plan_revision","body":"计划"}',
-        items: [],
-        usage: null,
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents(
+          makeCompletedStream(
+            'codex-thread-1',
+            '{"action":"plan_revision","body":"计划"}',
+          ),
+        ),
       }),
     };
     const client = {
@@ -252,7 +282,7 @@ describe('task-codex-runner', () => {
         approvalPolicy: 'never',
       }),
     );
-    expect(thread.run).toHaveBeenCalledWith(
+    expect(thread.runStreamed).toHaveBeenCalledWith(
       '生成计划',
       expect.objectContaining({
         outputSchema: { type: 'object' },
@@ -272,6 +302,306 @@ describe('task-codex-runner', () => {
     );
   });
 
+  it('消费 runStreamed 事件并把 Codex 实时输出写入会话 Tail', async () => {
+    const thread = {
+      id: 'codex-thread-1',
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents([
+          { type: 'thread.started', thread_id: 'codex-thread-1' },
+          { type: 'turn.started' },
+          {
+            type: 'item.started',
+            item: {
+              id: 'cmd-1',
+              type: 'command_execution',
+              command: 'bun test',
+              aggregated_output: '',
+              status: 'in_progress',
+            },
+          },
+          {
+            type: 'item.updated',
+            item: {
+              id: 'cmd-1',
+              type: 'command_execution',
+              command: 'bun test',
+              aggregated_output: 'pass',
+              status: 'in_progress',
+            },
+          },
+          {
+            type: 'item.updated',
+            item: {
+              id: 'cmd-1',
+              type: 'command_execution',
+              command: 'bun test',
+              aggregated_output: 'pass\nall',
+              status: 'in_progress',
+            },
+          },
+          {
+            type: 'item.completed',
+            item: {
+              id: 'cmd-1',
+              type: 'command_execution',
+              command: 'bun test',
+              aggregated_output: 'pass\nall',
+              status: 'completed',
+              exit_code: 0,
+            },
+          },
+          {
+            type: 'item.updated',
+            item: { id: 'msg-1', type: 'agent_message', text: '完成' },
+          },
+          {
+            type: 'item.updated',
+            item: { id: 'msg-1', type: 'agent_message', text: '完成实现' },
+          },
+          {
+            type: 'item.completed',
+            item: { id: 'msg-1', type: 'agent_message', text: '完成实现' },
+          },
+          {
+            type: 'turn.completed',
+            usage: {
+              input_tokens: 10,
+              cached_input_tokens: 1,
+              output_tokens: 5,
+              reasoning_output_tokens: 2,
+            },
+          },
+        ]),
+      }),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const result = await runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.assistantText).toBe('完成实现');
+    expect(planningMocks.recordTaskAgentProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'waiting',
+        summary: 'Codex 已开始处理本轮请求。',
+      }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'system',
+        kind: 'message',
+        content: 'Codex thread 已连接。',
+        metadata: expect.objectContaining({
+          provider_event_type: 'thread.started',
+          thread_id: 'codex-thread-1',
+        }),
+      }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'stdout',
+        kind: 'output',
+        content: 'pass',
+        metadata: expect.objectContaining({
+          provider_event_type: 'item.updated',
+          item_id: 'cmd-1',
+          delta_mode: 'delta',
+        }),
+      }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'stdout',
+        kind: 'output',
+        content: '\nall',
+      }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent',
+        kind: 'output',
+        content: '实现',
+        metadata: expect.objectContaining({
+          provider_event_type: 'item.updated',
+          item_type: 'agent_message',
+          delta_mode: 'delta',
+        }),
+      }),
+    );
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Codex turn 已完成。',
+        metadata: expect.objectContaining({
+          provider_event_type: 'turn.completed',
+          usage: expect.objectContaining({ input_tokens: 10 }),
+        }),
+      }),
+    );
+  });
+
+  it('当 item.updated 不是前缀增长时写 snapshot 并标记 metadata', async () => {
+    const thread = {
+      id: 'codex-thread-1',
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents([
+          { type: 'thread.started', thread_id: 'codex-thread-1' },
+          { type: 'turn.started' },
+          {
+            type: 'item.updated',
+            item: { id: 'msg-1', type: 'agent_message', text: '旧内容' },
+          },
+          {
+            type: 'item.updated',
+            item: { id: 'msg-1', type: 'agent_message', text: '重排后内容' },
+          },
+          {
+            type: 'item.completed',
+            item: { id: 'msg-1', type: 'agent_message', text: '重排后内容' },
+          },
+          {
+            type: 'turn.completed',
+            usage: {
+              input_tokens: 1,
+              cached_input_tokens: 0,
+              output_tokens: 1,
+              reasoning_output_tokens: 0,
+            },
+          },
+        ]),
+      }),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const result = await runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+    });
+
+    expect(result.success).toBe(true);
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent',
+        kind: 'output',
+        content: '重排后内容',
+        metadata: expect.objectContaining({
+          provider_event_type: 'item.updated',
+          item_id: 'msg-1',
+          delta_mode: 'snapshot',
+        }),
+      }),
+    );
+  });
+
+  it('当 Codex stream 返回 turn.failed 时写 Tail 错误并标记 run 失败', async () => {
+    const thread = {
+      id: 'codex-thread-1',
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents([
+          { type: 'thread.started', thread_id: 'codex-thread-1' },
+          {
+            type: 'turn.failed',
+            error: { message: 'provider unavailable' },
+          },
+        ]),
+      }),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const result = await runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+    });
+
+    expect(result.success).toBe(false);
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'system',
+        kind: 'error',
+        content: 'Codex turn 失败：provider unavailable',
+        metadata: expect.objectContaining({
+          provider_event_type: 'turn.failed',
+        }),
+      }),
+    );
+    expect(planningMocks.finishTaskAgentRun).toHaveBeenCalledWith({
+      runId: 'run-1',
+      status: 'failed',
+      providerSessionIdAtEnd: 'codex-thread-1',
+      error: 'provider unavailable',
+    });
+  });
+
+  it('当 Codex stream 返回 error 时写 Tail 错误并标记 run 失败', async () => {
+    const thread = {
+      id: 'codex-thread-1',
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents([
+          { type: 'thread.started', thread_id: 'codex-thread-1' },
+          {
+            type: 'error',
+            message: 'stream disconnected',
+          },
+        ]),
+      }),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const result = await runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+    });
+
+    expect(result.success).toBe(false);
+    expect(planningMocks.recordTaskAgentSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'system',
+        kind: 'error',
+        content: 'Codex stream 错误：stream disconnected',
+        metadata: expect.objectContaining({
+          provider_event_type: 'error',
+        }),
+      }),
+    );
+    expect(planningMocks.finishTaskAgentRun).toHaveBeenCalledWith({
+      runId: 'run-1',
+      status: 'failed',
+      providerSessionIdAtEnd: 'codex-thread-1',
+      error: 'stream disconnected',
+    });
+  });
+
   it('存在 provider session 时恢复 Codex thread', async () => {
     planningMocks.ensureTaskAgentBinding.mockReturnValueOnce({
       success: true,
@@ -285,10 +615,8 @@ describe('task-codex-runner', () => {
     });
     const thread = {
       id: 'codex-thread-old',
-      run: vi.fn().mockResolvedValue({
-        finalResponse: '完成',
-        items: [],
-        usage: null,
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents(makeCompletedStream('codex-thread-old', '完成')),
       }),
     };
     const client = {
@@ -317,7 +645,7 @@ describe('task-codex-runner', () => {
   it('当 Codex thread 执行失败但已有 session 时，期望保存 session 供下次恢复', async () => {
     const thread = {
       id: 'codex-thread-failed',
-      run: vi.fn().mockRejectedValue(new Error('provider unavailable')),
+      runStreamed: vi.fn().mockRejectedValue(new Error('provider unavailable')),
     };
     const client = {
       startThread: vi.fn().mockReturnValue(thread),
@@ -376,10 +704,8 @@ describe('task-codex-runner', () => {
     });
     const thread = {
       id: 'codex-thread-1',
-      run: vi.fn().mockResolvedValue({
-        finalResponse: '完成',
-        items: [],
-        usage: null,
+      runStreamed: vi.fn().mockResolvedValue({
+        events: streamEvents(makeCompletedStream('codex-thread-1', '完成')),
       }),
     };
     const client = {
@@ -413,7 +739,7 @@ describe('task-codex-runner', () => {
     try {
       const thread = {
         id: 'codex-thread-1',
-        run: vi.fn(
+        runStreamed: vi.fn(
           (
             _prompt: string,
             options?: { outputSchema?: unknown; signal?: AbortSignal },
@@ -457,5 +783,67 @@ describe('task-codex-runner', () => {
       }
       vi.useRealTimers();
     }
+  });
+
+  it('当用户取消 Codex turn 时，期望中止执行且不保存输出', async () => {
+    let aborted = false;
+    let resolveStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const thread = {
+      id: 'codex-thread-1',
+      runStreamed: vi.fn(
+        (
+          _prompt: string,
+          options?: { outputSchema?: unknown; signal?: AbortSignal },
+        ) =>
+          new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              aborted = true;
+              planningMocks.readTaskAgentRun.mockReturnValue({
+                success: true,
+                data: {
+                  runId: 'run-1',
+                  taskId: 'task-1',
+                  threadId: 'thread-1',
+                  agentId: 'planner',
+                  provider: 'codex',
+                  status: 'cancelled',
+                  inputArtifactIds: [],
+                  outputArtifactIds: [],
+                  startedAt: '2026-01-01T00:00:00.000Z',
+                  endedAt: '2026-01-01T00:00:01.000Z',
+                },
+              });
+              reject(new Error('aborted'));
+            });
+            resolveStarted();
+          }),
+      ),
+    };
+    const client = {
+      startThread: vi.fn().mockReturnValue(thread),
+      resumeThread: vi.fn(),
+    };
+
+    const pending = runTaskCodexTurn({
+      taskId: 'task-1',
+      threadId: 'thread-1',
+      agentId: 'planner',
+      prompt: '生成计划',
+      cwd: '/tmp/project',
+      createClient: () => client,
+    });
+    await started;
+    requestTaskAgentCancellation('run-1', 'user cancelled');
+    const result = await pending;
+
+    expect(result.success).toBe(true);
+    expect(aborted).toBe(true);
+    if (!result.success) throw new Error(result.error);
+    expect(result.data.run.status).toBe('cancelled');
+    expect(result.data.assistantText).toBe('');
+    expect(planningMocks.recordTaskAgentResult).not.toHaveBeenCalled();
   });
 });

--- a/packages/along/src/domain/task-codex-runner.ts
+++ b/packages/along/src/domain/task-codex-runner.ts
@@ -1,6 +1,11 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy runner keeps provider orchestration together.
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: legacy runner keeps provider orchestration together.
-import type { ThreadOptions } from '@openai/codex-sdk';
+import type {
+  ThreadEvent,
+  ThreadItem,
+  ThreadOptions,
+  Usage,
+} from '@openai/codex-sdk';
 import type { Result } from '../core/result';
 import { failure, success } from '../core/result';
 import {
@@ -22,7 +27,7 @@ import type {
   RunTaskClaudeTurnInput,
   RunTaskClaudeTurnOutput,
 } from './task-claude-runner';
-import { writeCodexTurnSessionEvents } from './task-codex-session-events';
+import { CodexStreamSessionEventMapper } from './task-codex-session-events';
 import {
   buildThreadOptions,
   createDefaultCodexClient,
@@ -46,7 +51,7 @@ const PROVIDER = 'codex';
 
 export interface TaskCodexTurn {
   finalResponse: string;
-  items: unknown[];
+  items: ThreadItem[];
   usage: unknown;
 }
 
@@ -56,10 +61,10 @@ export type TaskCodexInputItem =
 
 export interface TaskCodexThread {
   readonly id: string | null;
-  run(
+  runStreamed(
     input: string | TaskCodexInputItem[],
     options?: { outputSchema?: unknown; signal?: AbortSignal },
-  ): Promise<TaskCodexTurn>;
+  ): Promise<{ events: AsyncGenerator<ThreadEvent> }>;
 }
 
 export interface TaskCodexClient {
@@ -68,6 +73,11 @@ export interface TaskCodexClient {
 }
 
 export type CreateTaskCodexClient = () => TaskCodexClient;
+
+interface RunCodexPromptResult {
+  turn: TaskCodexTurn;
+  latestThreadId?: string;
+}
 
 export interface RunTaskCodexTurnInput extends RunTaskClaudeTurnInput {
   createClient?: CreateTaskCodexClient;
@@ -117,11 +127,16 @@ async function runStartedCodexTurn(
     thread = openCodexThread(input, progressContext, binding.providerSessionId);
     const turn = await runCodexPrompt(
       progressContext.runId,
+      progressContext,
       thread,
       promptRes.data,
       outputSchema,
+      (threadId) => {
+        latestThreadId = threadId;
+      },
     );
-    latestThreadId = thread.id || binding.providerSessionId;
+    latestThreadId =
+      turn.latestThreadId || thread.id || binding.providerSessionId;
     if (isTaskAgentRunCancelled(progressContext.runId)) {
       return completeCancelledCodexTurn(
         progressContext,
@@ -129,12 +144,11 @@ async function runStartedCodexTurn(
         latestThreadId,
       );
     }
-    writeCodexTurnSessionEvents(progressContext, turn);
     return completeCodexTurn(
       input,
       progressContext,
       usedResume,
-      turn,
+      turn.turn,
       outputSchema,
       latestThreadId,
     );
@@ -227,10 +241,12 @@ function openCodexThread(
 
 async function runCodexPrompt(
   runId: string,
+  context: TaskAgentProgressContext,
   thread: TaskCodexThread,
   prompt: string | TaskCodexInputItem[],
   outputSchema: unknown,
-): Promise<TaskCodexTurn> {
+  onThreadStarted: (threadId: string) => void,
+): Promise<RunCodexPromptResult> {
   const timeoutMs = readCodexTurnTimeoutMs();
   const abortController = new AbortController();
   const unregisterCancel = registerTaskAgentCancellation(runId, (reason) =>
@@ -243,6 +259,7 @@ async function runCodexPrompt(
   }, timeoutMs);
   return runCodexThreadWithTimeout(
     thread,
+    context,
     prompt,
     outputSchema,
     abortController,
@@ -250,11 +267,13 @@ async function runCodexPrompt(
     () => timedOut,
     timeoutMs,
     unregisterCancel,
+    onThreadStarted,
   );
 }
 
 async function runCodexThreadWithTimeout(
   thread: TaskCodexThread,
+  context: TaskAgentProgressContext,
   prompt: string | TaskCodexInputItem[],
   outputSchema: unknown,
   abortController: AbortController,
@@ -262,12 +281,14 @@ async function runCodexThreadWithTimeout(
   isTimedOut: () => boolean,
   timeoutMs: number,
   unregisterCancel: () => void,
-): Promise<TaskCodexTurn> {
+  onThreadStarted: (threadId: string) => void,
+): Promise<RunCodexPromptResult> {
   try {
-    return await thread.run(prompt, {
+    const stream = await thread.runStreamed(prompt, {
       outputSchema,
       signal: abortController.signal,
     });
+    return await consumeCodexStream(context, stream.events, onThreadStarted);
   } catch (error: unknown) {
     if (!isTimedOut()) throw error;
     throw new Error(
@@ -280,6 +301,48 @@ async function runCodexThreadWithTimeout(
     unregisterCancel();
     clearTimeout(timeout);
   }
+}
+
+async function consumeCodexStream(
+  context: TaskAgentProgressContext,
+  events: AsyncGenerator<ThreadEvent>,
+  onThreadStarted: (threadId: string) => void,
+): Promise<RunCodexPromptResult> {
+  const mapper = new CodexStreamSessionEventMapper(context);
+  const items: ThreadItem[] = [];
+  let finalResponse = '';
+  let usage: Usage | null = null;
+  let latestThreadId: string | undefined;
+
+  for await (const event of events) {
+    const eventRes = mapper.handleEvent(event);
+    if (!eventRes.success) throw new Error(eventRes.error);
+    if (eventRes.data.latestThreadId) {
+      latestThreadId = eventRes.data.latestThreadId;
+      onThreadStarted(latestThreadId);
+    }
+    if (event.type === 'item.completed') {
+      items.push(event.item);
+      if (event.item.type === 'agent_message') {
+        finalResponse = event.item.text;
+      }
+    } else if (event.type === 'turn.completed') {
+      usage = event.usage;
+    } else if (event.type === 'turn.failed') {
+      throw new Error(event.error.message);
+    } else if (event.type === 'error') {
+      throw new Error(event.message);
+    }
+  }
+
+  return {
+    turn: {
+      finalResponse,
+      items,
+      usage,
+    },
+    latestThreadId,
+  };
 }
 
 function completeCancelledCodexTurn(

--- a/packages/along/src/domain/task-codex-session-events.ts
+++ b/packages/along/src/domain/task-codex-session-events.ts
@@ -1,23 +1,521 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: Codex stream event mapping keeps provider cases explicit.
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: Codex stream event mapping keeps provider cases explicit.
+import type { ThreadEvent, ThreadItem } from '@openai/codex-sdk';
+import type { Result } from '../core/result';
+import { failure, success } from '../core/result';
 import type { TaskAgentProgressContext } from './task-agent-progress';
-import { writeTaskAgentSessionEvent } from './task-agent-progress';
-import type { TaskCodexTurn } from './task-codex-runner';
+import {
+  recordTaskAgentProgress,
+  recordTaskAgentSessionEvent,
+  TASK_AGENT_PROGRESS_PHASE,
+  type TaskAgentSessionEventKind,
+  type TaskAgentSessionEventSource,
+} from './task-planning';
 
-export function writeCodexTurnSessionEvents(
-  context: TaskAgentProgressContext,
-  turn: TaskCodexTurn,
-) {
-  if (turn.finalResponse.trim()) {
-    writeTaskAgentSessionEvent(context, 'agent', 'output', turn.finalResponse, {
-      type: 'final_response',
+const STREAM_CONTENT_LIMIT = 7500;
+
+interface ItemStreamState {
+  text: string;
+  output: string;
+  todoSnapshot: string;
+  toolSnapshot: string;
+  wroteText: boolean;
+  wroteOutput: boolean;
+}
+
+interface CodexStreamEventEffect {
+  latestThreadId?: string;
+}
+
+interface DeltaResult {
+  content: string;
+  mode: 'delta' | 'snapshot';
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Codex stream 错误';
+}
+
+function getItemState(
+  states: Map<string, ItemStreamState>,
+  item: ThreadItem,
+): ItemStreamState {
+  const existing = states.get(item.id);
+  if (existing) return existing;
+  const created: ItemStreamState = {
+    text: '',
+    output: '',
+    todoSnapshot: '',
+    toolSnapshot: '',
+    wroteText: false,
+    wroteOutput: false,
+  };
+  states.set(item.id, created);
+  return created;
+}
+
+function buildDelta(previous: string, next: string): DeltaResult | null {
+  if (next === previous) return null;
+  if (next.startsWith(previous)) {
+    const content = next.slice(previous.length);
+    return content ? { content, mode: 'delta' } : null;
+  }
+  return next ? { content: next, mode: 'snapshot' } : null;
+}
+
+function truncateContent(
+  content: string,
+  metadata: Record<string, unknown>,
+): { content: string; metadata: Record<string, unknown> } {
+  if (content.length <= STREAM_CONTENT_LIMIT) return { content, metadata };
+  const omitted = content.length - STREAM_CONTENT_LIMIT;
+  return {
+    content: `...[已截断 ${omitted} 字符]\n${content.slice(-STREAM_CONTENT_LIMIT)}`,
+    metadata: {
+      ...metadata,
+      truncated: true,
+      original_length: content.length,
+    },
+  };
+}
+
+function baseItemMetadata(
+  providerEventType: ThreadEvent['type'],
+  item: ThreadItem,
+): Record<string, unknown> {
+  return {
+    provider_event_type: providerEventType,
+    item_id: item.id,
+    item_type: item.type,
+  };
+}
+
+function getItemStatus(item: ThreadItem): string | undefined {
+  if ('status' in item && typeof item.status === 'string') return item.status;
+  return undefined;
+}
+
+function formatFileChanges(item: Extract<ThreadItem, { type: 'file_change' }>) {
+  if (item.changes.length === 0) return '无文件变更。';
+  return item.changes
+    .map((change) => `${change.kind}: ${change.path}`)
+    .join('\n');
+}
+
+function formatTodoList(item: Extract<ThreadItem, { type: 'todo_list' }>) {
+  if (item.items.length === 0) return 'Codex 任务清单为空。';
+  return item.items
+    .map((todo) => `${todo.completed ? '[x]' : '[ ]'} ${todo.text}`)
+    .join('\n');
+}
+
+function summarizeMcpResult(
+  item: Extract<ThreadItem, { type: 'mcp_tool_call' }>,
+): string {
+  if (item.error?.message) return item.error.message;
+  const content = item.result?.content;
+  if (!content || content.length === 0) return '工具调用已完成。';
+  return `工具调用已完成，返回 ${content.length} 条内容。`;
+}
+
+function buildToolSnapshot(item: ThreadItem): string {
+  if (item.type === 'mcp_tool_call') {
+    return JSON.stringify({
+      status: item.status,
+      error: item.error?.message,
+      resultCount: item.result?.content.length,
     });
   }
-  if (turn.items.length > 0) {
-    writeTaskAgentSessionEvent(
-      context,
-      'tool',
-      'message',
-      `Codex 返回 ${turn.items.length} 条会话 item。`,
-      { type: 'items', count: turn.items.length },
+  if (item.type === 'file_change') {
+    return JSON.stringify({ status: item.status, changes: item.changes });
+  }
+  return '';
+}
+
+export class CodexStreamSessionEventMapper {
+  private readonly itemStates = new Map<string, ItemStreamState>();
+
+  constructor(private readonly context: TaskAgentProgressContext) {}
+
+  handleEvent(event: ThreadEvent): Result<CodexStreamEventEffect> {
+    switch (event.type) {
+      case 'thread.started': {
+        const sessionRes = this.recordSession(
+          'system',
+          'message',
+          'Codex thread 已连接。',
+          {
+            provider_event_type: event.type,
+            thread_id: event.thread_id,
+          },
+        );
+        return sessionRes.success
+          ? success({ latestThreadId: event.thread_id })
+          : failure(sessionRes.error);
+      }
+      case 'turn.started':
+        return this.handleTurnStarted(event.type);
+      case 'item.started':
+      case 'item.updated':
+      case 'item.completed':
+        return this.handleItemEvent(event.type, event.item);
+      case 'turn.completed':
+        return this.handleTurnCompleted(event);
+      case 'turn.failed':
+        return this.toEffect(
+          this.recordSession(
+            'system',
+            'error',
+            `Codex turn 失败：${getErrorMessage(event.error.message)}`,
+            {
+              provider_event_type: event.type,
+              error: event.error.message,
+            },
+          ),
+        );
+      case 'error':
+        return this.toEffect(
+          this.recordSession(
+            'system',
+            'error',
+            `Codex stream 错误：${getErrorMessage(event.message)}`,
+            {
+              provider_event_type: event.type,
+              error: event.message,
+            },
+          ),
+        );
+    }
+  }
+
+  private toEffect(result: Result<void>): Result<CodexStreamEventEffect> {
+    return result.success ? success({}) : failure(result.error);
+  }
+
+  private handleTurnStarted(
+    providerEventType: ThreadEvent['type'],
+  ): Result<CodexStreamEventEffect> {
+    const progressRes = recordTaskAgentProgress({
+      ...this.context,
+      phase: TASK_AGENT_PROGRESS_PHASE.WAITING,
+      summary: 'Codex 已开始处理本轮请求。',
+    });
+    if (!progressRes.success) return failure(progressRes.error);
+    const sessionRes = this.recordSession(
+      'system',
+      'progress',
+      'Codex 已开始处理本轮请求。',
+      { provider_event_type: providerEventType },
     );
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private handleTurnCompleted(
+    event: Extract<ThreadEvent, { type: 'turn.completed' }>,
+  ): Result<CodexStreamEventEffect> {
+    const progressRes = recordTaskAgentProgress({
+      ...this.context,
+      phase: TASK_AGENT_PROGRESS_PHASE.FINALIZING,
+      summary: 'Codex 已完成本轮请求，正在保存输出。',
+    });
+    if (!progressRes.success) return failure(progressRes.error);
+    const sessionRes = this.recordSession(
+      'system',
+      'message',
+      'Codex turn 已完成。',
+      {
+        provider_event_type: event.type,
+        usage: event.usage,
+      },
+    );
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private handleItemEvent(
+    providerEventType: Extract<
+      ThreadEvent['type'],
+      'item.started' | 'item.updated' | 'item.completed'
+    >,
+    item: ThreadItem,
+  ): Result<CodexStreamEventEffect> {
+    if (providerEventType === 'item.started') {
+      return this.handleItemStarted(providerEventType, item);
+    }
+    if (providerEventType === 'item.updated') {
+      return this.handleItemUpdated(providerEventType, item);
+    }
+    return this.handleItemCompleted(providerEventType, item);
+  }
+
+  private handleItemStarted(
+    providerEventType: ThreadEvent['type'],
+    item: ThreadItem,
+  ): Result<CodexStreamEventEffect> {
+    getItemState(this.itemStates, item);
+    switch (item.type) {
+      case 'agent_message':
+      case 'reasoning':
+        return item.text
+          ? this.emitTextDelta(providerEventType, item)
+          : success({});
+      case 'command_execution':
+        return this.toEffect(
+          this.recordSession(
+            'tool',
+            'progress',
+            `开始执行命令：\n${item.command}`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              command: item.command,
+              status: item.status,
+            },
+          ),
+        );
+      case 'mcp_tool_call':
+        return this.toEffect(
+          this.recordSession(
+            'tool',
+            'progress',
+            `开始调用工具：${item.server}/${item.tool}`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              server: item.server,
+              tool: item.tool,
+              arguments: item.arguments,
+              status: item.status,
+            },
+          ),
+        );
+      case 'web_search':
+        return this.toEffect(
+          this.recordSession('tool', 'progress', `开始搜索：${item.query}`, {
+            ...baseItemMetadata(providerEventType, item),
+            query: item.query,
+          }),
+        );
+      case 'file_change':
+        return this.toEffect(
+          this.recordSession(
+            'tool',
+            'progress',
+            `文件变更开始处理。\n${formatFileChanges(item)}`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              status: item.status,
+              changes: item.changes,
+            },
+          ),
+        );
+      case 'todo_list':
+        return this.emitTodoSnapshot(providerEventType, item);
+      case 'error':
+        return this.toEffect(
+          this.recordSession('system', 'error', item.message, {
+            ...baseItemMetadata(providerEventType, item),
+          }),
+        );
+    }
+  }
+
+  private handleItemUpdated(
+    providerEventType: ThreadEvent['type'],
+    item: ThreadItem,
+  ): Result<CodexStreamEventEffect> {
+    switch (item.type) {
+      case 'agent_message':
+      case 'reasoning':
+        return this.emitTextDelta(providerEventType, item);
+      case 'command_execution':
+        return this.emitCommandOutputDelta(providerEventType, item);
+      case 'todo_list':
+        return this.emitTodoSnapshot(providerEventType, item);
+      case 'mcp_tool_call':
+      case 'file_change':
+        return this.emitToolSnapshot(providerEventType, item);
+      case 'web_search':
+        return success({});
+      case 'error':
+        return this.toEffect(
+          this.recordSession('system', 'error', item.message, {
+            ...baseItemMetadata(providerEventType, item),
+          }),
+        );
+    }
+  }
+
+  private handleItemCompleted(
+    providerEventType: ThreadEvent['type'],
+    item: ThreadItem,
+  ): Result<CodexStreamEventEffect> {
+    switch (item.type) {
+      case 'agent_message':
+      case 'reasoning':
+        return this.emitCompletionTextIfNeeded(providerEventType, item);
+      case 'command_execution':
+        return this.toEffect(
+          this.recordSession(
+            item.status === 'failed' ? 'stderr' : 'tool',
+            item.status === 'failed' ? 'error' : 'message',
+            `命令执行${item.status === 'failed' ? '失败' : '完成'}${
+              item.exit_code === undefined ? '' : `，退出码 ${item.exit_code}`
+            }。`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              command: item.command,
+              status: item.status,
+              exit_code: item.exit_code,
+            },
+          ),
+        );
+      case 'file_change':
+        return this.toEffect(
+          this.recordSession(
+            item.status === 'failed' ? 'stderr' : 'tool',
+            item.status === 'failed' ? 'error' : 'message',
+            `文件变更${item.status === 'failed' ? '失败' : '完成'}。\n${formatFileChanges(
+              item,
+            )}`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              status: item.status,
+              changes: item.changes,
+            },
+          ),
+        );
+      case 'mcp_tool_call':
+        return this.toEffect(
+          this.recordSession(
+            item.status === 'failed' ? 'stderr' : 'tool',
+            item.status === 'failed' ? 'error' : 'message',
+            `${item.server}/${item.tool} ${item.status === 'failed' ? '失败' : '完成'}：${summarizeMcpResult(
+              item,
+            )}`,
+            {
+              ...baseItemMetadata(providerEventType, item),
+              server: item.server,
+              tool: item.tool,
+              status: item.status,
+            },
+          ),
+        );
+      case 'web_search':
+        return this.toEffect(
+          this.recordSession('tool', 'message', `搜索完成：${item.query}`, {
+            ...baseItemMetadata(providerEventType, item),
+            query: item.query,
+          }),
+        );
+      case 'todo_list':
+        return this.emitTodoSnapshot(providerEventType, item);
+      case 'error':
+        return this.toEffect(
+          this.recordSession('system', 'error', item.message, {
+            ...baseItemMetadata(providerEventType, item),
+          }),
+        );
+    }
+  }
+
+  private emitCompletionTextIfNeeded(
+    providerEventType: ThreadEvent['type'],
+    item: Extract<ThreadItem, { type: 'agent_message' | 'reasoning' }>,
+  ): Result<CodexStreamEventEffect> {
+    const state = getItemState(this.itemStates, item);
+    if (state.wroteText || !item.text) return success({});
+    return this.emitTextDelta(providerEventType, item);
+  }
+
+  private emitTextDelta(
+    providerEventType: ThreadEvent['type'],
+    item: Extract<ThreadItem, { type: 'agent_message' | 'reasoning' }>,
+  ): Result<CodexStreamEventEffect> {
+    const state = getItemState(this.itemStates, item);
+    const delta = buildDelta(state.text, item.text);
+    state.text = item.text;
+    if (!delta) return success({});
+    state.wroteText = true;
+    const source: TaskAgentSessionEventSource = 'agent';
+    const kind: TaskAgentSessionEventKind =
+      item.type === 'agent_message' ? 'output' : 'message';
+    const sessionRes = this.recordSession(source, kind, delta.content, {
+      ...baseItemMetadata(providerEventType, item),
+      delta_mode: delta.mode,
+    });
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private emitCommandOutputDelta(
+    providerEventType: ThreadEvent['type'],
+    item: Extract<ThreadItem, { type: 'command_execution' }>,
+  ): Result<CodexStreamEventEffect> {
+    const state = getItemState(this.itemStates, item);
+    const delta = buildDelta(state.output, item.aggregated_output);
+    state.output = item.aggregated_output;
+    if (!delta) return success({});
+    state.wroteOutput = true;
+    const sessionRes = this.recordSession('stdout', 'output', delta.content, {
+      ...baseItemMetadata(providerEventType, item),
+      command: item.command,
+      status: item.status,
+      exit_code: item.exit_code,
+      delta_mode: delta.mode,
+    });
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private emitTodoSnapshot(
+    providerEventType: ThreadEvent['type'],
+    item: Extract<ThreadItem, { type: 'todo_list' }>,
+  ): Result<CodexStreamEventEffect> {
+    const state = getItemState(this.itemStates, item);
+    const snapshot = formatTodoList(item);
+    if (snapshot === state.todoSnapshot) return success({});
+    state.todoSnapshot = snapshot;
+    const sessionRes = this.recordSession('tool', 'message', snapshot, {
+      ...baseItemMetadata(providerEventType, item),
+      delta_mode: 'snapshot',
+    });
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private emitToolSnapshot(
+    providerEventType: ThreadEvent['type'],
+    item: Extract<ThreadItem, { type: 'mcp_tool_call' | 'file_change' }>,
+  ): Result<CodexStreamEventEffect> {
+    const state = getItemState(this.itemStates, item);
+    const snapshot = buildToolSnapshot(item);
+    if (snapshot === state.toolSnapshot) return success({});
+    state.toolSnapshot = snapshot;
+    const status = getItemStatus(item);
+    const content =
+      item.type === 'mcp_tool_call'
+        ? `${item.server}/${item.tool} 状态：${status || 'unknown'}`
+        : `文件变更状态：${status || 'unknown'}\n${formatFileChanges(item)}`;
+    const sessionRes = this.recordSession('tool', 'progress', content, {
+      ...baseItemMetadata(providerEventType, item),
+      status,
+      delta_mode: 'snapshot',
+    });
+    return sessionRes.success ? success({}) : failure(sessionRes.error);
+  }
+
+  private recordSession(
+    source: TaskAgentSessionEventSource,
+    kind: TaskAgentSessionEventKind,
+    content: string,
+    metadata: Record<string, unknown>,
+  ): Result<void> {
+    if (!content.trim()) return success(undefined);
+    const truncated = truncateContent(content, metadata);
+    const eventRes = recordTaskAgentSessionEvent({
+      ...this.context,
+      source,
+      kind,
+      content: truncated.content,
+      metadata: truncated.metadata,
+    });
+    return eventRes.success ? success(undefined) : failure(eventRes.error);
   }
 }


### PR DESCRIPTION
along-task: #28

## 修改内容
- `packages/along-web/src/task-planning/TaskProgressPanel.test.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.tsx`
- `packages/along/src/domain/task-codex-runner.test.ts`
- `packages/along/src/domain/task-codex-runner.ts`
- `packages/along/src/domain/task-codex-session-events.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/agent-28`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment

问题成立，且值得做。根因是 Codex runner 当前使用 thread.run(...)，它只在 turn 完成后返回最终结果，Along 只能在结束后写 finalResponse 和 items 摘要；因此“实时进展”和“Agent 会话 Tail”在运行中都主要展示 Along 自己的系统阶段事件，看起来像重复功能。正确方向是接入 Codex SDK 的 runStreamed(...)，把 provider 实时事件映射为 Along 会话事件，同时保留现有最终 artifact、结构化输出、run 状态、取消和超时链路。

Summary

本次只处理 Codex，不扩展 Claude 或外部 spawn agent。实现后，“实时进展”负责 Along 编排层状态，“Agent 会话 Tail”负责 Codex 原始运行日志；右侧历史流转继续保留 Task 业务事实，不承载高频 provider stream。

Mermaid

flowchart TD
  A[用户触发 Task Agent Run] --> B[Along 创建 task_agent_run]
  B --> C[准备 prompt、图片、Codex ThreadOptions]
  C --> D[Codex thread.runStreamed]
  D --> E[ThreadEvent 流]
  E --> F[事件映射与 delta 去重]
  F --> G[写入 task_agent_session_events]
  F --> H[必要时写入 task_agent_progress_events]
  E --> I[累计 items、finalResponse、usage]
  I --> J{turn 结果}
  J -->|completed| K[保存 provider session、agent output artifact、完成 run]
  J -->|failed/error| L[写错误会话事件、markTaskAgentFailed]
  G --> M[前端 Agent 会话 Tail 轮询展示]
  H --> N[前端实时进展展示]

Implementation Changes

1. Codex runner 执行模型调整

在 packages/along/src/domain/task-codex-runner.ts 中把 Codex 执行入口从 thread.run(...) 改为 thread.runStreamed(...)。保留现有 runTaskCodexTurn 对外返回契约：RunTaskClaudeTurnOutput、providerSessionId、assistantText、structuredOutput、outputArtifactIds 不能改变。

runStreamed 执行期间要持续消费 AsyncGenerator<ThreadEvent>。消费过程中累计最新 threadId、items、finalResponse、usage，并在 turn completed 后组装为现有 TaskCodexTurn 结构，继续复用 completeCodexTurn、saveTaskAgentOutput、parseStructuredOutput、finishTaskAgentSuccess 这条链路。

取消和超时继续使用 AbortController。超时或取消时必须终止 stream 消费，并沿用现有 completeTaskAgentCancellation 或 markTaskAgentFailed 语义，不能只写日志不改 run 状态。

2. Codex stream 事件映射

新增 Codex stream event mapper，建议放在 packages/along/src/domain/task-codex-session-events.ts 或拆成同目录独立模块，职责是把 @openai/codex-sdk 的 ThreadEvent 转换为 Along 的 task_agent_session_events 和必要的 task_agent_progress_events。

映射规则如下：

thread.started：更新 latestThreadId；写 Tail 会话事件，source=system、kind=message，content 表达 Codex thread 已连接，metadata 包含 provider_event_type=thread.started、thread_id。

turn.started：写实时进展，phase 使用当前等待/执行类阶段，summary 表达 Codex 已开始处理本轮请求；可同时写 Tail source=system、kind=progress，metadata 包含 provider_event_type=turn.started。

item.started：按 item.type 写 Tail 起始事件。command_execution 写命令开始执行；mcp_tool_call 写工具调用开始；web_search 写搜索开始；file_change 写文件变更开始或等待完成；todo_list 写任务清单出现；agent_message/reasoning 若开始时已有 text，则写入文本，否则只记录 metadata 或跳过空内容。

item.updated：这是实时输出核心。按 item.id 维护上一版展示内容，只写新增 delta。agent_message 和 reasoning 追踪 text；command_execution 追踪 aggregated_output；todo_list 可写当前清单快照但需避免无变化重复；mcp_tool_call 可在状态或可读结果变化时写事件。无法提取可读新增内容时，不写空事件，只更新内部累计状态。

item.completed：写完成摘要，不重复写已经通过 updated 输出过的全文。command_execution 写 status 和 exit_code；file_change 写 add/delete/update 文件列表；mcp_tool_call 写完成或失败摘要；web_search 写 query 完成；error item 写 kind=error；agent_message/reasoning 仅在此前未写过文本时补写最终文本。

turn.completed：写实时进展，summary 表达 Codex 已完成并进入保存输出；写 Tail source=system、kind=message，metadata 记录 usage 和 provider_event_type=turn.completed；随后进入现有完成链路。

turn.failed：写 Tail kind=error，metadata 记录 provider_event_type=turn.failed；调用 markTaskAgentFailed，结束 run。

error：按 SDK/stream 不可恢复错误处理，写 Tail kind=error，并让本轮 run 失败。

3. Delta 去重与内容裁剪

在单次 Codex turn 内维护 item 状态表，key 为 item.id。对 agent_message.text、reasoning.text、command_execution.aggregated_output 做前缀差异计算，只写新增部分。若新值不是旧值前缀，说明 SDK 返回内容发生重排，写一条完整快照并在 metadata 标记 delta_mode=snapshot，避免静默丢失信息。

content 字段只放用户可读正文；provider_event_type、item_id、item_type、status、exit_code、thread_id、usage、delta_mode 等进入 metadata。空 content 不写入，避免触发现有“Agent Session 内容不能为空”的失败。

对超长单条内容做单条裁剪，避免数据库和前端被大段命令输出拖垮。裁剪时 content 保留尾部或合理摘要，metadata 标记 truncated=true 和 original_length。最终 artifact 仍以 Codex turn 累计结果为准，不依赖 Tail 拼接。

4. 进展、Tail、历史流转边界

实时进展继续读取 task_agent_progress_events，只展示 Along 编排状态：准备上下文、Codex 开始处理、仍在运行、保存输出、失败、取消等。

Agent 会话 Tail 读取 task_agent_session_events，展示 Codex stream 映射后的运行日志：模型输出、推理摘要、命令执行、工具调用、文件变更、错误等。

历史流转不接入高频 stream 事件。历史流转只保留 Task 业务事实和正式 artifact，例如用户消息、planning_update、plan_revision、批准、反馈、实现完成、交付。若需要关联运行日志，只引用对应 run 的存在和状态，不把 stream 内容平铺进历史流转。

5. 前端最小调整

packages/along-web/src/task-planning/TaskProgressPanel.tsx 保持两个区域，但文案和展示语义需要更清楚：实时进展强调“编排状态”，Agent 会话 Tail 强调“Codex 实时输出”。现有 3 秒轮询可以作为第一阶段交付，不强制引入 SSE/WebSocket。

Tail 需要能够清晰展示 source=agent、tool、stdout、stderr、system 和 kind=progress、message、output、error。若现有样式已支持则只做必要文案调整；不要把高频日志混入右侧历史流转。

Contracts / Interfaces

TaskCodexThread 接口需要新增 runStreamed 能力，测试 fake thread 也要支持该方法。保留 run 只作为旧测试兼容不是核心目标；Codex runner 主路径必须使用 runStreamed。

TaskCodexTurn 保持 finalResponse、items、usage 字段不变。items 应来自 stream 中最终累计的 ThreadItem；finalResponse 优先使用 turn completed 后 SDK 可得结果或累计 agent_message 文本；usage 来自 turn.completed。

task_agent_session_events 现有 schema 不变。通过 metadata 承载 provider 原始事件结构化信息，不新增数据库表。

task_agent_progress_events 现有 schema 不变，只写少量阶段性进展，不写 token 级或命令输出级日志。

Failure Handling

Codex stream 中出现 turn.failed 或 error 时，必须写错误 Tail 事件，并调用 markTaskAgentFailed。错误消息优先使用 SDK error.message，其次 fallback 到通用 Codex stream 错误。

AbortSignal 触发时，如果是用户取消，走 completeTaskAgentCancellation；如果是超时，返回 Codex Agent 执行超时，并 markTaskAgentFailed。两者都不能继续保存成功 artifact。

写 session event 或 progress event 失败不应被静默吞掉。若关键事件写入失败影响运行状态一致性，应让本轮失败；非关键展示事件可以尽量不中断，但至少要在最终失败或日志中暴露。实现时按现有 recordTaskAgentSessionEvent 返回 Result 的风格处理，不使用 as any 或类型绕过。

Test Plan

1. 更新 packages/along/src/domain/task-codex-runner.test.ts：覆盖 runStreamed 正常完成，确保 thread.started、turn.started、item.updated、item.completed、turn.completed 会写入 session/progress event，并最终保存 output artifact、finish run。

2. 增加 delta 去重测试：agent_message 多次 updated 只写新增文本；command_execution aggregated_output 多次 updated 只写新增输出；非前缀变化时写 snapshot 并带 metadata。

3. 增加失败测试：turn.failed 和 error 会写 Tail 错误事件，并调用 markTaskAgentFailed，返回失败结果。

4. 增加取消和超时测试：AbortSignal 能传入 runStreamed；取消后不保存输出；超时后返回超时错误并标记 run 失败。

5. 增加最终结果聚合测试：stream 中累计的 agent_message 能成为 assistantText；结构化 outputSchema 场景仍能 parseStructuredOutput；usage 从 turn.completed 保留。

6. 更新 packages/along-web/src/task-planning/TaskProgressPanel.test.tsx：确认实时进展和 Agent 会话 Tail 文案边界清晰，agent/tool/stdout/stderr/system/error 等事件能按现有 UI 展示。

7. 运行相关验证：优先执行 @ranwawa/along 的 targeted vitest；若改到前端组件，再执行 @ranwawa/along-web 相关测试。若时间允许，执行仓库质量脚本或受影响包完整测试。

Assumptions

1. 第一阶段只支持 Codex，Claude 和 spawn runner 不纳入本次改造。

2. 第一阶段继续使用现有 3 秒轮询，不引入 SSE/WebSocket。实时性目标是“准实时可观察”，不是 token 级毫秒推送。

3. 不做向下兼容设计。Codex 主路径直接迁移到 runStreamed；如果 SDK 版本不支持 runStreamed，应视为依赖不满足，而不是回退到 run。

4. 高频 provider stream 不进入历史流转主视图，避免业务历史被运行日志污染。

5. 不改变数据库 schema，所有 provider 原始细节通过 task_agent_session_events.metadata 保存。

## 交付信息
- Commit: b1efea3a3d871bff7f6ff18ccc81de544dc96654