### PR TITLE
Task #35: along web面板交互调整 1. 中

### DIFF
--- a/packages/along-web/src/task-planning/TaskDetail.test.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.test.tsx
@@ -1,0 +1,257 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { TaskArtifactRecord, TaskPlanningSnapshot } from '../types';
+import type { DraftTaskInput } from './api';
+import { TaskDetail } from './TaskDetail';
+import { TaskDetailDialog } from './TaskDetailPanels';
+
+const draft: DraftTaskInput = {
+  repository: 'ranwawa/along',
+  title: '',
+  body: '',
+  attachments: [],
+  executionMode: 'manual',
+};
+
+function makeTask(): TaskPlanningSnapshot['task'] {
+  return {
+    taskId: 'task-1',
+    title: '调整任务详情面板',
+    body: '把辅助信息放到弹框里。',
+    source: 'test',
+    status: 'implementing',
+    currentWorkflowKind: 'implementation',
+    commitShas: [],
+    executionMode: 'manual',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:05:00.000Z',
+  };
+}
+
+function makeThread(): TaskPlanningSnapshot['thread'] {
+  return {
+    threadId: 'thread-1',
+    taskId: 'task-1',
+    purpose: 'implementation',
+    status: 'implementing',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:05:00.000Z',
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<TaskPlanningSnapshot> = {},
+): TaskPlanningSnapshot {
+  return {
+    task: makeTask(),
+    thread: makeThread(),
+    currentPlan: null,
+    openRound: null,
+    artifacts: [],
+    plans: [],
+    agentRuns: [],
+    agentProgressEvents: [
+      {
+        progressId: 'progress-1',
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'implementer',
+        provider: 'codex',
+        phase: 'tool',
+        summary: '正在执行命令。',
+        detail: '运行前端测试。',
+        createdAt: '2026-01-01T00:04:00.000Z',
+      },
+    ],
+    agentSessionEvents: [
+      {
+        eventId: 'session-1',
+        runId: 'run-1',
+        taskId: 'task-1',
+        threadId: 'thread-1',
+        agentId: 'implementer',
+        provider: 'codex',
+        source: 'agent',
+        kind: 'output',
+        content: '正在输出日志。',
+        metadata: {},
+        createdAt: '2026-01-01T00:04:30.000Z',
+      },
+    ],
+    agentStages: [],
+    flow: {
+      currentStageId: 'implementation',
+      conclusion: '实现阶段正在执行。',
+      severity: 'normal',
+      blockers: [],
+      stages: [],
+      actions: [],
+      events: [
+        {
+          eventId: 'flow-event-1',
+          type: 'agent_run_started',
+          stage: 'implementation',
+          title: '进入实现阶段',
+          summary: 'Builder 开始实施。',
+          occurredAt: '2026-01-01T00:03:00.000Z',
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function makeArtifact(): TaskArtifactRecord {
+  return {
+    artifactId: 'artifact-1',
+    taskId: 'task-1',
+    threadId: 'thread-1',
+    type: 'user_message',
+    role: 'user',
+    body: '用户确认执行。',
+    metadata: {},
+    attachments: [],
+    createdAt: '2026-01-01T00:01:00.000Z',
+  };
+}
+
+function renderDetail(snapshot = makeSnapshot()): string {
+  return renderToStaticMarkup(
+    <TaskDetail
+      selected={snapshot}
+      isNewTaskOpen={false}
+      draft={draft}
+      sortedArtifacts={[makeArtifact()]}
+      messageBody=""
+      messageAttachments={[]}
+      messageExecutionMode="manual"
+      busyAction={null}
+      onDraftChange={() => undefined}
+      onDraftAttachmentsChange={() => undefined}
+      onCreateTask={() => undefined}
+      onMessageChange={() => undefined}
+      onMessageAttachmentsChange={() => undefined}
+      onMessageExecutionModeChange={() => undefined}
+      onSubmitMessage={() => undefined}
+      onCancelAgentRun={() => undefined}
+      onAction={() => undefined}
+    />,
+  );
+}
+
+function countText(value: string, text: string): number {
+  return value.split(text).length - 1;
+}
+
+describe('TaskDetail layout', () => {
+  it('在中间滚动区顶部渲染固定 header 入口，并让右侧只保留状态图', () => {
+    const html = renderDetail();
+
+    expect(html).toContain('sticky top-0');
+    expect(countText(html, '实时进展')).toBe(1);
+    expect(countText(html, 'Agent 会话 Tail')).toBe(1);
+    expect(countText(html, '任务元信息')).toBe(1);
+    expect(countText(html, '历史流转')).toBe(1);
+    expect(html).toContain('实现阶段正在执行');
+    expect(html).not.toContain('运行前端测试');
+    expect(html).not.toContain('进入实现阶段');
+  });
+});
+
+describe('TaskDetailDialog', () => {
+  it('实时进展弹框展示当前任务进展和失败态', () => {
+    const snapshot = makeSnapshot({
+      agentProgressEvents: [
+        {
+          progressId: 'progress-failed',
+          runId: 'run-1',
+          taskId: 'task-1',
+          threadId: 'thread-1',
+          agentId: 'implementer',
+          provider: 'codex',
+          phase: 'failed',
+          summary: 'Agent 运行失败。',
+          detail: '命令退出码 1',
+          createdAt: '2026-01-01T00:04:00.000Z',
+        },
+      ],
+    });
+
+    const html = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="progress"
+        selected={snapshot}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('实时进展');
+    expect(html).toContain('Agent 运行失败');
+    expect(html).toContain('失败');
+    expect(html).toContain('命令退出码 1');
+  });
+
+  it('Agent 会话 Tail 弹框展示当前任务会话输出', () => {
+    const html = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="tail"
+        selected={makeSnapshot()}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Agent 会话 Tail');
+    expect(html).toContain('正在输出日志');
+  });
+
+  it('任务元信息和历史流转弹框复用当前任务数据', () => {
+    const snapshot = makeSnapshot();
+    const metadataHtml = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="metadata"
+        selected={snapshot}
+        onClose={() => undefined}
+      />,
+    );
+    const historyHtml = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="history"
+        selected={snapshot}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(metadataHtml).toContain('task-1');
+    expect(metadataHtml).toContain('thread-1');
+    expect(metadataHtml).toContain('人工确认');
+    expect(historyHtml).toContain('历史流转');
+    expect(historyHtml).toContain('进入实现阶段');
+  });
+
+  it('空内容弹框展示中文空态', () => {
+    const snapshot = makeSnapshot({
+      agentProgressEvents: [],
+      agentSessionEvents: [],
+      flow: { ...makeSnapshot().flow, events: [] },
+    });
+
+    const progressHtml = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="progress"
+        selected={snapshot}
+        onClose={() => undefined}
+      />,
+    );
+    const historyHtml = renderToStaticMarkup(
+      <TaskDetailDialog
+        kind="history"
+        selected={snapshot}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(progressHtml).toContain('暂无 Agent 运行进展');
+    expect(historyHtml).toContain('暂无历史事件');
+  });
+});

--- a/packages/along-web/src/task-planning/TaskDetail.tsx
+++ b/packages/along-web/src/task-planning/TaskDetail.tsx
@@ -17,128 +17,14 @@ import type {
 import { AgentStagesPanel } from './AgentStagesPanel';
 import type { DraftTaskInput, RepositoryOption } from './api';
 import { ExistingTaskComposer } from './ExistingTaskComposer';
-import { formatTime, getTaskStatusLabel, getThreadStatusLabel } from './format';
 import { TaskComposerInput } from './TaskComposerInput';
-import { FlowHistory, TaskFlowPanel } from './TaskFlowPanel';
-import { TaskProgressPanel } from './TaskProgressPanel';
+import {
+  TaskDetailDialog,
+  type TaskDetailDialogKind,
+  TaskDetailHeader,
+} from './TaskDetailPanels';
+import { TaskFlowPanel } from './TaskFlowPanel';
 import { TaskRecordsPanel } from './TaskRecords';
-
-function TaskInfoPanel({ selected }: { selected: TaskPlanningSnapshot }) {
-  const [isExpanded, setIsExpanded] = useState(true);
-  const statusLabel =
-    selected.display?.label || getTaskStatusLabel(selected.task.status);
-  return (
-    <aside className="min-w-0 rounded-lg border border-border-color bg-black/25">
-      <button
-        type="button"
-        aria-expanded={isExpanded}
-        onClick={() => setIsExpanded((value) => !value)}
-        className="w-full px-4 py-3 text-left outline-none focus:ring-1 focus:ring-brand/60"
-      >
-        <div className="flex min-w-0 items-center justify-between gap-3">
-          <div className="min-w-0 flex items-center gap-2">
-            <span className="text-sm font-semibold text-text-secondary">
-              任务元信息
-            </span>
-            {!isExpanded && (
-              <span className="truncate text-xs text-text-muted">
-                {statusLabel} · {formatTime(selected.task.updatedAt)}
-              </span>
-            )}
-          </div>
-          <span className="shrink-0 text-xs text-text-muted">
-            {isExpanded ? '收起' : '展开'}
-          </span>
-        </div>
-      </button>
-      {isExpanded && (
-        <TaskInfoRows selected={selected} statusLabel={statusLabel} />
-      )}
-    </aside>
-  );
-}
-
-function TaskInfoRows({
-  selected,
-  statusLabel,
-}: {
-  selected: TaskPlanningSnapshot;
-  statusLabel: string;
-}) {
-  const executionMode =
-    selected.task.executionMode === 'autonomous' ? '全自动' : '人工确认';
-  return (
-    <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-4 pb-4 text-sm">
-      <span className="text-text-muted">ID</span>
-      <span className="truncate">{selected.task.taskId}</span>
-      {selected.task.seq != null && (
-        <>
-          <span className="text-text-muted">Seq</span>
-          <span>#{selected.task.seq}</span>
-        </>
-      )}
-      {selected.task.type && (
-        <>
-          <span className="text-text-muted">Type</span>
-          <span>{selected.task.type}</span>
-        </>
-      )}
-      <span className="text-text-muted">Thread</span>
-      <span className="truncate">{selected.thread.threadId}</span>
-      <span className="text-text-muted">Plan Status</span>
-      <span>{getThreadStatusLabel(selected.thread.status)}</span>
-      <span className="text-text-muted">Workflow</span>
-      <span>{selected.task.currentWorkflowKind}</span>
-      <span className="text-text-muted">Source</span>
-      <span>{selected.task.source}</span>
-      <span className="text-text-muted">Mode</span>
-      <span>{executionMode}</span>
-      <span className="text-text-muted">Status</span>
-      <span>{statusLabel}</span>
-      <TaskInfoOptionalRows selected={selected} />
-      <span className="text-text-muted">Updated</span>
-      <span>{formatTime(selected.task.updatedAt)}</span>
-    </div>
-  );
-}
-
-function TaskInfoOptionalRows({
-  selected,
-}: {
-  selected: TaskPlanningSnapshot;
-}) {
-  return (
-    <>
-      {selected.task.branchName && (
-        <>
-          <span className="text-text-muted">Branch</span>
-          <span className="truncate">{selected.task.branchName}</span>
-        </>
-      )}
-      {selected.task.worktreePath && (
-        <>
-          <span className="text-text-muted">Worktree</span>
-          <span className="truncate" title={selected.task.worktreePath}>
-            {selected.task.worktreePath}
-          </span>
-        </>
-      )}
-      {selected.task.prUrl && (
-        <>
-          <span className="text-text-muted">PR</span>
-          <a
-            href={selected.task.prUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="truncate text-brand hover:text-brand-hover"
-          >
-            #{selected.task.prNumber || selected.task.prUrl}
-          </a>
-        </>
-      )}
-    </>
-  );
-}
 
 function NewTaskComposer({
   draft,
@@ -302,54 +188,91 @@ function SelectedTaskDetail({
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: (element: HTMLDivElement) => void;
 }) {
+  const [activeDialog, setActiveDialog] = useState<TaskDetailDialogKind | null>(
+    null,
+  );
+
   return (
     <div className="flex-1 min-h-0 grid grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(260px,40vh)] 2xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-rows-1">
-      <section className="min-h-0 min-w-0 flex flex-col">
-        <div
-          ref={scrollRef}
-          onScroll={(event) => onScroll(event.currentTarget)}
-          className="flex-1 min-h-0 overflow-auto p-4 md:p-6"
-        >
-          <div className="min-w-0 flex flex-col gap-5">
-            <TaskProgressPanel snapshot={selected} />
-            <AgentStagesPanel stages={selected.agentStages || []} />
-            <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
-          </div>
-        </div>
-        <div className="shrink-0 border-t border-border-color bg-bg-secondary p-3 md:p-4">
-          <ExistingTaskComposer
-            snapshot={selected}
-            flow={selected.flow}
-            messageBody={detail.messageBody}
-            attachments={detail.messageAttachments}
-            executionMode={detail.messageExecutionMode}
-            busyAction={detail.busyAction}
-            onMessageChange={detail.onMessageChange}
-            onAttachmentsChange={detail.onMessageAttachmentsChange}
-            onExecutionModeChange={detail.onMessageExecutionModeChange}
-            onSubmitMessage={detail.onSubmitMessage}
-            onCancelAgentRun={detail.onCancelAgentRun}
-          />
-        </div>
-      </section>
-      <aside className="min-h-0 min-w-0 overflow-hidden border-t border-border-color 2xl:border-l 2xl:border-t-0">
-        <div className="flex h-full min-w-0 flex-col">
-          <div className="shrink-0 p-4 pb-3 md:p-5 md:pb-3">
-            <TaskInfoPanel selected={selected} />
-          </div>
-          <div className="min-h-0 flex-1 overflow-auto px-4 pb-4 md:px-5 md:pb-5">
-            <TaskFlowPanel
-              flow={selected.flow}
-              currentPlan={selected.currentPlan}
-              busyAction={detail.busyAction}
-              onAction={detail.onAction}
-            />
-          </div>
-          <div className="max-h-[45%] shrink-0 overflow-auto border-t border-border-color bg-bg-secondary p-4 md:p-5">
-            <FlowHistory flow={selected.flow} />
-          </div>
-        </div>
-      </aside>
+      <SelectedTaskMain
+        detail={detail}
+        selected={selected}
+        scrollRef={scrollRef}
+        onScroll={onScroll}
+        onOpenDialog={setActiveDialog}
+      />
+      <SelectedTaskFlowAside detail={detail} selected={selected} />
+      <TaskDetailDialog
+        kind={activeDialog}
+        selected={selected}
+        onClose={() => setActiveDialog(null)}
+      />
     </div>
+  );
+}
+
+function SelectedTaskMain({
+  detail,
+  selected,
+  scrollRef,
+  onScroll,
+  onOpenDialog,
+}: {
+  detail: TaskDetailProps;
+  selected: TaskPlanningSnapshot;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: (element: HTMLDivElement) => void;
+  onOpenDialog: (kind: TaskDetailDialogKind) => void;
+}) {
+  return (
+    <section className="min-h-0 min-w-0 flex flex-col">
+      <div
+        ref={scrollRef}
+        onScroll={(event) => onScroll(event.currentTarget)}
+        className="flex-1 min-h-0 overflow-auto"
+      >
+        <TaskDetailHeader onOpenDialog={onOpenDialog} />
+        <div className="min-w-0 flex flex-col gap-5 p-4 md:p-6">
+          <AgentStagesPanel stages={selected.agentStages || []} />
+          <TaskRecordsPanel artifacts={detail.sortedArtifacts} />
+        </div>
+      </div>
+      <div className="shrink-0 border-t border-border-color bg-bg-secondary p-3 md:p-4">
+        <ExistingTaskComposer
+          snapshot={selected}
+          flow={selected.flow}
+          messageBody={detail.messageBody}
+          attachments={detail.messageAttachments}
+          executionMode={detail.messageExecutionMode}
+          busyAction={detail.busyAction}
+          onMessageChange={detail.onMessageChange}
+          onAttachmentsChange={detail.onMessageAttachmentsChange}
+          onExecutionModeChange={detail.onMessageExecutionModeChange}
+          onSubmitMessage={detail.onSubmitMessage}
+          onCancelAgentRun={detail.onCancelAgentRun}
+        />
+      </div>
+    </section>
+  );
+}
+
+function SelectedTaskFlowAside({
+  detail,
+  selected,
+}: {
+  detail: TaskDetailProps;
+  selected: TaskPlanningSnapshot;
+}) {
+  return (
+    <aside className="min-h-0 min-w-0 overflow-hidden border-t border-border-color 2xl:border-l 2xl:border-t-0">
+      <div className="h-full min-w-0 overflow-auto p-4 md:p-5">
+        <TaskFlowPanel
+          flow={selected.flow}
+          currentPlan={selected.currentPlan}
+          busyAction={detail.busyAction}
+          onAction={detail.onAction}
+        />
+      </div>
+    </aside>
   );
 }

--- a/packages/along-web/src/task-planning/TaskDetailPanels.tsx
+++ b/packages/along-web/src/task-planning/TaskDetailPanels.tsx
@@ -1,0 +1,225 @@
+// biome-ignore-all lint/style/noJsxLiterals: task planning panels use existing inline labels.
+// biome-ignore-all lint/style/noMagicNumbers: task planning layout uses fixed UI thresholds.
+import { useEffect } from 'react';
+import type { TaskPlanningSnapshot } from '../types';
+import { formatTime, getTaskStatusLabel, getThreadStatusLabel } from './format';
+import { FlowHistory } from './TaskFlowPanel';
+import {
+  TaskProgressEventsView,
+  TaskSessionTailView,
+} from './TaskProgressPanel';
+
+export type TaskDetailDialogKind = 'progress' | 'tail' | 'metadata' | 'history';
+
+const TASK_DETAIL_ACTIONS: {
+  kind: TaskDetailDialogKind;
+  label: string;
+}[] = [
+  { kind: 'progress', label: '实时进展' },
+  { kind: 'tail', label: 'Agent 会话 Tail' },
+  { kind: 'metadata', label: '任务元信息' },
+  { kind: 'history', label: '历史流转' },
+];
+
+function getTaskDialogTitle(kind: TaskDetailDialogKind): string {
+  return (
+    TASK_DETAIL_ACTIONS.find((action) => action.kind === kind)?.label || ''
+  );
+}
+
+function TaskInfoRows({
+  selected,
+  statusLabel,
+}: {
+  selected: TaskPlanningSnapshot;
+  statusLabel: string;
+}) {
+  const executionMode =
+    selected.task.executionMode === 'autonomous' ? '全自动' : '人工确认';
+  return (
+    <div className="grid grid-cols-[92px_1fr] gap-x-3 gap-y-2 px-4 pb-4 text-sm">
+      <span className="text-text-muted">ID</span>
+      <span className="truncate">{selected.task.taskId}</span>
+      {selected.task.seq != null && (
+        <>
+          <span className="text-text-muted">Seq</span>
+          <span>#{selected.task.seq}</span>
+        </>
+      )}
+      {selected.task.type && (
+        <>
+          <span className="text-text-muted">Type</span>
+          <span>{selected.task.type}</span>
+        </>
+      )}
+      <span className="text-text-muted">Thread</span>
+      <span className="truncate">{selected.thread.threadId}</span>
+      <span className="text-text-muted">Plan Status</span>
+      <span>{getThreadStatusLabel(selected.thread.status)}</span>
+      <span className="text-text-muted">Workflow</span>
+      <span>{selected.task.currentWorkflowKind}</span>
+      <span className="text-text-muted">Source</span>
+      <span>{selected.task.source}</span>
+      <span className="text-text-muted">Mode</span>
+      <span>{executionMode}</span>
+      <span className="text-text-muted">Status</span>
+      <span>{statusLabel}</span>
+      <TaskInfoOptionalRows selected={selected} />
+      <span className="text-text-muted">Updated</span>
+      <span>{formatTime(selected.task.updatedAt)}</span>
+    </div>
+  );
+}
+
+function TaskInfoOptionalRows({
+  selected,
+}: {
+  selected: TaskPlanningSnapshot;
+}) {
+  return (
+    <>
+      {selected.task.branchName && (
+        <>
+          <span className="text-text-muted">Branch</span>
+          <span className="truncate">{selected.task.branchName}</span>
+        </>
+      )}
+      {selected.task.worktreePath && (
+        <>
+          <span className="text-text-muted">Worktree</span>
+          <span className="truncate" title={selected.task.worktreePath}>
+            {selected.task.worktreePath}
+          </span>
+        </>
+      )}
+      {selected.task.prUrl && (
+        <>
+          <span className="text-text-muted">PR</span>
+          <a
+            href={selected.task.prUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="truncate text-brand hover:text-brand-hover"
+          >
+            #{selected.task.prNumber || selected.task.prUrl}
+          </a>
+        </>
+      )}
+    </>
+  );
+}
+
+export function TaskDetailHeader({
+  onOpenDialog,
+}: {
+  onOpenDialog: (kind: TaskDetailDialogKind) => void;
+}) {
+  return (
+    <div className="sticky top-0 z-20 border-b border-border-color bg-bg-secondary/95 px-4 py-3 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur md:px-6">
+      <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm font-semibold text-text-secondary">
+          任务面板
+        </div>
+        <div className="flex min-w-0 gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:justify-end sm:overflow-visible sm:pb-0">
+          {TASK_DETAIL_ACTIONS.map((action) => (
+            <button
+              key={action.kind}
+              type="button"
+              onClick={() => onOpenDialog(action.kind)}
+              className="shrink-0 rounded-md border border-border-color bg-black/20 px-3 py-1.5 text-xs font-semibold text-text-secondary hover:bg-white/5 focus:outline-none focus:ring-1 focus:ring-brand/60"
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TaskDetailDialogContent({
+  kind,
+  selected,
+}: {
+  kind: TaskDetailDialogKind;
+  selected: TaskPlanningSnapshot;
+}) {
+  if (kind === 'progress') {
+    return <TaskProgressEventsView snapshot={selected} />;
+  }
+
+  if (kind === 'tail') {
+    return <TaskSessionTailView snapshot={selected} />;
+  }
+
+  if (kind === 'metadata') {
+    return (
+      <section className="rounded-lg border border-border-color bg-black/20 pt-4">
+        <TaskInfoRows
+          selected={selected}
+          statusLabel={
+            selected.display?.label || getTaskStatusLabel(selected.task.status)
+          }
+        />
+      </section>
+    );
+  }
+
+  return <FlowHistory flow={selected.flow} defaultOpen={true} />;
+}
+
+export function TaskDetailDialog({
+  kind,
+  selected,
+  onClose,
+}: {
+  kind: TaskDetailDialogKind | null;
+  selected: TaskPlanningSnapshot;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    if (!kind) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [kind, onClose]);
+
+  if (!kind) return null;
+
+  const title = getTaskDialogTitle(kind);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-4"
+    >
+      <button
+        type="button"
+        aria-label="关闭弹框"
+        className="absolute inset-0 bg-black/60"
+        onClick={onClose}
+      />
+      <div className="relative flex max-h-[86vh] w-full max-w-4xl flex-col rounded-lg border border-border-color bg-bg-secondary shadow-xl">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border-color px-4 py-3">
+          <h3 className="min-w-0 truncate text-sm font-semibold text-text-secondary">
+            {title}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-md border border-border-color px-2 py-1 text-xs font-semibold text-text-secondary hover:bg-white/5"
+          >
+            关闭
+          </button>
+        </div>
+        <div className="min-h-0 overflow-auto p-4">
+          <TaskDetailDialogContent kind={kind} selected={selected} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/along-web/src/task-planning/TaskFlowPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskFlowPanel.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/noJsxLiterals: existing task flow panel uses inline labels.
 import { useEffect, useState } from 'react';
 import type {
   TaskFlowAction,
@@ -106,9 +107,18 @@ export function CurrentPlanDialog({
   );
 }
 
-export function FlowHistory({ flow }: { flow: TaskFlowSnapshot }) {
+export function FlowHistory({
+  flow,
+  defaultOpen = false,
+}: {
+  flow: TaskFlowSnapshot;
+  defaultOpen?: boolean;
+}) {
   return (
-    <details className="rounded-lg border border-border-color bg-black/20">
+    <details
+      className="rounded-lg border border-border-color bg-black/20"
+      open={defaultOpen || undefined}
+    >
       <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-text-secondary">
         历史流转
       </summary>

--- a/packages/along-web/src/task-planning/TaskProgressPanel.tsx
+++ b/packages/along-web/src/task-planning/TaskProgressPanel.tsx
@@ -330,7 +330,7 @@ function ProgressEventsPanel({
   );
 }
 
-export function TaskProgressPanel({
+export function TaskProgressEventsView({
   snapshot,
   nowMs = Date.now(),
 }: {
@@ -338,7 +338,6 @@ export function TaskProgressPanel({
   nowMs?: number;
 }) {
   const events = sortProgressEvents(snapshot.agentProgressEvents || []);
-  const sessionEvents = sortSessionEvents(snapshot.agentSessionEvents || []);
   const runningRun = getLatestRunningRun(snapshot.agentRuns || []);
 
   return (
@@ -362,11 +361,36 @@ export function TaskProgressPanel({
         runningRun={runningRun}
         nowMs={nowMs}
       />
-      <SessionTail
-        events={sessionEvents}
-        runningRun={runningRun}
-        nowMs={nowMs}
-      />
+    </section>
+  );
+}
+
+export function TaskSessionTailView({
+  snapshot,
+  nowMs = Date.now(),
+}: {
+  snapshot: TaskPlanningSnapshot;
+  nowMs?: number;
+}) {
+  const sessionEvents = sortSessionEvents(snapshot.agentSessionEvents || []);
+  const runningRun = getLatestRunningRun(snapshot.agentRuns || []);
+
+  return (
+    <SessionTail events={sessionEvents} runningRun={runningRun} nowMs={nowMs} />
+  );
+}
+
+export function TaskProgressPanel({
+  snapshot,
+  nowMs = Date.now(),
+}: {
+  snapshot: TaskPlanningSnapshot;
+  nowMs?: number;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <TaskProgressEventsView snapshot={snapshot} nowMs={nowMs} />
+      <TaskSessionTailView snapshot={snapshot} nowMs={nowMs} />
     </section>
   );
 }


### PR DESCRIPTION
along-task: #35

## 修改内容
- `packages/along-web/src/task-planning/TaskDetail.test.tsx`
- `packages/along-web/src/task-planning/TaskDetail.tsx`
- `packages/along-web/src/task-planning/TaskDetailPanels.tsx`
- `packages/along-web/src/task-planning/TaskFlowPanel.tsx`
- `packages/along-web/src/task-planning/TaskProgressPanel.tsx`

## 执行步骤
1. 读取 Task 已批准方案
2. 确认实施阶段已完成本地 commit
3. 推送分支 `feat/along-web-1-35`
4. 创建 Pull Request

## 影响范围
- 影响范围以已批准方案为准
- 未写入 `fixes/closes/resolves #...`，不会触发 GitHub Issue session 清理

## 已批准方案
## Problem Assessment

问题成立。当前目标不是新增任务数据能力，而是调整 Along Web 任务详情页的信息架构：把分散在右侧或主窗口内的辅助信息收敛到中间主窗口顶部的固定 Header 入口中，降低右侧栏复杂度，并让状态图保持常驻可见。

关键假设：现有“实时进展”“Agent 会话 Tail”“任务元信息”“历史流转”已有可复用的数据来源或展示组件，本次优先做交互与布局重组，不重新定义这些内容的数据语义。若现有页面没有独立“实时进展”或“Agent 会话 Tail”的明确内容边界，Builder 需要先按现有页面语义映射，不能临时创造新的业务含义。

## Recommended Direction

推荐采用“中间内容区 Sticky Header + 按钮触发 Modal + 右侧单一状态图面板”的布局方向。这样能保留用户在任务详情页的核心阅读流，同时把低频查看的信息改为按需打开，右侧只承载持续观察价值最高的状态图。

不推荐把这些内容改成右侧 Tabs，因为用户明确要求右侧不再展示任务元信息和历史流转；也不推荐把所有内容折叠在主内容流里，因为会继续占用中间阅读空间，无法形成清晰的固定入口。

## Scope

- 在中间主窗口顶部增加一个随主内容滚动上下文固定的 Header 区域。
- Header 内提供“实时进展”“Agent 会话 Tail”“任务元信息”“历史流转”四个入口按钮。
- 点击入口后，以弹框展示对应内容，并复用现有数据与展示语义。
- 调整右侧栏，只保留状态图面板，并确保该面板不随中间主窗口内容滚动。
- 保持任务详情页现有主内容阅读、状态更新和数据加载行为不被破坏。
- 处理窄屏或空间不足时 Header 按钮的可用性与不重叠展示。

## Not Doing

- 不新增或改变任务、Thread、Artifact、PlanRevision、FeedbackRound 等后端数据模型。
- 不重新设计状态图的业务语义或状态流转规则。
- 不改变实时进展、Agent Tail、任务元信息、历史流转的内容来源，除非发现现有数据无法支撑展示。
- 不把本次调整扩展为整站级导航、主题或设计系统重构。
- 不引入新的持久化用户偏好，除非现有弹框/布局框架天然要求。

## Architecture / Flow

页面结构调整为三层关注点：中间主窗口负责主任务内容与固定 Header；弹框层负责按需展示辅助信息；右侧栏只负责状态图常驻展示。

```mermaid
flowchart LR
  Page[任务详情页] --> Center[中间主窗口]
  Page --> Right[右侧栏]
  Center --> StickyHeader[固定 Header]
  Center --> MainContent[主内容流]
  StickyHeader --> ProgressBtn[实时进展按钮]
  StickyHeader --> TailBtn[Agent 会话 Tail 按钮]
  StickyHeader --> MetaBtn[任务元信息按钮]
  StickyHeader --> HistoryBtn[历史流转按钮]
  ProgressBtn --> Modal[弹框层]
  TailBtn --> Modal
  MetaBtn --> Modal
  HistoryBtn --> Modal
  Modal --> ExistingData[复用现有内容与数据源]
  Right --> StateGraph[状态图面板]
```

Header 的固定行为应绑定中间主窗口的滚动上下文，而不是错误绑定整个页面导致右侧或外层布局异常。弹框应有清晰标题、关闭方式、加载态和失败态；内容过长时在弹框内部滚动，不影响底层主窗口滚动位置。右侧状态图面板应与中间主窗口滚动解耦，在任务内容滚动时保持可见。

## Acceptance Criteria

- 中间主窗口顶部存在固定 Header，主内容滚动时 Header 保持可见且不遮挡正文的起始内容。
- Header 中可见并可点击四个入口：“实时进展”“Agent 会话 Tail”“任务元信息”“历史流转”。
- 点击任一入口都会打开对应弹框，弹框内容与当前任务匹配，不展示其他任务的数据。
- 弹框可关闭；关闭后用户回到原任务详情页，主内容滚动位置和右侧状态图不被意外重置。
- 内容加载中、为空或加载失败时，弹框内有清晰的中文状态反馈。
- 右侧栏不再展示任务元信息和历史流转面板，只保留状态图相关面板。
- 中间主窗口滚动时，右侧状态图面板保持固定可见，不跟随中间内容一起滚走。
- 页面在常见桌面宽度下无按钮重叠、文本溢出或弹框内容不可操作问题。
- 窄屏场景下入口仍可访问，布局不出现横向不可控溢出或关键操作被遮挡。
- 既有任务详情数据加载、状态图渲染、任务内容展示和现有交互不发生回归。

## Validation Strategy

- 增加或更新前端组件测试，覆盖 Header 入口渲染、点击打开正确弹框、关闭弹框、空态/失败态展示。
- 增加或更新布局/交互层测试，确认右侧只展示状态图语义内容，任务元信息和历史流转不再作为右侧常驻面板出现。
- 运行项目既有类型检查、lint 和相关前端测试脚本。
- 进行浏览器手动验证：桌面宽度下滚动中间主窗口，确认 Header sticky、右侧状态图固定、弹框内容可滚动且关闭后位置稳定。
- 如项目已有视觉或端到端测试能力，补充关键路径截图或 E2E 用例覆盖四个弹框入口。

## Builder Handoff

- Recommended sequence: 先确认任务详情页当前布局和四类内容的数据/组件边界；再调整页面信息架构，将辅助信息入口收敛到中间 Header；随后重组右侧栏为单一状态图面板；最后补齐测试与浏览器验证。
- Read first: README 中的前端启动与质量命令；当前 Web 任务详情页布局相关模块；现有状态图、任务元信息、历史流转、实时进展和 Agent 会话 Tail 的展示入口或组件；项目现有 Modal/Dialog 与按钮组件规范。
- Risks: sticky 行为可能受现有滚动容器和 CSS overflow 影响；弹框内容如果直接复用右侧面板组件，可能需要适配高度、空态和内部滚动；窄屏布局可能需要入口折叠或横向可控滚动；状态图固定位置可能与现有页面高度计算冲突。
- Return to Planner if: 发现四个入口中某一类没有明确现有数据来源；右侧状态图并非单一面板而承担了其他必要操作；现有布局架构无法在不大改页面骨架的情况下实现 sticky Header；产品希望改变四类内容的业务语义、排序、权限或持久化行为。

## 交付信息
- Commit: 4df72a113c1b2d89204438ce1a3b3c3b82992184