### PR TITLE
Task #34: 删除along web左侧仓库下拉框右边

### DIFF
--- a/packages/along-web/src/TaskPlanningView.tsx
+++ b/packages/along-web/src/TaskPlanningView.tsx
@@ -76,11 +76,8 @@ function TaskPlanningSidebar({
       <TaskListPanel
         draft={taskPlanning.draft}
         repositories={taskPlanning.repositories}
-        selectedRepository={taskPlanning.selectedRepository}
-        repositoriesRefreshing={taskPlanning.repositoriesRefreshing}
         error={taskPlanning.error}
         onDraftChange={taskPlanning.updateDraft}
-        onRefreshRepositories={taskPlanning.refreshRepositories}
         tasks={taskPlanning.tasks}
         loading={taskPlanning.loading}
         selectedTaskId={taskPlanning.selected?.task.taskId}

--- a/packages/along-web/src/task-planning/TaskSidebar.test.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.test.tsx
@@ -107,15 +107,12 @@ function renderPanel(
         executionMode: 'manual',
       }}
       repositories={repositories}
-      selectedRepository={repositories[0]}
-      repositoriesRefreshing={false}
       error={null}
       tasks={[makeSnapshot()]}
       loading={false}
       selectedTaskId={undefined}
       isNewTaskOpen={false}
       onDraftChange={() => undefined}
-      onRefreshRepositories={() => undefined}
       onNewTask={() => undefined}
       onSelect={() => undefined}
       {...overrides}
@@ -242,13 +239,14 @@ describe('TaskListPanel', () => {
     expect(emptyHtml).toContain('暂无任务。');
   });
 
-  it('在列表头部展示仓库下拉和刷新入口，不使用原生 title', () => {
+  it('在列表头部展示仓库下拉和新任务提示，不展示刷新入口和仓库路径', () => {
     const html = renderPanel();
 
     expect(html).toContain('aria-label="仓库"');
     expect(html).toContain('ranwawa/along');
-    expect(html).toContain('/workspace/along');
-    expect(html).toContain('刷新');
+    expect(html).not.toContain('/workspace/along');
+    expect(html).not.toContain('刷新');
+    expect(html).toContain('aria-label="新任务"');
     expect(html).toContain('role="tooltip"');
     expect(html).not.toContain('主入口');
     expect(html).not.toContain('title="/workspace/along"');

--- a/packages/along-web/src/task-planning/TaskSidebar.tsx
+++ b/packages/along-web/src/task-planning/TaskSidebar.tsx
@@ -32,54 +32,33 @@ function PopupTooltip({
 function RepositoryControls({
   draft,
   repositories,
-  selectedRepository,
-  repositoriesRefreshing,
   error,
   onDraftChange,
-  onRefreshRepositories,
 }: {
   draft: DraftTaskInput;
   repositories: RepositoryOption[];
-  selectedRepository?: RepositoryOption;
-  repositoriesRefreshing: boolean;
   error: string | null;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
-  onRefreshRepositories: () => void;
 }) {
   return (
     <div className="min-w-0 flex-1 flex flex-col gap-2">
-      <div className="flex gap-2">
-        <select
-          aria-label="仓库"
-          value={draft.repository}
-          onChange={(event) => onDraftChange('repository', event.target.value)}
-          className="min-w-0 flex-1 bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
-        >
-          {repositories.length === 0 ? (
-            <option value="">{EMPTY_REPOSITORY_LABEL}</option>
-          ) : (
-            repositories.map((repository) => (
-              <option key={repository.fullName} value={repository.fullName}>
-                {repository.fullName}
-                {repository.isDefault ? ' · 默认' : ''}
-              </option>
-            ))
-          )}
-        </select>
-        <button
-          type="button"
-          onClick={onRefreshRepositories}
-          disabled={repositoriesRefreshing}
-          className="shrink-0 px-3 py-2 rounded-lg text-xs font-semibold border border-border-color text-text-secondary hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {repositoriesRefreshing ? '刷新中' : '刷新'}
-        </button>
-      </div>
-      {selectedRepository && (
-        <div className="text-xs text-text-muted truncate">
-          {selectedRepository.path}
-        </div>
-      )}
+      <select
+        aria-label="仓库"
+        value={draft.repository}
+        onChange={(event) => onDraftChange('repository', event.target.value)}
+        className="min-w-0 w-full bg-black/30 border border-border-color rounded-lg px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-brand/60"
+      >
+        {repositories.length === 0 ? (
+          <option value="">{EMPTY_REPOSITORY_LABEL}</option>
+        ) : (
+          repositories.map((repository) => (
+            <option key={repository.fullName} value={repository.fullName}>
+              {repository.fullName}
+              {repository.isDefault ? ' · 默认' : ''}
+            </option>
+          ))
+        )}
+      </select>
       {error && (
         <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
           {error}
@@ -92,29 +71,23 @@ function RepositoryControls({
 export function TaskListPanel({
   draft,
   repositories,
-  selectedRepository,
-  repositoriesRefreshing,
   error,
   tasks,
   loading,
   selectedTaskId,
   isNewTaskOpen,
   onDraftChange,
-  onRefreshRepositories,
   onNewTask,
   onSelect,
 }: {
   draft: DraftTaskInput;
   repositories: RepositoryOption[];
-  selectedRepository?: RepositoryOption;
-  repositoriesRefreshing: boolean;
   error: string | null;
   tasks: TaskPlanningSnapshot[];
   loading: boolean;
   selectedTaskId?: string;
   isNewTaskOpen: boolean;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
-  onRefreshRepositories: () => void;
   onNewTask: () => void;
   onSelect: (snapshot: TaskPlanningSnapshot) => void;
 }) {
@@ -123,12 +96,9 @@ export function TaskListPanel({
       <TaskListHeader
         draft={draft}
         repositories={repositories}
-        selectedRepository={selectedRepository}
-        repositoriesRefreshing={repositoriesRefreshing}
         error={error}
         isNewTaskOpen={isNewTaskOpen}
         onDraftChange={onDraftChange}
-        onRefreshRepositories={onRefreshRepositories}
         onNewTask={onNewTask}
       />
       <TaskListContent
@@ -210,22 +180,16 @@ function TaskListItem({
 function TaskListHeader({
   draft,
   repositories,
-  selectedRepository,
-  repositoriesRefreshing,
   error,
   isNewTaskOpen,
   onDraftChange,
-  onRefreshRepositories,
   onNewTask,
 }: {
   draft: DraftTaskInput;
   repositories: RepositoryOption[];
-  selectedRepository?: RepositoryOption;
-  repositoriesRefreshing: boolean;
   error: string | null;
   isNewTaskOpen: boolean;
   onDraftChange: (key: keyof DraftTaskInput, value: string) => void;
-  onRefreshRepositories: () => void;
   onNewTask: () => void;
 }) {
   return (
@@ -233,11 +197,8 @@ function TaskListHeader({
       <RepositoryControls
         draft={draft}
         repositories={repositories}
-        selectedRepository={selectedRepository}
-        repositoriesRefreshing={repositoriesRefreshing}
         error={error}
         onDraftChange={onDraftChange}
-        onRefreshRepositories={onRefreshRepositories}
       />
       <PopupTooltip label="新任务">
         <button

--- a/packages/along-web/src/task-planning/actionTypes.ts
+++ b/packages/along-web/src/task-planning/actionTypes.ts
@@ -26,7 +26,6 @@ export interface UseTaskPlanningActionsInput {
   messageAttachments: File[];
   messageExecutionMode: TaskExecutionMode;
   busyAction: string | null;
-  repositoriesRefreshing: boolean;
   canApprove: boolean;
   canImplement: boolean;
   canDeliver: boolean;
@@ -43,8 +42,6 @@ export interface UseTaskPlanningActionsInput {
     React.SetStateAction<TaskExecutionMode>
   >;
   setBusyAction: React.Dispatch<React.SetStateAction<string | null>>;
-  setRepositoriesRefreshing: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;
-  loadRepositories: () => Promise<void>;
   loadSelectedTask: (taskId: string) => Promise<void>;
 }

--- a/packages/along-web/src/task-planning/flowActionRouter.test.ts
+++ b/packages/along-web/src/task-planning/flowActionRouter.test.ts
@@ -93,7 +93,6 @@ function makeInput(
     draft: { title: '', body: '', repository: '' },
     messageBody: '',
     busyAction: null,
-    repositoriesRefreshing: false,
     canApprove: false,
     canImplement: false,
     canDeliver: false,
@@ -104,9 +103,7 @@ function makeInput(
     setSelectedSnapshot: makeDispatch(),
     setMessageBody: makeDispatch(),
     setBusyAction: makeDispatch(),
-    setRepositoriesRefreshing: makeDispatch(),
     setError: makeDispatch(),
-    loadRepositories: vi.fn(),
     loadSelectedTask: vi.fn(),
     ...overrides,
   };

--- a/packages/along-web/src/task-planning/useTaskPlanningActions.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningActions.ts
@@ -37,26 +37,6 @@ async function runBusy(
   }
 }
 
-function useRepositoryActions(input: UseTaskPlanningActionsInput) {
-  const refreshRepositories = async () => {
-    if (input.repositoriesRefreshing) return;
-    input.setRepositoriesRefreshing(true);
-    input.setError(null);
-    try {
-      await readJsonResponse<unknown>(
-        await fetch('/api/rescan', { method: 'POST' }),
-      );
-      input.setDraft((previous) => ({ ...previous, repository: '' }));
-      await input.loadRepositories();
-    } catch (err: unknown) {
-      input.setError(getErrorMessage(err));
-    } finally {
-      input.setRepositoriesRefreshing(false);
-    }
-  };
-  return { refreshRepositories };
-}
-
 function useSelectionActions(input: UseTaskPlanningActionsInput) {
   const selectTask = (snapshot: TaskPlanningSnapshot) => {
     input.setIsNewTaskOpen(false);
@@ -289,7 +269,6 @@ function useFlowActions(input: UseTaskPlanningActionsInput) {
 export function useTaskPlanningActions(input: UseTaskPlanningActionsInput) {
   return {
     ...useDraftActions(input, runBusy),
-    ...useRepositoryActions(input),
     ...useSelectionActions(input),
     ...useFlowActions(input),
   };

--- a/packages/along-web/src/task-planning/useTaskPlanningController.ts
+++ b/packages/along-web/src/task-planning/useTaskPlanningController.ts
@@ -34,7 +34,6 @@ function usePlanningBaseState() {
   const [messageExecutionMode, setMessageExecutionMode] =
     useState<TaskExecutionMode>('manual');
   const [busyAction, setBusyAction] = useState<string | null>(null);
-  const [repositoriesRefreshing, setRepositoriesRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   return {
     taskState,
@@ -47,8 +46,6 @@ function usePlanningBaseState() {
     setMessageExecutionMode,
     busyAction,
     setBusyAction,
-    repositoriesRefreshing,
-    setRepositoriesRefreshing,
     error,
     setError,
   };
@@ -137,7 +134,6 @@ function usePlanningActions(
     messageAttachments: base.messageAttachments,
     messageExecutionMode: base.messageExecutionMode,
     busyAction: base.busyAction,
-    repositoriesRefreshing: base.repositoriesRefreshing,
     ...flowFlags,
     setDraft: base.repositoryState.setDraft,
     setTasks: base.taskState.setTasks,
@@ -148,9 +144,7 @@ function usePlanningActions(
     setMessageAttachments: base.setMessageAttachments,
     setMessageExecutionMode: base.setMessageExecutionMode,
     setBusyAction: base.setBusyAction,
-    setRepositoriesRefreshing: base.setRepositoriesRefreshing,
     setError: base.setError,
-    loadRepositories: base.repositoryState.loadRepositories,
     loadSelectedTask: loaders.loadSelectedTask,
   });
   return actions;
@@ -170,7 +164,6 @@ export function useTaskPlanningController() {
     messageExecutionMode: base.messageExecutionMode,
     loading: loadState.loading,
     busyAction: base.busyAction,
-    repositoriesRefreshing: base.repositoriesRefreshing,
     error: base.error,
     setMessageBody: base.setMessageBody,
     setMessageAttachments: base.setMessageAttachments,


### PR DESCRIPTION
along-task: #34

## 修改内容
- `packages/along-web/src/TaskPlanningView.tsx`
- `packages/along-web/src/task-planning/TaskSidebar.test.tsx`
- `packages/along-web/src/task-planning/TaskSidebar.tsx`
- `packages/along-web/src/task-planning/actionTypes.ts`
- `packages/along-web/src/task-planning/flowActionRouter.test.ts`
- `packages/along-web/src/task-planning/useTaskPlanningActions.ts`
- `packages/along-web/src/task-planning/useTaskPlanningController.ts`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/along-web-34`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
Assessment
需求成立，属于沿用现有侧栏结构的界面精简：删除低频手动刷新入口和本地仓库路径文案，可以降低左侧栏噪声；仓库选择、初始仓库加载、按仓库筛选任务的主流程应保持不变。

Summary
精简 along web 左侧任务栏的仓库区域，只保留仓库下拉框、错误提示和新任务入口；移除下拉框右侧“刷新/刷新中”按钮，以及选中仓库下方的仓库地址 path 文案。

Implementation Changes
1. 修改 packages/along-web/src/task-planning/TaskSidebar.tsx：RepositoryControls 只渲染仓库 select 和 error；删除刷新按钮、selectedRepository.path 文案，以及 TaskListPanel / TaskListHeader / RepositoryControls 中仅服务于这两个 UI 元素的 props。
2. 修改 packages/along-web/src/TaskPlanningView.tsx：停止向 TaskListPanel 传入 selectedRepository、repositoriesRefreshing、onRefreshRepositories；selectedRepository 继续传给 TaskDetail，保证新建任务输入禁用逻辑不变。
3. 清理 task-planning/useTaskPlanningController.ts、useTaskPlanningActions.ts、actionTypes.ts 中仅为手动刷新按钮服务的 repositoriesRefreshing / refreshRepositories 契约；保留 useInitialRepositories 和 loadRepositories，页面进入后的仓库列表初始化行为不变。
4. 更新 packages/along-web/src/task-planning/TaskSidebar.test.tsx：原“展示仓库下拉和刷新入口”断言改为只验证仓库下拉、新任务 tooltip、无原生 title；新增或调整断言确保不再出现“刷新”和仓库 path 文案。

Contracts / Interfaces
左侧栏仓库区域的用户可见契约变为：用户只能通过下拉框切换仓库；仓库列表仍由页面初始化加载；该区域不再提供手动触发 /api/rescan 的入口。后端 /api/rescan 不在本计划内删除，避免影响其他潜在调用方。

Failure Handling
仓库初始加载失败仍使用现有 error 区域展示；删除刷新按钮后不再提供本区域内的失败重试入口，用户需要通过页面刷新或后续新增的其他入口重试。

Test Plan
1. 运行 bun --filter @ranwawa/along-web build，确认 TypeScript 与前端构建通过。
2. 运行 bun lint 或 bun ./.along/preset/scripts/quality/run-changed.mjs，确认格式和静态检查通过。
3. 检查 TaskSidebar.test.tsx 的断言更新覆盖：仓库下拉仍存在，“刷新”和仓库 path 不再渲染。

Assumptions
当前工作区已有与本任务无关的 packages/along 下 ai-registry 相关改动，实施时不得回滚或混入这些改动。

## 交付信息
- Commit: ffa4d60229656810542827a3d74137a6a40fa190